### PR TITLE
Modified data structure to allow for ExperimentalProteoforms to be constructed from Component

### DIFF
--- a/ProteoformSuite/PS_0.00/AggregatedProteoforms.cs
+++ b/ProteoformSuite/PS_0.00/AggregatedProteoforms.cs
@@ -19,8 +19,9 @@ namespace ProteoformSuite
 
         public void AggregatedProteoforms_Load(object sender, EventArgs e)
         {
-            InitializeSettings();
+            this.InitializeSettings();
             if (Lollipop.proteoform_community.experimental_proteoforms.Count == 0) Lollipop.aggregate_proteoforms();
+            this.FillAggregatesTable();
         }
 
         private void InitializeSettings()

--- a/ProteoformSuite/PS_0.00/AggregatedProteoforms.cs
+++ b/ProteoformSuite/PS_0.00/AggregatedProteoforms.cs
@@ -20,7 +20,7 @@ namespace ProteoformSuite
         public void AggregatedProteoforms_Load(object sender, EventArgs e)
         {
             InitializeSettings();
-            if (Lollipop.proteoform_community.experimental_proteoforms.Count == 0) Lollipop.aggregate_neucode_light_proteoforms();
+            if (Lollipop.proteoform_community.experimental_proteoforms.Count == 0) Lollipop.aggregate_proteoforms();
         }
 
         private void InitializeSettings()
@@ -61,7 +61,7 @@ namespace ProteoformSuite
             {
                 ExperimentalProteoform selected_pf = (ExperimentalProteoform)this.dgv_AggregatedProteoforms.Rows[e.RowIndex].DataBoundItem;
                 BindingSource bs = new BindingSource();
-                bs.DataSource = selected_pf.aggregated_neucode_pairs;
+                bs.DataSource = selected_pf.aggregated_components;
                 dgv_AcceptNeuCdLtProteoforms.DataSource = bs;
                 dgv_AcceptNeuCdLtProteoforms.ReadOnly = true;
                 //dgv_AcceptNeuCdLtProteoforms.Columns["Aggregated Mass"].DefaultCellStyle.Format = "0.####";
@@ -79,25 +79,25 @@ namespace ProteoformSuite
         private void nUP_mass_tolerance_ValueChanged(object sender, EventArgs e)
         {
             Lollipop.mass_tolerance = nUP_mass_tolerance.Value;
-            Lollipop.aggregate_neucode_light_proteoforms();
+            Lollipop.aggregate_proteoforms();
         }
 
         private void nUD_RetTimeToleranace_ValueChanged(object sender, EventArgs e)
         {
             Lollipop.retention_time_tolerance = nUD_RetTimeToleranace.Value;
-            Lollipop.aggregate_neucode_light_proteoforms();
+            Lollipop.aggregate_proteoforms();
         }
 
         private void nUD_Missed_Monos_ValueChanged(object sender, EventArgs e)
         {
             Lollipop.missed_monos = nUD_Missed_Monos.Value;
-            Lollipop.aggregate_neucode_light_proteoforms();
+            Lollipop.aggregate_proteoforms();
         }
 
         private void nUD_Missed_Ks_ValueChanged(object sender, EventArgs e)
         {
             Lollipop.missed_lysines = nUD_Missed_Ks.Value;
-            Lollipop.aggregate_neucode_light_proteoforms();
+            Lollipop.aggregate_proteoforms();
         }
 
         private void dgv_AcceptNeuCdLtProteoforms_CellContentClick(object sender, DataGridViewCellEventArgs e)

--- a/ProteoformSuite/PS_0.00/Component.cs
+++ b/ProteoformSuite/PS_0.00/Component.cs
@@ -90,16 +90,16 @@ namespace ProteoformSuite
             this.charge_states.Add(new ChargeState(charge_row));
         }
 
-        public string as_csv_row()
+        public string as_tsv_row()
         {
-            return String.Join(",", new List<string> { this.id.ToString(), this.monoisotopic_mass.ToString(), this.weighted_monoisotopic_mass.ToString(), this.intensity_sum.ToString(), this.num_charge_states.ToString(),
+            return String.Join("\t", new List<string> { this.id.ToString(), this.monoisotopic_mass.ToString(), this.weighted_monoisotopic_mass.ToString(), this.intensity_sum.ToString(), this.num_charge_states.ToString(),
                 this.delta_mass.ToString(), this.relative_abundance.ToString(), this.fract_abundance.ToString(), this.scan_range.ToString(), this.rt_apex.ToString(),
                 this.rt_apex.ToString(), this.file_origin.ToString() });
         }
 
-        public static string get_csv_header()
+        public static string get_tsv_header()
         {
-            return String.Join(",", new List<string> { "id", "monoisotopic_mass", "weighted_monoisotopic_mass", "intensity_sum", "num_charge_states",
+            return String.Join("\t", new List<string> { "id", "monoisotopic_mass", "weighted_monoisotopic_mass", "intensity_sum", "num_charge_states",
                 "delta_mass", "relative_abundance", "fract_abundance", "scan_range", "rt_apex",
                 "rt_apex", "file_origin" });
         }

--- a/ProteoformSuite/PS_0.00/Component.cs
+++ b/ProteoformSuite/PS_0.00/Component.cs
@@ -23,6 +23,7 @@ namespace ProteoformSuite
         public string rt_range { get; set; }
         public double rt_apex { get; set; }
         public double weighted_monoisotopic_mass { get; set; }
+        public double corrected_mass { get; set; }
         public List<ChargeState> charge_states { get; set; } = new List<ChargeState>();
         public int num_charge_states
         {
@@ -48,6 +49,24 @@ namespace ProteoformSuite
             this.rt_apex = Convert.ToDouble(component_cells[10].InnerText);
             this.file_origin = filename;
         }
+        public Component(Component c)
+        {
+            this.file_origin = c.file_origin;
+            this.id = c.id;
+            this.monoisotopic_mass = c.monoisotopic_mass;
+            this.weighted_monoisotopic_mass = c.weighted_monoisotopic_mass;
+            this.corrected_mass = c.corrected_mass;
+            this.intensity_sum = c.intensity_sum = c.intensity_sum;
+            this.delta_mass = c.delta_mass;
+            this.relative_abundance = c.relative_abundance;
+            this.fract_abundance = c.fract_abundance;
+            this.scan_range = c.scan_range;
+            this.rt_apex = c.rt_apex;
+            this.rt_range = c.rt_range;
+            this.charge_states = c.charge_states;
+            this.num_detected_intervals = c.num_detected_intervals;
+            this.num_charge_states_fromFile = c.num_charge_states_fromFile;
+        }
 
         public double calculate_sum_intensity()
         {
@@ -63,6 +82,7 @@ namespace ProteoformSuite
         public void calculate_weighted_monoisotopic_mass()
         {
             this.weighted_monoisotopic_mass = this.charge_states.Select(charge_state => charge_state.intensity / this.intensity_sum * charge_state.calculated_mass).Sum();
+            this.corrected_mass = this.weighted_monoisotopic_mass;
         }
 
         public void add_charge_state(List<Cell> charge_row)

--- a/ProteoformSuite/PS_0.00/DeltaMassPeak.cs
+++ b/ProteoformSuite/PS_0.00/DeltaMassPeak.cs
@@ -36,15 +36,15 @@ namespace ProteoformSuite
             this.group_fdr = median_false_peak_count / (double)group_count;
         }
 
-        public string as_csv_row()
+        public string as_tsv_row()
         {
-            return String.Join(",", new List<string> { this.connected_proteoforms[0].accession.ToString(), this.connected_proteoforms[1].accession.ToString(), this.delta_mass.ToString(), this.group_adjusted_deltaM.ToString(),
+            return String.Join("\t", new List<string> { this.connected_proteoforms[0].accession.ToString(), this.connected_proteoforms[1].accession.ToString(), this.delta_mass.ToString(), this.group_adjusted_deltaM.ToString(),
                 this.group_count.ToString(), group_fdr.ToString() });
         }
 
-        public static string get_csv_header()
+        public static string get_tsv_header()
         {
-            return String.Join(",", new List<string> { "proteoform1_accession", "proteoform2_accession", "delta_mass", "group_adjusted_deltaM", "group_count", "group_fdr" });
+            return String.Join("\t", new List<string> { "proteoform1_accession", "proteoform2_accession", "delta_mass", "group_adjusted_deltaM", "group_count", "group_fdr" });
         }
     }
 }

--- a/ProteoformSuite/PS_0.00/ExperimentTheoreticalComparison.cs
+++ b/ProteoformSuite/PS_0.00/ExperimentTheoreticalComparison.cs
@@ -24,80 +24,130 @@ namespace ProteoformSuite
             dgv_ET_Peak_List.CellValueChanged += new DataGridViewCellEventHandler(propagatePeakListAcceptedPeakChangeToPairsTable); //when 'acceptance' of an ET peak gets changed, we change the ET pairs table.
         }
 
+        bool initial_load = true;
         public void ExperimentTheoreticalComparison_Load(object sender, EventArgs e)
         {
-            GraphETHistogram();
-            FillETPeakListTable();
-            FillETPairsGridView();
-            GraphETPairsList();
-        }
-
-        public void run_comparison()
-        {
+            Lollipop.make_et_relationships();
             InitializeParameterSet();
-            UpdateFiguresOfMerit();
+            initial_load = false;
+            //GraphETRelations();
+            //FillETPeakListTable();
+            FillETRelationsGridView();
+            //GraphETPeaks();
         }
 
-        private void RunTheGamut()
+        private void InitializeParameterSet()
         {
-            this.Cursor = Cursors.WaitCursor;
-            ct_ET_Histogram.ChartAreas[0].AxisY.StripLines.Clear();
-            ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Clear();
-            GraphETHistogram();
-            FillETPeakListTable();
-            FillETPairsGridView();
-            GraphETPairsList();
-            UpdateFiguresOfMerit();
-            this.Cursor = Cursors.Default;
+            nUD_ET_Lower_Bound.Minimum = -500;
+            nUD_ET_Lower_Bound.Maximum = 0;
+            nUD_ET_Lower_Bound.Value = -250; // maximum delta mass for theoretical proteoform that has mass LOWER than the experimental protoform mass
+
+            nUD_ET_Upper_Bound.Minimum = 0;
+            nUD_ET_Upper_Bound.Maximum = 500;
+            nUD_ET_Upper_Bound.Value = 250; // maximum delta mass for theoretical proteoform that has mass HIGHER than the experimental protoform mass
+
+            yMaxET.Minimum = 0;
+            yMaxET.Maximum = 1000;
+            yMaxET.Value = 100; // scaling for y-axis of displayed ET Histogram of all ET pairs
+
+            yMinET.Minimum = -100;
+            yMinET.Maximum = yMaxET.Maximum;
+            yMinET.Value = 0; // scaling for y-axis of displayed ET Histogram of all ET pairs
+
+            xMinET.Minimum = nUD_ET_Lower_Bound.Value;
+            xMinET.Maximum = xMaxET.Value;
+            xMinET.Value = nUD_ET_Lower_Bound.Value; // scaling for x-axis of displayed ET Histogram of all ET pairs
+
+            xMaxET.Minimum = xMinET.Value;
+            xMaxET.Maximum = nUD_ET_Upper_Bound.Value;
+            xMaxET.Value = nUD_ET_Upper_Bound.Value; // scaling for x-axis of displayed ET Histogram of all ET pairs
+
+            nUD_NoManLower.Minimum = 00m;
+            nUD_NoManLower.Maximum = 0.49m;
+            nUD_NoManLower.Value = Convert.ToDecimal(Lollipop.no_mans_land_lowerBound); // lower bound for the range of decimal values that is impossible to achieve chemically. these would be artifacts
+
+            nUD_NoManUpper.Minimum = 0.50m;
+            nUD_NoManUpper.Maximum = 1.00m;
+            nUD_NoManUpper.Value = Convert.ToDecimal(Lollipop.no_mans_land_upperBound); // upper bound for the range of decimal values that is impossible to achieve chemically. these would be artifacts
+
+            nUD_PeakWidthBase.Minimum = 0.001m;
+            nUD_PeakWidthBase.Maximum = 0.5000m;
+            nUD_PeakWidthBase.Value = Convert.ToDecimal(Lollipop.peak_width_base); // bin size used for including individual ET pairs in one 'Peak Center Mass' and peak with for one ET peak
+
+            nUD_PeakCountMinThreshold.Minimum = 0;
+            nUD_PeakCountMinThreshold.Maximum = 1000;
+            nUD_PeakCountMinThreshold.Value = Convert.ToDecimal(Lollipop.min_peak_count); // ET pairs with [Peak Center Count] AND ET peaks with [Peak Count] above this value are considered acceptable for use in proteoform family. this will be eventually set following ED analysis.
         }
 
-        private void FillETPairsGridView()
+        private void FillETRelationsGridView()
         {
             BindingSource bs = new BindingSource();
             bs.DataSource = Lollipop.et_relations;
             dgv_ET_Pairs.DataSource = bs;
             dgv_ET_Pairs.ReadOnly = true;
-            dgv_ET_Pairs.Columns["Acceptable Peak"].ReadOnly = false;
-            dgv_ET_Pairs.Columns["Aggregated Retention Time"].DefaultCellStyle.Format = "0.##";
-            dgv_ET_Pairs.Columns["Proteoform Mass"].DefaultCellStyle.Format = "0.#####";
-            dgv_ET_Pairs.Columns["Aggregated Mass"].DefaultCellStyle.Format = "0.#####";
-            dgv_ET_Pairs.Columns["Delta Mass"].DefaultCellStyle.Format = "0.#####";
-            dgv_ET_Pairs.Columns["Peak Center Mass"].DefaultCellStyle.Format = "0.#####";
+            //dgv_ET_Pairs.Columns["Acceptable Peak"].ReadOnly = false;
+            //dgv_ET_Pairs.Columns["Aggregated Retention Time"].DefaultCellStyle.Format = "0.##";
+            //dgv_ET_Pairs.Columns["Proteoform Mass"].DefaultCellStyle.Format = "0.#####";
+            //dgv_ET_Pairs.Columns["Aggregated Mass"].DefaultCellStyle.Format = "0.#####";
+            //dgv_ET_Pairs.Columns["Delta Mass"].DefaultCellStyle.Format = "0.#####";
+            //dgv_ET_Pairs.Columns["Peak Center Mass"].DefaultCellStyle.Format = "0.#####";
             dgv_ET_Pairs.DefaultCellStyle.BackColor = System.Drawing.Color.LightGray;
             dgv_ET_Pairs.AlternatingRowsDefaultCellStyle.BackColor = System.Drawing.Color.DarkGray;
         }
 
-        private void GraphETPairsList()
+        private void FillETPeakListTable()
         {
-           // string colName = "Delta Mass";
-           // string direction = "DESC";
-           // DataTable dt = Lollipop.experimentTheoreticalPairs;
-           // dt.DefaultView.Sort = colName + " " + direction;
-           // dt = dt.DefaultView.ToTable();
-           // Lollipop.experimentTheoreticalPairs = dt;
+            BindingSource bs = new BindingSource();
+            bs.DataSource = Lollipop.et_peaks;
+            dgv_ET_Peak_List.DataSource = bs;
+            dgv_ET_Pairs.ReadOnly = true;
+            //dgv_ET_Peak_List.Columns["Average Delta Mass"].ReadOnly = true;
+            //dgv_ET_Peak_List.Columns["Peak Count"].ReadOnly = true;
+            //dgv_ET_Peak_List.Columns["Average Delta Mass"].DefaultCellStyle.Format = "0.#####";
+            dgv_ET_Peak_List.DefaultCellStyle.BackColor = System.Drawing.Color.LightGray;
+            dgv_ET_Peak_List.AlternatingRowsDefaultCellStyle.BackColor = System.Drawing.Color.DarkGray;
+            //dgv_ET_Peak_List.EndEdit();
+            //dgv_ET_Peak_List.Refresh();
+        }
 
-           // ct_ET_peakList.Series["etPeakList"].XValueMember = "Delta Mass";
-           // ct_ET_peakList.Series["etPeakList"].YValueMembers = "Running Sum";
-           // ct_ET_peakList.DataSource = Lollipop.experimentTheoreticalPairs;
-           // ct_ET_peakList.DataBind();
-           // ct_ET_peakList.ChartAreas[0].AxisX.LabelStyle.Format = "{0:0.00}";
+        private void GraphETRelations()
+        {
+            List<ProteoformRelation> et_relations_ordered = Lollipop.et_relations.OrderByDescending(r => r.group_adjusted_deltaM).ToList();
+            ct_ET_Histogram.DataSource = et_relations_ordered;
+            ct_ET_peakList.DataBind();
+            ct_ET_Histogram.Series["etHistogram"].XValueMember = "group_adjusted_deltaM";
+            ct_ET_Histogram.Series["etHistogram"].YValueMembers = "group_count";
+            ct_ET_Histogram.ChartAreas[0].AxisY.StripLines.Clear();
 
-           // ct_ET_peakList.ChartAreas[0].AxisX.Minimum = Convert.ToDouble(dgv_ET_Peak_List.Rows[0].Cells["Average Delta Mass"].Value.ToString()) - Convert.ToDouble(nUD_PeakWidthBase.Value);
-           // ct_ET_peakList.ChartAreas[0].AxisX.Maximum = Convert.ToDouble(dgv_ET_Peak_List.Rows[0].Cells["Average Delta Mass"].Value.ToString()) + Convert.ToDouble(nUD_PeakWidthBase.Value);
-           //// ct_ET_peakList.Series["etPeakList"].ToolTip = "#VALX{#.##}" + " , " + "#VALY{#.##}";
-           // ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Add(new StripLine()
-           // {
-           //     BorderColor = Color.Red,
-           //     IntervalOffset = Convert.ToDouble(dgv_ET_Peak_List.Rows[0].Cells["Average Delta Mass"].Value.ToString()) + 0.5 * Convert.ToDouble((nUD_PeakWidthBase.Value)),
-           // });
+            ct_ET_Histogram.ChartAreas[0].AxisY.StripLines.Clear();
+            StripLine lowerCountBound_stripline = new StripLine() { BorderColor = Color.Red, IntervalOffset = Convert.ToDouble(nUD_PeakCountMinThreshold.Value) };
+            ct_ET_Histogram.ChartAreas[0].AxisY.StripLines.Add(lowerCountBound_stripline);
 
-           // ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Add(new StripLine()
-           // {
-           //     BorderColor = Color.Red,
-           //     IntervalOffset = Convert.ToDouble(dgv_ET_Peak_List.Rows[0].Cells["Average Delta Mass"].Value.ToString()) - 0.5 * Convert.ToDouble((nUD_PeakWidthBase.Value)),
-           // });
-           // ct_ET_peakList.ChartAreas[0].AxisX.Title = "Delta m/z";
-           // ct_ET_peakList.ChartAreas[0].AxisY.Title = "Peak Count";
+            ct_ET_Histogram.ChartAreas[0].AxisX.Title = "Adjusted Delta m/z";
+            ct_ET_Histogram.ChartAreas[0].AxisY.Title = "Nearby Count";
+        }
+
+        private void GraphETPeaks()
+        {
+            List<DeltaMassPeak> et_peaks_ordered = Lollipop.et_peaks.OrderByDescending(r => r.group_adjusted_deltaM).ToList();
+            ct_ET_peakList.DataSource = et_peaks_ordered;
+            ct_ET_peakList.DataBind();
+            ct_ET_peakList.Series["etPeakList"].XValueMember = "group_adjusted_deltaM";
+            ct_ET_peakList.Series["etPeakList"].YValueMembers = "group_count";
+            ct_ET_peakList.ChartAreas[0].AxisX.LabelStyle.Format = "{0:0.00}";
+
+            ct_ET_peakList.ChartAreas[0].AxisX.Minimum = et_peaks_ordered[0].group_adjusted_deltaM - Convert.ToDouble(nUD_PeakWidthBase.Value);
+            ct_ET_peakList.ChartAreas[0].AxisX.Maximum = et_peaks_ordered[0].group_adjusted_deltaM + Convert.ToDouble(nUD_PeakWidthBase.Value);
+
+            ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Clear();
+            double stripline_tolerance = Convert.ToDouble(nUD_PeakWidthBase.Value) * 0.5;
+            StripLine lowerPeakBound_stripline = new StripLine() { BorderColor = Color.Red, IntervalOffset = et_peaks_ordered[0].group_adjusted_deltaM - stripline_tolerance };
+            StripLine upperPeakBound_stripline = new StripLine() { BorderColor = Color.Red, IntervalOffset = et_peaks_ordered[0].group_adjusted_deltaM + stripline_tolerance };
+            ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Add(lowerPeakBound_stripline);
+            ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Add(upperPeakBound_stripline);
+
+            ct_ET_peakList.ChartAreas[0].AxisX.Title = "Adjusted Delta m/z";
+            ct_ET_peakList.ChartAreas[0].AxisY.Title = "Peak Group Count";
         }
 
         private void dgv_ET_Peak_List_CellClick(object sender, MouseEventArgs e)
@@ -106,33 +156,80 @@ namespace ProteoformSuite
             {
                 int clickedRow = dgv_ET_Peak_List.HitTest(e.X, e.Y).RowIndex;
                 if (clickedRow >= 0 && clickedRow < Lollipop.et_relations.Count)
-                    ETPeakListGraphParameters(clickedRow);
+                {
+                    ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Clear();
+                    DeltaMassPeak selected_peak = (DeltaMassPeak)this.dgv_ET_Peak_List.Rows[clickedRow].DataBoundItem;
+                    double graphMax = selected_peak.group_adjusted_deltaM + Convert.ToDouble((nUD_PeakWidthBase.Value));
+                    double graphMin = selected_peak.group_adjusted_deltaM - Convert.ToDouble((nUD_PeakWidthBase.Value));
+                    if (graphMin < graphMax)
+                    {
+                        ct_ET_peakList.ChartAreas[0].AxisX.Minimum = Convert.ToDouble(graphMin);
+                        ct_ET_peakList.ChartAreas[0].AxisX.Maximum = Convert.ToDouble(graphMax);
+                    }
+
+                    ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Clear();
+                    double stripline_tolerance = Convert.ToDouble(nUD_PeakWidthBase.Value) * 0.5;
+                    StripLine lowerPeakBound_stripline = new StripLine() { BorderColor = Color.Red, IntervalOffset = selected_peak.group_adjusted_deltaM - stripline_tolerance };
+                    StripLine upperPeakBound_stripline = new StripLine() { BorderColor = Color.Red, IntervalOffset = selected_peak.group_adjusted_deltaM + stripline_tolerance };
+                    ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Add(lowerPeakBound_stripline);
+                    ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Add(upperPeakBound_stripline);
+                }
             }
         }
 
-        private void ETPeakListGraphParameters(int clickedRow)
+        Point? ct_ET_Histogram_prevPosition = null;
+        ToolTip ct_ET_Histogram_tt = new ToolTip();
+
+        private void ct_ET_Histogram_MouseMove(object sender, MouseEventArgs e)
         {
-            ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Clear();
-            double graphMax = Convert.ToDouble(dgv_ET_Peak_List.Rows[clickedRow].Cells["Average Delta Mass"].Value.ToString()) + Convert.ToDouble((nUD_PeakWidthBase.Value));
-            double graphMin = Convert.ToDouble(dgv_ET_Peak_List.Rows[clickedRow].Cells["Average Delta Mass"].Value.ToString()) - Convert.ToDouble((nUD_PeakWidthBase.Value));
+            tooltip_graph_display(ct_ET_peakList_tt, e, ct_ET_Histogram, ct_ET_Histogram_prevPosition);
+        }
 
-            if (graphMin < graphMax)
+        Point? ct_ET_peakList_prevPosition = null;
+        ToolTip ct_ET_peakList_tt = new ToolTip();
+
+        private void ct_ET_peakList_MouseMove(object sender, MouseEventArgs e)
+        {
+            tooltip_graph_display(ct_ET_peakList_tt, e, ct_ET_peakList, ct_ET_peakList_prevPosition);
+        }
+
+        private void tooltip_graph_display(ToolTip t, MouseEventArgs e, Chart c, Point? p)
+        {
+            var pos = e.Location;
+            if (p.HasValue && pos == p.Value) return;
+            t.RemoveAll();
+            p = pos;
+            var results = c.HitTest(pos.X, pos.Y, false, ChartElementType.DataPoint);
+            foreach (var result in results)
             {
-                ct_ET_peakList.ChartAreas[0].AxisX.Minimum = Convert.ToDouble(graphMin);
-                ct_ET_peakList.ChartAreas[0].AxisX.Maximum = Convert.ToDouble(graphMax);
+                if (result.ChartElementType == ChartElementType.DataPoint)
+                {
+                    var prop = result.Object as DataPoint;
+                    if (prop != null)
+                    {
+                        var pointXPixel = result.ChartArea.AxisX.ValueToPixelPosition(prop.XValue);
+                        var pointYPixel = result.ChartArea.AxisY.ValueToPixelPosition(prop.YValues[0]);
+
+                        // check if the cursor is really close to the point (2 pixels around the point)
+                        if (Math.Abs(pos.X - pointXPixel) < 2) //&&
+                                                               // Math.Abs(pos.Y - pointYPixel) < 2)
+                        {
+                            t.Show("X=" + prop.XValue + ", Y=" + prop.YValues[0], c, pos.X, pos.Y - 15);
+                        }
+                    }
+                }
             }
+        }
 
-            ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Add(new StripLine()
-            {
-                BorderColor = Color.Red,
-                IntervalOffset = Convert.ToDouble(dgv_ET_Peak_List.Rows[clickedRow].Cells["Average Delta Mass"].Value.ToString()) + 0.5 * Convert.ToDouble((nUD_PeakWidthBase.Value)),
-            });
-
-            ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Add(new StripLine()
-            {
-                BorderColor = Color.Red,
-                IntervalOffset = Convert.ToDouble(dgv_ET_Peak_List.Rows[clickedRow].Cells["Average Delta Mass"].Value.ToString()) - 0.5 * Convert.ToDouble((nUD_PeakWidthBase.Value)),
-            });
+        private void RunTheGamut()
+        {
+            this.Cursor = Cursors.WaitCursor;
+            //GraphETRelations();
+            //FillETPeakListTable();
+            FillETRelationsGridView();
+            //GraphETPeaks();
+            UpdateFiguresOfMerit();
+            this.Cursor = Cursors.Default;
         }
 
         private void UpdateFiguresOfMerit()
@@ -154,37 +251,6 @@ namespace ProteoformSuite
             //{
 
             //}
-        }
-
-        //private void ZeroETPairsTableValues()
-        //{
-        //    foreach (DataRow row in GlobalData.experimentTheoreticalPairs.Rows)
-        //    {
-        //        row["Acceptable Peak"] = false;
-        //        row["Peak Center Count"] = 0;
-        //    }
-        //}
-
-        //private void ClearETPeakListTable()
-        //{
-        //    etPeakList.Clear();
-        //    InitializeETPeakListTable();
-        //}
-
-        private void FillETPeakListTable()
-        {
-            BindingSource bs = new BindingSource();
-            bs.DataSource = Lollipop.et_peaks;
-            dgv_ET_Peak_List.DataSource = bs;
-            ////dgv_ET_Pairs.ReadOnly = true;
-            //dgv_ET_Peak_List.Columns["Average Delta Mass"].ReadOnly = true;
-            //dgv_ET_Peak_List.Columns["Peak Count"].ReadOnly = true;
-            //dgv_ET_Peak_List.Columns["Average Delta Mass"].DefaultCellStyle.Format = "0.#####";
-            //dgv_ET_Peak_List.DefaultCellStyle.BackColor = System.Drawing.Color.LightGray;
-            //dgv_ET_Peak_List.AlternatingRowsDefaultCellStyle.BackColor = System.Drawing.Color.DarkGray;
-            dgv_ET_Peak_List.EndEdit();
-            dgv_ET_Peak_List.Refresh();
-
         }
 
         private void propagatePeakListAcceptedPeakChangeToPairsTable(object sender, DataGridViewCellEventArgs e)
@@ -235,187 +301,53 @@ namespace ProteoformSuite
             }
         }
 
-        private void GraphETHistogram()
-        {
-            //try
-            //{
-            //    string colName = "Delta Mass";
-            //    string direction = "DESC";
-
-
-
-            //    ct_ET_Histogram.Series["etHistogram"].XValueMember = Lollipop.et_relations.OrderByDescending(r => r.group_adjusted_deltaM).Select(r => r.group_adjusted_deltaM);
-            //    ct_ET_Histogram.Series["etHistogram"].YValueMembers = "Running Sum";
-            //    ct_ET_Histogram.DataBind();
-
-            //    ct_ET_Histogram.ChartAreas[0].AxisY.StripLines.Clear();
-
-            //    ct_ET_Histogram.ChartAreas[0].AxisY.StripLines.Add(new StripLine()
-            //    {
-            //        BorderColor = Color.Red,
-            //        IntervalOffset = Convert.ToDouble(nUD_PeakCountMinThreshold.Value),
-            //    });
-
-
-            //    //  ct_ET_Histogram.Series["etHistogram"].ToolTip = "#VALX{#.##}" + " , " + "#VALY{#.##}";
-            //    ct_ET_Histogram.ChartAreas[0].AxisX.Title = "Delta m/z";
-            //    ct_ET_Histogram.ChartAreas[0].AxisY.Title = "Peak Count";
-            //}
-            //catch
-            //{
-
-            //}
-            
-        }
-
         private void splitContainer3_Panel2_Paint(object sender, PaintEventArgs e)
-        {
-
-        }
+        { }
 
         private void nUD_ET_Lower_Bound_ValueChanged(object sender, EventArgs e) // maximum delta mass for theoretical proteoform that has mass LOWER than the experimental protoform mass
         {
-            if (true) RunTheGamut();
+            if (!initial_load) RunTheGamut();
         }
 
         private void nUD_ET_Upper_Bound_ValueChanged(object sender, EventArgs e) // maximum delta mass for theoretical proteoform that has mass HIGHER than the experimental protoform mass
         {
-            if (true) RunTheGamut();
+            if (!initial_load) RunTheGamut();
         }
 
-        private void yMaxET_ValueChanged(object sender, EventArgs e) // scaling for y-axis of displayed ET Histogram of all ET pairs
+        // scaling for axes of displayed ET Histogram of all ET pairs
+        private void yMaxET_ValueChanged(object sender, EventArgs e)
         {
-            if (true) ct_ET_Histogram.ChartAreas[0].AxisY.Maximum = double.Parse(yMaxET.Value.ToString());
+            ct_ET_Histogram.ChartAreas[0].AxisY.Maximum = double.Parse(yMaxET.Value.ToString());
         }
+        private void yMinET_ValueChanged(object sender, EventArgs e) { ct_ET_Histogram.ChartAreas[0].AxisY.Minimum = double.Parse(yMinET.Value.ToString()); }
+        private void xMinET_ValueChanged(object sender, EventArgs e) { ct_ET_Histogram.ChartAreas[0].AxisX.Minimum = double.Parse(xMinET.Value.ToString()); }
+        private void xMaxET_ValueChanged(object sender, EventArgs e) { ct_ET_Histogram.ChartAreas[0].AxisX.Maximum = double.Parse(xMaxET.Value.ToString()); }
 
-        private void yMinET_ValueChanged(object sender, EventArgs e) // scaling for y-axis of displayed ET Histogram of all ET pairs
-        {
-            if (true) ct_ET_Histogram.ChartAreas[0].AxisY.Minimum = double.Parse(yMinET.Value.ToString());
-        }
-
-        private void xMinET_ValueChanged(object sender, EventArgs e) // scaling for x-axis of displayed ET Histogram of all ET pairs
-        {
-            if (true) ct_ET_Histogram.ChartAreas[0].AxisX.Minimum = double.Parse(xMinET.Value.ToString());
-        }
-
-        private void xMaxET_ValueChanged(object sender, EventArgs e) // scaling for x-axis of displayed ET Histogram of all ET pairs
-        {
-            if (true) ct_ET_Histogram.ChartAreas[0].AxisX.Maximum = double.Parse(xMaxET.Value.ToString());
-        }
-
-        private void nUD_NoManLower_ValueChanged(object sender, EventArgs e) // lower bound for the range of decimal values that is impossible to achieve chemically. these would be artifacts
+        // bound for the range of decimal values that is impossible to achieve chemically. these would be artifacts
+        private void nUD_NoManLower_ValueChanged(object sender, EventArgs e)
         {
             Lollipop.no_mans_land_lowerBound = Convert.ToDouble(nUD_NoManLower.Value);
-            if (true) RunTheGamut();
+            if (!initial_load) RunTheGamut();
         }
-
-        private void nUD_NoManUpper_ValueChanged(object sender, EventArgs e)// upper bound for the range of decimal values that is impossible to achieve chemically. these would be artifacts
+        private void nUD_NoManUpper_ValueChanged(object sender, EventArgs e)
         {
             Lollipop.no_mans_land_upperBound = Convert.ToDouble(nUD_NoManUpper.Value);
-            if (true) RunTheGamut();
+            if (!initial_load) RunTheGamut();
         }
 
-        private void nUD_PeakWidthBase_ValueChanged(object sender, EventArgs e) // bin size used for including individual ET pairs in one 'Peak Center Mass' and peak with for one ET peak
+        // bin size used for including individual ET pairs in one 'Peak Center Mass' and peak with for one ET peak
+        private void nUD_PeakWidthBase_ValueChanged(object sender, EventArgs e) 
         {
             Lollipop.peak_width_base = Convert.ToDouble(nUD_PeakWidthBase.Value);
-            if (true) RunTheGamut();
+            if (!initial_load) RunTheGamut();
         }
 
-        private void nUD_PeakCountMinThreshold_ValueChanged(object sender, EventArgs e) // ET pairs with [Peak Center Count] AND ET peaks with [Peak Count] above this value are considered acceptable for use in proteoform family. this will be eventually set following ED analysis.
+        // ET pairs with [Peak Center Count] AND ET peaks with [Peak Count] above this value are considered acceptable for use in proteoform family. this will be eventually set following ED analysis.
+        private void nUD_PeakCountMinThreshold_ValueChanged(object sender, EventArgs e) 
         {
             Lollipop.min_peak_count = Convert.ToDouble(nUD_PeakCountMinThreshold.Value);
-            if (true)
-            {
-                GraphETHistogram(); //we do this hear because the redline threshold needs to be redrawn
-                UpdateFiguresOfMerit();
-            }
-        }
-
-        Point? ct_ET_Histogram_prevPosition = null;
-        ToolTip ct_ET_Histogram_tt = new ToolTip();
-
-        private void ct_ET_Histogram_MouseMove(object sender, MouseEventArgs e)
-        {
-            tooltip_graph_display(ct_ET_peakList_tt, e, ct_ET_Histogram, ct_ET_Histogram_prevPosition);
-        }
-
-        Point? ct_ET_peakList_prevPosition = null;
-        ToolTip ct_ET_peakList_tt = new ToolTip();
-
-        private void ct_ET_peakList_MouseMove(object sender, MouseEventArgs e)
-        {
-            tooltip_graph_display(ct_ET_peakList_tt, e, ct_ET_peakList, ct_ET_peakList_prevPosition);
-        }
-
-        private void tooltip_graph_display(ToolTip t, MouseEventArgs e, Chart c, Point? p)
-        {
-            var pos = e.Location;
-            if (p.HasValue && pos == p.Value) return;
-            t.RemoveAll();
-            p = pos;
-            var results = c.HitTest(pos.X, pos.Y, false, ChartElementType.DataPoint);
-            foreach (var result in results)
-            {
-                if (result.ChartElementType == ChartElementType.DataPoint)
-                {
-                    var prop = result.Object as DataPoint;
-                    if (prop != null)
-                    {
-                        var pointXPixel = result.ChartArea.AxisX.ValueToPixelPosition(prop.XValue);
-                        var pointYPixel = result.ChartArea.AxisY.ValueToPixelPosition(prop.YValues[0]);
-
-                        // check if the cursor is really close to the point (2 pixels around the point)
-                        if (Math.Abs(pos.X - pointXPixel) < 2) //&&
-                                                               // Math.Abs(pos.Y - pointYPixel) < 2)
-                        {
-                            t.Show("X=" + prop.XValue + ", Y=" + prop.YValues[0], c, pos.X, pos.Y - 15);
-                        }
-                    }
-                }
-            }
-        }
-
-        private void InitializeParameterSet()
-        {
-            nUD_ET_Lower_Bound.Minimum = -500;
-            nUD_ET_Lower_Bound.Maximum = 0;
-            nUD_ET_Lower_Bound.Value = -250; // maximum delta mass for theoretical proteoform that has mass LOWER than the experimental protoform mass
-
-            nUD_ET_Upper_Bound.Minimum = 0;
-            nUD_ET_Upper_Bound.Maximum = 500;
-            nUD_ET_Upper_Bound.Value = 250; // maximum delta mass for theoretical proteoform that has mass HIGHER than the experimental protoform mass
-
-            yMaxET.Minimum = 0;
-            yMaxET.Maximum = 1000;
-            yMaxET.Value = 100; // scaling for y-axis of displayed ET Histogram of all ET pairs
-
-            yMinET.Minimum = -100;
-            yMinET.Maximum = yMaxET.Maximum;
-            yMinET.Value = 0; // scaling for y-axis of displayed ET Histogram of all ET pairs
-
-            xMinET.Minimum = nUD_ET_Lower_Bound.Value;
-            xMinET.Maximum = xMaxET.Value;
-            xMinET.Value = nUD_ET_Lower_Bound.Value; // scaling for x-axis of displayed ET Histogram of all ET pairs
-
-            xMaxET.Minimum = xMinET.Value;
-            xMaxET.Maximum = nUD_ET_Upper_Bound.Value;
-            xMaxET.Value = nUD_ET_Upper_Bound.Value; // scaling for x-axis of displayed ET Histogram of all ET pairs
-
-            nUD_NoManLower.Minimum = 00m;
-            nUD_NoManLower.Maximum = 0.49m;
-            nUD_NoManLower.Value = Convert.ToDecimal(Lollipop.no_mans_land_lowerBound); // lower bound for the range of decimal values that is impossible to achieve chemically. these would be artifacts
-
-            nUD_NoManUpper.Minimum = 0.50m;
-            nUD_NoManUpper.Maximum = 1.00m;
-            nUD_NoManUpper.Value = Convert.ToDecimal(Lollipop.no_mans_land_upperBound); // upper bound for the range of decimal values that is impossible to achieve chemically. these would be artifacts
-
-            nUD_PeakWidthBase.Minimum = 0.001m;
-            nUD_PeakWidthBase.Maximum = 0.5000m;
-            nUD_PeakWidthBase.Value = Convert.ToDecimal(Lollipop.peak_width_base); // bin size used for including individual ET pairs in one 'Peak Center Mass' and peak with for one ET peak
-
-            nUD_PeakCountMinThreshold.Minimum = 0;
-            nUD_PeakCountMinThreshold.Maximum = 1000;
-            nUD_PeakCountMinThreshold.Value = Convert.ToDecimal(Lollipop.min_peak_count); // ET pairs with [Peak Center Count] AND ET peaks with [Peak Count] above this value are considered acceptable for use in proteoform family. this will be eventually set following ED analysis.
+            GraphETRelations(); //we do this hear because the redline threshold needs to be redrawn
+            UpdateFiguresOfMerit();
         }
 
         private void ET_Update_Click(object sender, EventArgs e)

--- a/ProteoformSuite/PS_0.00/LoadDeconvolutionResults.Designer.cs
+++ b/ProteoformSuite/PS_0.00/LoadDeconvolutionResults.Designer.cs
@@ -32,6 +32,7 @@
             this.btnDeconResultsAdd = new System.Windows.Forms.Button();
             this.btnDeconResultsRemove = new System.Windows.Forms.Button();
             this.btnDeconResultsClear = new System.Windows.Forms.Button();
+            this.cb_neuCodeLabeled = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // lbDeconResults
@@ -40,11 +41,11 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.lbDeconResults.FormattingEnabled = true;
-            this.lbDeconResults.ItemHeight = 20;
             this.lbDeconResults.Location = new System.Drawing.Point(0, 0);
+            this.lbDeconResults.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.lbDeconResults.Name = "lbDeconResults";
             this.lbDeconResults.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
-            this.lbDeconResults.Size = new System.Drawing.Size(1130, 584);
+            this.lbDeconResults.Size = new System.Drawing.Size(755, 381);
             this.lbDeconResults.Sorted = true;
             this.lbDeconResults.TabIndex = 0;
             this.lbDeconResults.SelectedIndexChanged += new System.EventHandler(this.lbDeconResults_SelectedIndexChanged);
@@ -52,9 +53,10 @@
             // btnDeconResultsAdd
             // 
             this.btnDeconResultsAdd.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btnDeconResultsAdd.Location = new System.Drawing.Point(13, 653);
+            this.btnDeconResultsAdd.Location = new System.Drawing.Point(9, 424);
+            this.btnDeconResultsAdd.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.btnDeconResultsAdd.Name = "btnDeconResultsAdd";
-            this.btnDeconResultsAdd.Size = new System.Drawing.Size(103, 44);
+            this.btnDeconResultsAdd.Size = new System.Drawing.Size(69, 29);
             this.btnDeconResultsAdd.TabIndex = 1;
             this.btnDeconResultsAdd.Text = "Add";
             this.btnDeconResultsAdd.UseVisualStyleBackColor = true;
@@ -63,9 +65,10 @@
             // btnDeconResultsRemove
             // 
             this.btnDeconResultsRemove.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.btnDeconResultsRemove.Location = new System.Drawing.Point(533, 653);
+            this.btnDeconResultsRemove.Location = new System.Drawing.Point(355, 424);
+            this.btnDeconResultsRemove.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.btnDeconResultsRemove.Name = "btnDeconResultsRemove";
-            this.btnDeconResultsRemove.Size = new System.Drawing.Size(103, 44);
+            this.btnDeconResultsRemove.Size = new System.Drawing.Size(69, 29);
             this.btnDeconResultsRemove.TabIndex = 2;
             this.btnDeconResultsRemove.Text = "Remove";
             this.btnDeconResultsRemove.UseVisualStyleBackColor = true;
@@ -74,24 +77,40 @@
             // btnDeconResultsClear
             // 
             this.btnDeconResultsClear.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnDeconResultsClear.Location = new System.Drawing.Point(1006, 653);
+            this.btnDeconResultsClear.Location = new System.Drawing.Point(671, 424);
+            this.btnDeconResultsClear.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.btnDeconResultsClear.Name = "btnDeconResultsClear";
-            this.btnDeconResultsClear.Size = new System.Drawing.Size(103, 44);
+            this.btnDeconResultsClear.Size = new System.Drawing.Size(69, 29);
             this.btnDeconResultsClear.TabIndex = 3;
             this.btnDeconResultsClear.Text = "Clear";
             this.btnDeconResultsClear.UseVisualStyleBackColor = true;
             this.btnDeconResultsClear.Click += new System.EventHandler(this.btnDeconResultsClear_Click);
             // 
+            // cb_neuCodeLabeled
+            // 
+            this.cb_neuCodeLabeled.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.cb_neuCodeLabeled.Checked = true;
+            this.cb_neuCodeLabeled.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cb_neuCodeLabeled.Location = new System.Drawing.Point(9, 386);
+            this.cb_neuCodeLabeled.Name = "cb_neuCodeLabeled";
+            this.cb_neuCodeLabeled.Size = new System.Drawing.Size(112, 17);
+            this.cb_neuCodeLabeled.TabIndex = 4;
+            this.cb_neuCodeLabeled.Text = "NeuCode Labeled";
+            this.cb_neuCodeLabeled.UseVisualStyleBackColor = true;
+            this.cb_neuCodeLabeled.CheckedChanged += new System.EventHandler(this.cb_neuCodeLabeled_CheckedChanged);
+            // 
             // LoadDeconvolutionResults
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1130, 722);
+            this.ClientSize = new System.Drawing.Size(753, 469);
             this.ControlBox = false;
+            this.Controls.Add(this.cb_neuCodeLabeled);
             this.Controls.Add(this.btnDeconResultsClear);
             this.Controls.Add(this.btnDeconResultsRemove);
             this.Controls.Add(this.btnDeconResultsAdd);
             this.Controls.Add(this.lbDeconResults);
+            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.Name = "LoadDeconvolutionResults";
             this.Text = "LoadDeconvolutionResults";
             this.Load += new System.EventHandler(this.LoadDeconvolutionResults_Load);
@@ -105,5 +124,6 @@
         private System.Windows.Forms.Button btnDeconResultsAdd;
         private System.Windows.Forms.Button btnDeconResultsRemove;
         private System.Windows.Forms.Button btnDeconResultsClear;
+        private System.Windows.Forms.CheckBox cb_neuCodeLabeled;
     }
 }

--- a/ProteoformSuite/PS_0.00/LoadDeconvolutionResults.cs
+++ b/ProteoformSuite/PS_0.00/LoadDeconvolutionResults.cs
@@ -101,5 +101,11 @@ namespace ProteoformSuite
         {
             
         }
+
+        private void cb_neuCodeLabeled_CheckedChanged(object sender, EventArgs e)
+        {
+            ((ProteoformSweet)MdiParent).enable_neuCodeProteoformPairsToolStripMenuItem(cb_neuCodeLabeled.Checked);
+            Lollipop.neucode_labeled = cb_neuCodeLabeled.Checked;
+        }
     }
 }

--- a/ProteoformSuite/PS_0.00/Lollipop.cs
+++ b/ProteoformSuite/PS_0.00/Lollipop.cs
@@ -32,6 +32,7 @@ namespace ProteoformSuite
         //RAW EXPERIMENTAL COMPONENTS
         public static BindingList<string> deconResultsFileNames = new BindingList<string>();
         public static List<Component> raw_experimental_components = new List<Component>();
+        public static bool neucode_labeled = true;
         public static void process_raw_components()
         {
             Parallel.ForEach<string>(Lollipop.deconResultsFileNames, filename =>
@@ -39,7 +40,7 @@ namespace ProteoformSuite
                 List<Component> raw_components = new List<Component>(new ExcelReader().read_components_from_xlsx(filename));
                 raw_experimental_components.AddRange(raw_components);
 
-                //if (no_label_button_checked)
+                if (neucode_labeled)
                 {
                     HashSet<string> scan_ranges = new HashSet<string>(raw_components.Select(c => c.scan_range));
                     Parallel.ForEach<string>(scan_ranges, scan_range =>
@@ -350,31 +351,31 @@ namespace ProteoformSuite
         //RESULTS OUTPUT
         public static string raw_component_results()
         {
-            return Component.get_csv_header() + Environment.NewLine + String.Join(Environment.NewLine, Lollipop.raw_experimental_components.Where(c => c != null).Select(c => c.as_csv_row()));
+            return Component.get_tsv_header() + Environment.NewLine + String.Join(Environment.NewLine, Lollipop.raw_experimental_components.Where(c => c != null).Select(c => c.as_tsv_row()));
         }
         public static string raw_neucode_pair_results()
         {
-            return NeuCodePair.get_csv_header() + Environment.NewLine + String.Join(Environment.NewLine, Lollipop.raw_neucode_pairs.Select(p => p.as_csv_row()));
+            return NeuCodePair.get_tsv_header() + Environment.NewLine + String.Join(Environment.NewLine, Lollipop.raw_neucode_pairs.Select(p => p.as_tsv_row()));
         }
         public static string aggregated_experimental_proteoform_results()
         {
-            return ExperimentalProteoform.get_csv_header() + Environment.NewLine + String.Join(Environment.NewLine, Lollipop.proteoform_community.experimental_proteoforms.Select(p => p.as_csv_row()));
+            return ExperimentalProteoform.get_tsv_header() + Environment.NewLine + String.Join(Environment.NewLine, Lollipop.proteoform_community.experimental_proteoforms.Select(p => p.as_tsv_row()));
         }
         public static string et_relations_results()
         {
-            return ProteoformRelation.get_csv_header() + Environment.NewLine + String.Join(Environment.NewLine, et_relations.Select(r => r.as_csv_row()));
+            return ProteoformRelation.get_tsv_header() + Environment.NewLine + String.Join(Environment.NewLine, et_relations.Select(r => r.as_tsv_row()));
         }
         public static string et_peak_results()
         {
-            return DeltaMassPeak.get_csv_header() + Environment.NewLine + String.Join(Environment.NewLine, et_peaks.Select(r => r.as_csv_row()));
+            return DeltaMassPeak.get_tsv_header() + Environment.NewLine + String.Join(Environment.NewLine, et_peaks.Select(r => r.as_tsv_row()));
         }
         public static string ee_relations_results()
         {
-            return ProteoformRelation.get_csv_header() + Environment.NewLine + String.Join(Environment.NewLine, ee_relations.Select(r => r.as_csv_row()));
+            return ProteoformRelation.get_tsv_header() + Environment.NewLine + String.Join(Environment.NewLine, ee_relations.Select(r => r.as_tsv_row()));
         }
         public static string ee_peak_results()
         {
-            return DeltaMassPeak.get_csv_header() + Environment.NewLine + String.Join(Environment.NewLine, ee_peaks.Select(r => r.as_csv_row()));
+            return DeltaMassPeak.get_tsv_header() + Environment.NewLine + String.Join(Environment.NewLine, ee_peaks.Select(r => r.as_tsv_row()));
         }
 
         //METHOD FILE

--- a/ProteoformSuite/PS_0.00/NeuCodePair.cs
+++ b/ProteoformSuite/PS_0.00/NeuCodePair.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ProteoformSuite
+{
+    public class NeuCodePair : Component
+    {
+        Component neuCodeLight;
+        Component neuCodeHeavy;
+        public double corrected_mass { get; set; }
+        public List<int> overlapping_charge_states { get; set; }
+
+        public double intensity_ratio { get; set; }
+        public int lysine_count { get; set; }
+        public bool accepted { get; set; } = true;
+
+        public NeuCodePair(Component neuCodeLight, Component neuCodeHeavy, double mass_difference, List<int> overlapping_charge_states) : base(neuCodeLight)
+        {
+            this.overlapping_charge_states = overlapping_charge_states;
+            this.neuCodeHeavy = neuCodeHeavy;
+
+            int diff_integer = Convert.ToInt32(Math.Round(mass_difference / 1.0015 - 0.5, 0, MidpointRounding.AwayFromZero));
+            double firstCorrection = neuCodeLight.weighted_monoisotopic_mass + diff_integer * 1.0015;
+            this.lysine_count = Math.Abs(Convert.ToInt32(Math.Round((neuCodeHeavy.weighted_monoisotopic_mass - firstCorrection) / 0.036015372, 0, MidpointRounding.AwayFromZero)));
+            this.intensity_ratio = this.intensity_sum / this.neuCodeHeavy.intensity_sum;
+            this.corrected_mass = this.weighted_monoisotopic_mass + Math.Round((this.lysine_count * 0.1667 - 0.4), 0, MidpointRounding.AwayFromZero) * 1.0015;
+        }
+
+        public string as_csv_row()
+        {
+            return String.Join(",", new List<string> { this.id.ToString(), this.intensity_sum.ToString(), this.weighted_monoisotopic_mass.ToString(), this.corrected_mass.ToString(), this.rt_apex.ToString(),
+                this.neuCodeHeavy.id.ToString(), this.neuCodeHeavy.intensity_sum.ToString(), this.neuCodeHeavy.weighted_monoisotopic_mass.ToString(), this.intensity_ratio.ToString(), this.lysine_count.ToString(),
+                this.file_origin.ToString() });
+        }
+
+        public static string get_csv_header()
+        {
+            return String.Join(",", new List<string> { "light_id", "light_intensity", "light_weighted_monoisotopic_mass", "light_corrected_mass", "light_apexRt",
+                "heavy_id", "heavy_intensity", "heavy_weighted_monoisotopic_mass", "intensity_ratio", "lysine_count", "file_origin" });
+        }
+    }
+}

--- a/ProteoformSuite/PS_0.00/NeuCodePair.cs
+++ b/ProteoformSuite/PS_0.00/NeuCodePair.cs
@@ -29,16 +29,16 @@ namespace ProteoformSuite
             this.corrected_mass = this.weighted_monoisotopic_mass + Math.Round((this.lysine_count * 0.1667 - 0.4), 0, MidpointRounding.AwayFromZero) * 1.0015;
         }
 
-        public string as_csv_row()
+        public string as_tsv_row()
         {
-            return String.Join(",", new List<string> { this.id.ToString(), this.intensity_sum.ToString(), this.weighted_monoisotopic_mass.ToString(), this.corrected_mass.ToString(), this.rt_apex.ToString(),
+            return String.Join("\t", new List<string> { this.id.ToString(), this.intensity_sum.ToString(), this.weighted_monoisotopic_mass.ToString(), this.corrected_mass.ToString(), this.rt_apex.ToString(),
                 this.neuCodeHeavy.id.ToString(), this.neuCodeHeavy.intensity_sum.ToString(), this.neuCodeHeavy.weighted_monoisotopic_mass.ToString(), this.intensity_ratio.ToString(), this.lysine_count.ToString(),
                 this.file_origin.ToString() });
         }
 
-        public static string get_csv_header()
+        public static string get_tsv_header()
         {
-            return String.Join(",", new List<string> { "light_id", "light_intensity", "light_weighted_monoisotopic_mass", "light_corrected_mass", "light_apexRt",
+            return String.Join("\t", new List<string> { "light_id", "light_intensity", "light_weighted_monoisotopic_mass", "light_corrected_mass", "light_apexRt",
                 "heavy_id", "heavy_intensity", "heavy_weighted_monoisotopic_mass", "intensity_ratio", "lysine_count", "file_origin" });
         }
     }

--- a/ProteoformSuite/PS_0.00/NeuCodePair.cs
+++ b/ProteoformSuite/PS_0.00/NeuCodePair.cs
@@ -10,7 +10,6 @@ namespace ProteoformSuite
     {
         Component neuCodeLight;
         Component neuCodeHeavy;
-        public double corrected_mass { get; set; }
         public List<int> overlapping_charge_states { get; set; }
 
         public double intensity_ratio { get; set; }
@@ -20,6 +19,7 @@ namespace ProteoformSuite
         public NeuCodePair(Component neuCodeLight, Component neuCodeHeavy, double mass_difference, List<int> overlapping_charge_states) : base(neuCodeLight)
         {
             this.overlapping_charge_states = overlapping_charge_states;
+            this.neuCodeLight = neuCodeLight;
             this.neuCodeHeavy = neuCodeHeavy;
 
             int diff_integer = Convert.ToInt32(Math.Round(mass_difference / 1.0015 - 0.5, 0, MidpointRounding.AwayFromZero));

--- a/ProteoformSuite/PS_0.00/Proteoform.cs
+++ b/ProteoformSuite/PS_0.00/Proteoform.cs
@@ -109,15 +109,15 @@ namespace ProteoformSuite
             return false;
         }
 
-        public string as_csv_row()
+        public string as_tsv_row()
         {
-            return String.Join(",", new List<string> { this.accession.ToString(), this.modified_mass.ToString(), this.lysine_count.ToString(), this.is_target.ToString(), this.is_decoy.ToString(),
+            return String.Join("\t", new List<string> { this.accession.ToString(), this.modified_mass.ToString(), this.lysine_count.ToString(), this.is_target.ToString(), this.is_decoy.ToString(),
                 this.agg_mass.ToString(), this.agg_intensity.ToString(), this.agg_rt.ToString(), this.observation_count.ToString() });
         }
 
-        public static string get_csv_header()
+        public static string get_tsv_header()
         {
-            return String.Join(",", new List<string> { "accession", "modified_mass", "lysine_count", "is_target", "is_decoy",
+            return String.Join("\t", new List<string> { "accession", "modified_mass", "lysine_count", "is_target", "is_decoy",
                 "agg_mass", "agg_intensity", "agg_rt", "observation_count" });
         }
     }

--- a/ProteoformSuite/PS_0.00/Proteoform.cs
+++ b/ProteoformSuite/PS_0.00/Proteoform.cs
@@ -7,79 +7,11 @@ using System.Threading.Tasks;
 
 namespace ProteoformSuite
 {
-    public class NeuCodePair 
-    {
-        Component neuCodeLight;
-        Component neuCodeHeavy;
-        public string file_origin { get { return neuCodeLight.file_origin; } }
-        public int light_id { get { return neuCodeLight.id; } }
-        public double light_weighted_monoisotopic_mass { get { return neuCodeLight.weighted_monoisotopic_mass; } }
-        public double light_corrected_mass { get; set; }
-        public double light_intensity { get; set; }
-        public double light_apexRt { get { return neuCodeLight.rt_apex; } }
-        public int heavy_id { get { return neuCodeHeavy.id; } }
-        public double heavy_weighted_monoisotopic_mass { get { return neuCodeHeavy.weighted_monoisotopic_mass; } }
-        public double heavy_intensity { get; set; }
-        public List<int> overlapping_charge_states { get; set; }
-        
-        public double intensity_ratio { get; set; }
-        public int lysine_count { get; set; }
-        public bool accepted { get; set; } = false;
-
-        public NeuCodePair(Component lower_rawNeuCode, Component higher_rawNeuCode)
-        {
-            double mass_difference = higher_rawNeuCode.weighted_monoisotopic_mass - lower_rawNeuCode.weighted_monoisotopic_mass; //changed from decimal; it doesn't seem like that should make a difference
-            List<int> lower_charges = lower_rawNeuCode.charge_states.Select(charge_state => charge_state.charge_count).ToList<int>();
-            List<int> higher_charges = higher_rawNeuCode.charge_states.Select(charge_states => charge_states.charge_count).ToList<int>();
-            this.overlapping_charge_states = lower_charges.Intersect(higher_charges).ToList();
-            double lower_intensity = lower_rawNeuCode.calculate_sum_intensity(this.overlapping_charge_states);
-            double higher_intensity = lower_rawNeuCode.calculate_sum_intensity(this.overlapping_charge_states);
-
-            if (lower_intensity > 0 || higher_intensity > 0)
-            {
-                this.accepted = true;
-                if (lower_intensity > higher_intensity) //lower mass is neucode light
-                {
-                    neuCodeLight = lower_rawNeuCode;
-                    this.light_intensity = lower_intensity;
-                    neuCodeHeavy = higher_rawNeuCode;
-                    this.heavy_intensity = higher_intensity;
-                }
-                else //higher mass is neucode light
-                {
-                    neuCodeLight = higher_rawNeuCode;
-                    this.light_intensity = higher_intensity;
-                    neuCodeHeavy = lower_rawNeuCode;
-                    this.heavy_intensity = lower_intensity;
-                }
-
-                int diff_integer = Convert.ToInt32(Math.Round(mass_difference / 1.0015 - 0.5, 0, MidpointRounding.AwayFromZero));
-                double firstCorrection = neuCodeLight.weighted_monoisotopic_mass + diff_integer * 1.0015;
-                this.lysine_count = Math.Abs(Convert.ToInt32(Math.Round((neuCodeHeavy.weighted_monoisotopic_mass - firstCorrection) / 0.036015372, 0, MidpointRounding.AwayFromZero)));
-                this.intensity_ratio = this.light_intensity / this.heavy_intensity;
-                this.light_corrected_mass = neuCodeLight.weighted_monoisotopic_mass + Math.Round((this.lysine_count * 0.1667 - 0.4), 0, MidpointRounding.AwayFromZero) * 1.0015;
-            }
-        }
-
-        public string as_csv_row()
-        {
-            return String.Join(",", new List<string> { this.light_id.ToString(), this.light_intensity.ToString(), this.light_weighted_monoisotopic_mass.ToString(), this.light_corrected_mass.ToString(), this.light_apexRt.ToString(),
-                this.heavy_id.ToString(), this.heavy_intensity.ToString(), this.heavy_weighted_monoisotopic_mass.ToString(), this.intensity_ratio.ToString(), this.lysine_count.ToString(),
-                this.file_origin.ToString() });
-        }
-
-        public static string get_csv_header()
-        {
-            return String.Join(",", new List<string> { "light_id", "light_intensity", "light_weighted_monoisotopic_mass", "light_corrected_mass", "light_apexRt",
-                "heavy_id", "heavy_intensity", "heavy_weighted_monoisotopic_mass", "intensity_ratio", "lysine_count", "file_origin" });
-        }
-    }
-
     public class Proteoform
     {
         public string accession { get; set; }
         public double modified_mass { get; set; }
-        public int lysine_count { get; set; }
+        public int lysine_count { get; set; } = -1
         public bool is_target { get; set; } = true;
         public bool is_decoy { get; } = false;
         public List<MassDifference> relationships { get; set; } = new List<MassDifference>();
@@ -112,64 +44,66 @@ namespace ProteoformSuite
     //"ExperimentalProteoform" and "TheoreticalProteoform" objects
     public class ExperimentalProteoform : Proteoform 
     {
-        private NeuCodePair root;
-        public List<NeuCodePair> aggregated_neucode_pairs;
+        private Component root;
+        public List<Component> aggregated_components;
         public double agg_mass { get; set; } = 0;
         public double agg_intensity { get; set; } = 0;
         public double agg_rt { get; set; } = 0;
         public int observation_count
         {
-            get { return aggregated_neucode_pairs.Count; }
+            get { return aggregated_components.Count; }
         }
 
-        public ExperimentalProteoform(string accession, NeuCodePair root, List<NeuCodePair> candidate_observations, bool is_target) : base(accession, is_target)
+        public ExperimentalProteoform(string accession, Component root, List<Component> candidate_observations, bool is_target) : base(accession, is_target)
         {
             this.root = root;
-            this.aggregated_neucode_pairs = new List<NeuCodePair>() { root };
-            this.aggregated_neucode_pairs.AddRange(candidate_observations.Where(p => this.includes(p)));
+            this.aggregated_components = new List<Component>() { root };
+            this.aggregated_components.AddRange(candidate_observations.Where(p => this.includes(p)));
             this.calculate_properties();
         }
 
         private void calculate_properties()
         {
-            this.agg_intensity = aggregated_neucode_pairs.Select(p => p.light_intensity).Sum();
-            this.agg_rt = aggregated_neucode_pairs.Select(p => p.light_apexRt * p.light_intensity / this.agg_intensity).Sum();
-            this.agg_mass = aggregated_neucode_pairs.Select(p =>
-                (p.light_corrected_mass + Math.Round((this.root.light_corrected_mass - p.light_corrected_mass), 0) * 1.0015) //mass + mass shift
-                * p.light_intensity / this.agg_intensity).Sum();
-            this.lysine_count = this.root.lysine_count;
+            this.agg_intensity = aggregated_components.Select(p => p.intensity_sum).Sum();
+            this.agg_rt = aggregated_components.Select(p => p.rt_apex * p.intensity_sum / this.agg_intensity).Sum();
+            this.agg_mass = aggregated_components.Select(p =>
+                (p.corrected_mass + Math.Round((this.root.corrected_mass - p.corrected_mass), 0) * 1.0015) //mass + mass shift
+                * p.intensity_sum / this.agg_intensity).Sum();
+            if (root is NeuCodePair) this.lysine_count = ((NeuCodePair)this.root).lysine_count;
             this.modified_mass = this.agg_mass;
         }
 
-        public bool includes(NeuCodePair candidate)
+        public bool includes(Component candidate)
         {
-            return tolerable_rt(candidate) && tolerable_lysCt(candidate) && tolerable_mass(candidate);
+            bool does_include = tolerable_rt(candidate) && tolerable_mass(candidate);
+            if (candidate is NeuCodePair) does_include = does_include && tolerable_lysCt((NeuCodePair)candidate);
+            return does_include;
         }
 
-        private bool tolerable_rt(NeuCodePair candidate)
+        private bool tolerable_rt(Component candidate)
         {
-            return candidate.light_apexRt >= this.root.light_apexRt - Convert.ToDouble(Lollipop.retention_time_tolerance) &&
-                candidate.light_apexRt <= this.root.light_apexRt + Convert.ToDouble(Lollipop.retention_time_tolerance);
+            return candidate.rt_apex >= this.root.rt_apex - Convert.ToDouble(Lollipop.retention_time_tolerance) &&
+                candidate.rt_apex <= this.root.rt_apex + Convert.ToDouble(Lollipop.retention_time_tolerance);
         }
 
         private bool tolerable_lysCt(NeuCodePair candidate)
         {
             int max_missed_lysines = Convert.ToInt32(Lollipop.missed_lysines);
-            List<int> acceptable_lysineCts = Enumerable.Range(this.root.lysine_count - max_missed_lysines, max_missed_lysines * 2 + 1).ToList();
+            List<int> acceptable_lysineCts = Enumerable.Range(((NeuCodePair)this.root).lysine_count - max_missed_lysines, max_missed_lysines * 2 + 1).ToList();
             return acceptable_lysineCts.Contains(candidate.lysine_count);
         }
 
-        private bool tolerable_mass(NeuCodePair candidate)
+        private bool tolerable_mass(Component candidate)
         {
             int max_missed_monoisotopics = Convert.ToInt32(Lollipop.missed_monos);
             List<int> missed_monoisotopics = Enumerable.Range(-max_missed_monoisotopics, max_missed_monoisotopics * 2 + 1).ToList();
             foreach (int m in missed_monoisotopics)
             {
                 double shift = m * 1.0015;
-                double mass_tolerance = (this.root.light_corrected_mass + shift) / 1000000 * Convert.ToInt32(Lollipop.mass_tolerance);
-                double low = this.root.light_corrected_mass + shift - mass_tolerance;
-                double high = this.root.light_corrected_mass + shift + mass_tolerance;
-                bool tolerable_mass = candidate.light_corrected_mass >= low && candidate.light_corrected_mass <= high;
+                double mass_tolerance = (this.root.corrected_mass + shift) / 1000000 * Convert.ToInt32(Lollipop.mass_tolerance);
+                double low = this.root.corrected_mass + shift - mass_tolerance;
+                double high = this.root.corrected_mass + shift + mass_tolerance;
+                bool tolerable_mass = candidate.corrected_mass >= low && candidate.corrected_mass <= high;
                 if (tolerable_mass) return true; //Return a true result immediately; acts as an OR between these conditions
             }
             return false;

--- a/ProteoformSuite/PS_0.00/Proteoform.cs
+++ b/ProteoformSuite/PS_0.00/Proteoform.cs
@@ -11,7 +11,7 @@ namespace ProteoformSuite
     {
         public string accession { get; set; }
         public double modified_mass { get; set; }
-        public int lysine_count { get; set; } = -1
+        public int lysine_count { get; set; } = -1;
         public bool is_target { get; set; } = true;
         public bool is_decoy { get; } = false;
         public List<MassDifference> relationships { get; set; } = new List<MassDifference>();

--- a/ProteoformSuite/PS_0.00/ProteoformRelation.cs
+++ b/ProteoformSuite/PS_0.00/ProteoformRelation.cs
@@ -99,15 +99,15 @@ namespace ProteoformSuite
             return nearby_relations;
         }
 
-        public string as_csv_row()
+        public string as_tsv_row()
         {
-            return String.Join(",", new List<string> { this.connected_proteoforms[0].accession.ToString(), this.connected_proteoforms[1].accession.ToString(), this.delta_mass.ToString(), this.group_adjusted_deltaM.ToString(),
+            return String.Join("\t", new List<string> { this.connected_proteoforms[0].accession.ToString(), this.connected_proteoforms[1].accession.ToString(), this.delta_mass.ToString(), this.group_adjusted_deltaM.ToString(),
                 this.group_count.ToString() });
         }
 
-        public static string get_csv_header()
+        public static string get_tsv_header()
         {
-            return String.Join(",", new List<string> { "proteoform1_accession", "proteoform2_accession", "delta_mass", "group_adjusted_deltaM", "group_count" });
+            return String.Join("\t", new List<string> { "proteoform1_accession", "proteoform2_accession", "delta_mass", "group_adjusted_deltaM", "group_count" });
         }
     }
 }

--- a/ProteoformSuite/PS_0.00/ProteoformSuite.csproj
+++ b/ProteoformSuite/PS_0.00/ProteoformSuite.csproj
@@ -87,6 +87,7 @@
     </Compile>
     <Compile Include="AminoAcidMasses.cs" />
     <Compile Include="Component.cs" />
+    <Compile Include="ComponentAggregate.cs" />
     <Compile Include="DeltaMassPeak.cs" />
     <Compile Include="ExcelReader.cs" />
     <Compile Include="Proteoform.cs" />

--- a/ProteoformSuite/PS_0.00/ProteoformSuite.csproj
+++ b/ProteoformSuite/PS_0.00/ProteoformSuite.csproj
@@ -87,7 +87,7 @@
     </Compile>
     <Compile Include="AminoAcidMasses.cs" />
     <Compile Include="Component.cs" />
-    <Compile Include="ComponentAggregate.cs" />
+    <Compile Include="NeuCodePair.cs" />
     <Compile Include="DeltaMassPeak.cs" />
     <Compile Include="ExcelReader.cs" />
     <Compile Include="Proteoform.cs" />

--- a/ProteoformSuite/PS_0.00/ProteoformSweet.Designer.cs
+++ b/ProteoformSuite/PS_0.00/ProteoformSweet.Designer.cs
@@ -82,35 +82,35 @@
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(114, 22);
             this.openToolStripMenuItem.Text = "Open";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
             // saveToolStripMenuItem
             // 
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(114, 22);
             this.saveToolStripMenuItem.Text = "Save";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
             // 
             // saveAsToolStripMenuItem
             // 
             this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
-            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(114, 22);
             this.saveAsToolStripMenuItem.Text = "Save As";
             this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
             // 
             // printToolStripMenuItem
             // 
             this.printToolStripMenuItem.Name = "printToolStripMenuItem";
-            this.printToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.printToolStripMenuItem.Size = new System.Drawing.Size(114, 22);
             this.printToolStripMenuItem.Text = "Print";
             this.printToolStripMenuItem.Click += new System.EventHandler(this.printToolStripMenuItem_Click);
             // 
             // closeToolStripMenuItem
             // 
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
-            this.closeToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.closeToolStripMenuItem.Size = new System.Drawing.Size(114, 22);
             this.closeToolStripMenuItem.Text = "Close";
             this.closeToolStripMenuItem.Click += new System.EventHandler(this.closeToolStripMenuItem_Click);
             // 
@@ -225,7 +225,7 @@
             this.loadRunToolStripMenuItem.Text = "Load && Run";
             this.loadRunToolStripMenuItem.Click += new System.EventHandler(this.loadRunToolStripMenuItem_Click);
             // 
-            // Form1
+            // ProteoformSweet
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
@@ -237,7 +237,7 @@
             this.IsMdiContainer = true;
             this.MainMenuStrip = this.menuStrip1;
             this.Margin = new System.Windows.Forms.Padding(2);
-            this.Name = "Form1";
+            this.Name = "ProteoformSweet";
             this.Text = "Proteoform Suite 0.00";
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();

--- a/ProteoformSuite/PS_0.00/ProteoformSweet.cs
+++ b/ProteoformSuite/PS_0.00/ProteoformSweet.cs
@@ -55,48 +55,20 @@ namespace ProteoformSuite
             form.Show();
             form.WindowState = FormWindowState.Maximized;
         }
-
-        public void loadDeconvolutionResultsToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            showForm(loadDeconvolutionResults);
-        }
-
-        private void rawExperimentalProteoformsToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            showForm(rawExperimentalComponents);
-        }
-
-        private void neuCodeProteoformPairsToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            showForm(neuCodePairs);
-        }
-
-        private void aggregatedProteoformsToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            showForm(aggregatedProteoforms);
-        }
-
-        private void theoreticalProteoformDatabaseToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            showForm(theoreticalDatabase);
-        }
-
-        private void experimentTheoreticalComparisonToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            showForm(experimentalTheoreticalComparison);
-        }
         
+        // tool strip clicks
+        public void loadDeconvolutionResultsToolStripMenuItem_Click(object sender, EventArgs e) { showForm(loadDeconvolutionResults); }
+        private void rawExperimentalProteoformsToolStripMenuItem_Click(object sender, EventArgs e) { showForm(rawExperimentalComponents); }
+        private void neuCodeProteoformPairsToolStripMenuItem_Click(object sender, EventArgs e) { showForm(neuCodePairs); }
+        private void aggregatedProteoformsToolStripMenuItem_Click(object sender, EventArgs e) { showForm(aggregatedProteoforms); }
+        private void theoreticalProteoformDatabaseToolStripMenuItem_Click(object sender, EventArgs e) { showForm(theoreticalDatabase); }
+        private void experimentTheoreticalComparisonToolStripMenuItem_Click(object sender, EventArgs e) { showForm(experimentalTheoreticalComparison); }
+        private void experimentExperimentComparisonToolStripMenuItem_Click(object sender, EventArgs e) { showForm(experimentExperimentComparison); }
         private void experimentDecoyComparisonToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (Lollipop.decoy_databases > 0) showForm(experimentDecoyComparison);
             else MessageBox.Show("Create at least 1 decoy database in Theoretical Proteoform Database in order to view Experiment - Decoy Comparison.");
         }
-
-        private void experimentExperimentComparisonToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-            showForm(experimentExperimentComparison);
-        }
-
         private void proteoformFamilyAssignmentToolStripMenuItem_Click(object sender, EventArgs e)
         {
             //showForm(proteoformFamilyAssignment);

--- a/ProteoformSuite/PS_0.00/ProteoformSweet.cs
+++ b/ProteoformSuite/PS_0.00/ProteoformSweet.cs
@@ -195,6 +195,11 @@ namespace ProteoformSuite
             );
         }
 
+        public void enable_neuCodeProteoformPairsToolStripMenuItem(bool setting)
+        {
+            neuCodeProteoformPairsToolStripMenuItem.Enabled = setting;
+        }
+
         private void openToolStripMenuItem_Click(object sender, EventArgs e)
         {
             MessageBox.Show("openToolStripMenuItem_Click");

--- a/ProteoformSuite/PS_0.00/RawExperimentalComponents.cs
+++ b/ProteoformSuite/PS_0.00/RawExperimentalComponents.cs
@@ -26,6 +26,7 @@ namespace ProteoformSuite
         public void RawExperimentalComponents_Load(object sender, EventArgs e)
         {
             if (Lollipop.raw_experimental_components.Count == 0) Lollipop.process_raw_components();
+            this.FillRawExpComponentsTable();
         }
 
         public void FillRawExpComponentsTable()

--- a/ProteoformSuite/PS_0.00/neuCodePairs.cs
+++ b/ProteoformSuite/PS_0.00/neuCodePairs.cs
@@ -25,6 +25,7 @@ namespace ProteoformSuite
         {
             GraphLysineCount();
             GraphIntensityRatio();
+            FillNeuCodePairsDGV();
         }
 
         public void FillNeuCodePairsDGV()
@@ -54,12 +55,13 @@ namespace ProteoformSuite
             int ymax = 0;
             for (double i = 0; i <= 20; i = i + 0.05)
             {
-                string expression = "[Intensity Ratio] >= " + (i - .025) + "AND [Intensity Ratio] < " + (i + .025);
                 List<NeuCodePair> proteoforms_by_intensityRatio = Lollipop.raw_neucode_pairs.Where(p => p.intensity_ratio >= i - 0.025 && p.intensity_ratio < i + 0.025).ToList();
                 if (proteoforms_by_intensityRatio.Count > ymax)
                     ymax = proteoforms_by_intensityRatio.Count;
                 intensityRatioHistogram.Rows.Add(i, proteoforms_by_intensityRatio.Count);
             }
+            ct_IntensityRatio.DataSource = intensityRatioHistogram;
+            ct_IntensityRatio.DataBind();
 
             ct_IntensityRatio.Series["intensityRatio"].XValueMember = "intRatio";
             ct_IntensityRatio.Series["intensityRatio"].YValueMembers = "numPairsAtThisIntRatio";
@@ -74,9 +76,6 @@ namespace ProteoformSuite
 
             ct_IntensityRatio.ChartAreas[0].AxisX.Title = "Intensity Ratio of a Pair";
             ct_IntensityRatio.ChartAreas[0].AxisY.Title = "Number of NeuCode Pairs";
-
-            ct_IntensityRatio.DataSource = intensityRatioHistogram;
-            ct_IntensityRatio.DataBind();
         }
 
         private void GraphLysineCount()
@@ -86,8 +85,6 @@ namespace ProteoformSuite
             lysCtHistogram.Columns.Add("numPairsAtThisLysCt", typeof(int));
 
             int ymax = 0;
-            //double xInt = 0.2;
-
             for (int i = 0; i <= 28; i++)
             {
                 List<NeuCodePair> pf_by_lysCt = Lollipop.raw_neucode_pairs.Where(p => p.lysine_count == i).ToList();
@@ -95,6 +92,8 @@ namespace ProteoformSuite
                     ymax = pf_by_lysCt.Count;
                 lysCtHistogram.Rows.Add(i, pf_by_lysCt.Count);
             }
+            ct_LysineCount.DataSource = lysCtHistogram;
+            ct_LysineCount.DataBind();
 
             ct_LysineCount.Series["lysineCount"].XValueMember = "numLysines";
             ct_LysineCount.Series["lysineCount"].YValueMembers = "numPairsAtThisLysCt";
@@ -108,11 +107,7 @@ namespace ProteoformSuite
             KMinAcceptable.Minimum = 0; KMinAcceptable.Maximum = 28; KMinAcceptable.Value = Lollipop.min_lysine_ct;
 
             ct_LysineCount.ChartAreas[0].AxisX.Title = "Lysine Count";
-            ct_LysineCount.ChartAreas[0].AxisY.Title = "Number of NeuCode Pairs";
-
-            ct_LysineCount.DataSource = lysCtHistogram;
-            ct_LysineCount.DataBind();
-
+            ct_LysineCount.ChartAreas[0].AxisY.Title = "Number of NeuCode Pairs";            
         }
 
         Point? ct_intensityRatio_prevPosition = null;

--- a/ProteoformSuite/TasteTesting/ComponentTests.cs
+++ b/ProteoformSuite/TasteTesting/ComponentTests.cs
@@ -11,9 +11,9 @@ namespace TasteTesting
         [TestMethod]
         public void FindNeuCodePairs_withEmptyComponentList()
         {
-            List<ProteoformSuite.Component> c_list = new List<ProteoformSuite.Component>();
-            ProteoformSuite.Lollipop.find_neucode_pairs(c_list);
-            Assert.AreEqual(0, ProteoformSuite.Lollipop.raw_neucode_pairs.Count);
+            List<ProteoformSuite.Component> c_list = new List<ProteoformSuite.Component>(); //arrange
+            ProteoformSuite.Lollipop.find_neucode_pairs(c_list); //act
+            Assert.AreEqual(0, ProteoformSuite.Lollipop.raw_neucode_pairs.Count); //assert
         }
     }
 }


### PR DESCRIPTION
ExperimentalProteoform objects can now be constructed from Components, and not just NeuCodePairs.

NeuCodePair is now a derivative class of RawExperimentalComponent, where the light neucode component is taken as the base component. Also, ExperimentalProteoform now takes in a list of Component objects, which may be NeuCodePair objects, and it aggregates them irrespective of lysine count if the component is not a NeuCodePair. Proteoforms now start with a lysine count of -1 to indicate there is no lysine count assigned.

There is space in the RawExperimentalComponents section of Lollipop to put an if statement for whether or not NeuCode was used. Someone who wants to make a button for that can implement the check there.
