### PR TITLE
utility for sortable lists of objects in datagridview

### DIFF
--- a/ProteoformSuiteGUI/DataGridViewDisplayUtility.cs
+++ b/ProteoformSuiteGUI/DataGridViewDisplayUtility.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace ProteoformSuite
+{
+    public class DataGridViewDisplayUtility
+    {
+
+        public static void FillDataGridView(DataGridView dgv, IEnumerable<object> someList)
+        {
+            SortableBindingList<object> sbl = new SortableBindingList<object>(someList);
+            dgv.DataSource = sbl;
+            dgv.ReadOnly = true;
+            dgv.DefaultCellStyle.BackColor = System.Drawing.Color.LightGray;
+            dgv.AlternatingRowsDefaultCellStyle.BackColor = System.Drawing.Color.DarkGray;
+        }
+
+        public static void sortDataGridViewColumn(DataGridView dgv, int columnIndex)
+        {
+            DataGridViewColumn newColumn = dgv.Columns[columnIndex];
+            DataGridViewColumn oldColumn = dgv.SortedColumn;
+            ListSortDirection direction;
+
+            // If oldColumn is null, then the DataGridView is not sorted.
+            if (oldColumn != null)
+            {
+                if (oldColumn == newColumn)
+                {
+                    if (dgv.SortOrder == SortOrder.Ascending)                    
+                        direction = ListSortDirection.Descending;                   
+                    else
+                        direction = ListSortDirection.Ascending;
+
+                }
+                else
+                {
+                    direction = ListSortDirection.Descending;
+                    oldColumn.HeaderCell.SortGlyphDirection = SortOrder.None;
+                }
+
+            }
+            else
+            {
+                direction = ListSortDirection.Descending;
+            }
+
+            // Sort the selected column.
+            dgv.Sort(newColumn, direction);
+            newColumn.HeaderCell.SortGlyphDirection =
+                direction == ListSortDirection.Ascending ?
+                SortOrder.Ascending : SortOrder.Descending;
+        }
+
+    }
+}

--- a/ProteoformSuiteGUI/ProteoformSuiteGUI.csproj
+++ b/ProteoformSuiteGUI/ProteoformSuiteGUI.csproj
@@ -110,6 +110,7 @@
     <Compile Include="AggregatedProteoforms.Designer.cs">
       <DependentUpon>AggregatedProteoforms.cs</DependentUpon>
     </Compile>
+    <Compile Include="DataGridViewDisplayUtility.cs" />
     <Compile Include="ExcelReader.cs" />
     <Compile Include="ExperimentExperimentComparison.cs">
       <SubType>Form</SubType>
@@ -158,6 +159,7 @@
     <Compile Include="RawExperimentalComponents.Designer.cs">
       <DependentUpon>RawExperimentalComponents.cs</DependentUpon>
     </Compile>
+    <Compile Include="SortableBindingList.cs" />
     <Compile Include="TheoreticalDatabase.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/ProteoformSuiteGUI/RawExperimentalComponents.cs
+++ b/ProteoformSuiteGUI/RawExperimentalComponents.cs
@@ -21,19 +21,12 @@ namespace ProteoformSuite
 
         public void FillRawExpComponentsTable()
         {
-            BindingSource bs = new BindingSource();
-            bs.DataSource = Lollipop.raw_experimental_components;
-            dgv_RawExpComp_MI_masses.DataSource = bs;
-            dgv_RawExpComp_MI_masses.ReadOnly = true;
-            //dgv_RawExpComp_MI_masses.Columns["Monoisotopic Mass"].DefaultCellStyle.Format = "0.####";
-            //dgv_RawExpComp_MI_masses.Columns["Delta Mass"].DefaultCellStyle.Format = "0.####";
-            //dgv_RawExpComp_MI_masses.Columns["Weighted Monoisotopic Mass"].DefaultCellStyle.Format = "0.####";
-            //dgv_RawExpComp_MI_masses.Columns["Apex RT"].DefaultCellStyle.Format = "0.##";
-            //dgv_RawExpComp_MI_masses.Columns["Relative Abundance"].DefaultCellStyle.Format = "0.####";
-            //dgv_RawExpComp_MI_masses.Columns["Fractional Abundance"].DefaultCellStyle.Format = "0.####";
-            //dgv_RawExpComp_MI_masses.Columns["Sum Intensity"].DefaultCellStyle.Format = "0";
-            dgv_RawExpComp_MI_masses.DefaultCellStyle.BackColor = System.Drawing.Color.LightGray;
-            dgv_RawExpComp_MI_masses.AlternatingRowsDefaultCellStyle.BackColor = System.Drawing.Color.DarkGray;
+            DataGridViewDisplayUtility.FillDataGridView(dgv_RawExpComp_MI_masses, Lollipop.raw_experimental_components);
+        }
+
+        private void dgv_RawExpComp_MI_masses_ColumnHeaderMouseClick(object sender, DataGridViewCellMouseEventArgs e)
+        {
+            //DataGridViewDisplayUtility.sortDataGridViewColumn(dgv_RawExpComp_MI_masses, e.ColumnIndex);           
         }
 
         private void dgv_RawExpComp_MI_masses_CellContentClick(object sender, DataGridViewCellEventArgs e)
@@ -41,17 +34,7 @@ namespace ProteoformSuite
             if (e.RowIndex >= 0)
             {
                 ProteoformSuiteInternal.Component c = (ProteoformSuiteInternal.Component)this.dgv_RawExpComp_MI_masses.Rows[e.RowIndex].DataBoundItem;
-
-                //Round doubles before displaying
-                BindingSource bs = new BindingSource();
-                bs.DataSource = new BindingList<ChargeState>(c.charge_states);
-                dgv_RawExpComp_IndChgSts.DataSource = bs;
-                dgv_RawExpComp_IndChgSts.ReadOnly = true;
-                //dgv_RawExpComp_IndChgSts.Columns["MZ Centroid"].DefaultCellStyle.Format = "0.####";
-                //dgv_RawExpComp_IndChgSts.Columns["Calculated Mass"].DefaultCellStyle.Format = "0.####";
-                //dgv_RawExpComp_IndChgSts.Columns["Intensity"].DefaultCellStyle.Format = "0";
-                dgv_RawExpComp_IndChgSts.DefaultCellStyle.BackColor = System.Drawing.Color.LightGray;
-                dgv_RawExpComp_IndChgSts.AlternatingRowsDefaultCellStyle.BackColor = System.Drawing.Color.DarkGray;
+                DataGridViewDisplayUtility.FillDataGridView(dgv_RawExpComp_IndChgSts, c.charge_states);
             }
         }
     }

--- a/ProteoformSuiteGUI/SortableBindingList.cs
+++ b/ProteoformSuiteGUI/SortableBindingList.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ProteoformSuite
+{
+    public class SortableBindingList<T> : BindingList<T> where T : class
+    {
+        private bool _isSorted;
+        private ListSortDirection _sortDirection = ListSortDirection.Ascending;
+        private PropertyDescriptor _sortProperty;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SortableBindingList{T}"/> class.
+        /// </summary>
+        public SortableBindingList()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SortableBindingList{T}"/> class.
+        /// </summary>
+        /// <param name="list">An <see cref="T:System.Collections.Generic.IList`1" /> of items to be contained in the <see cref="T:System.ComponentModel.BindingList`1" />.</param>
+        public SortableBindingList(IList<T> list)
+            : base(list)
+        {
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of IEnumberable....
+
+        public SortableBindingList(IEnumerable<T> enumerable)
+            : base(enumerable.ToList())
+        {
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the list supports sorting.
+        /// </summary>
+        protected override bool SupportsSortingCore
+        {
+            get { return true; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the list is sorted.
+        /// </summary>
+        protected override bool IsSortedCore
+        {
+            get { return _isSorted; }
+        }
+
+        /// <summary>
+        /// Gets the direction the list is sorted.
+        /// </summary>
+        protected override ListSortDirection SortDirectionCore
+        {
+            get { return _sortDirection; }
+        }
+
+        /// <summary>
+        /// Gets the property descriptor that is used for sorting the list if sorting is implemented in a derived class; otherwise, returns null
+        /// </summary>
+        protected override PropertyDescriptor SortPropertyCore
+        {
+            get { return _sortProperty; }
+        }
+
+        /// <summary>
+        /// Removes any sort applied with ApplySortCore if sorting is implemented
+        /// </summary>
+        protected override void RemoveSortCore()
+        {
+            _sortDirection = ListSortDirection.Ascending;
+            _sortProperty = null;
+            _isSorted = false; //thanks Luca
+        }
+
+        /// <summary>
+        /// Sorts the items if overridden in a derived class
+        /// </summary>
+        /// <param name="prop"></param>
+        /// <param name="direction"></param>
+        protected override void ApplySortCore(PropertyDescriptor prop, ListSortDirection direction)
+        {
+            _sortProperty = prop;
+            _sortDirection = direction;
+
+            List<T> list = Items as List<T>;
+            if (list == null) return;
+
+            list.Sort(Compare);
+
+            _isSorted = true;
+            //fire an event that the list has been changed.
+            OnListChanged(new ListChangedEventArgs(ListChangedType.Reset, -1));
+        }
+
+
+        private int Compare(T lhs, T rhs)
+        {
+            var result = OnComparison(lhs, rhs);
+            //invert if descending
+            if (_sortDirection == ListSortDirection.Descending)
+                result = -result;
+            return result;
+        }
+
+        private int OnComparison(T lhs, T rhs)
+        {
+            object lhsValue = lhs == null ? null : _sortProperty.GetValue(lhs);
+            object rhsValue = rhs == null ? null : _sortProperty.GetValue(rhs);
+            if (lhsValue == null)
+            {
+                return (rhsValue == null) ? 0 : -1; //nulls are equal
+            }
+            if (rhsValue == null)
+            {
+                return 1; //first has value, second doesn't
+            }
+            if (lhsValue is IComparable)
+            {
+                return ((IComparable)lhsValue).CompareTo(rhsValue);
+            }
+            if (lhsValue.Equals(rhsValue))
+            {
+                return 0; //both are the same
+            }
+            //not comparable, compare ToString
+            return lhsValue.ToString().CompareTo(rhsValue.ToString());
+        }
+    }
+}


### PR DESCRIPTION
created sortablebindinglist class which allows collections of objects displayed in datagridview to be sorted on column header mouse click.

created datagridview display utility which converts a collection of objects to sortablebindinglist and fills a datagridview. This can be used from any GUI form that displays object collections