### PR TITLE
multiple mass shifts at once, and click for tool-tip in charts

### DIFF
--- a/ProteoformSuiteGUI/DisplayUtility.cs
+++ b/ProteoformSuiteGUI/DisplayUtility.cs
@@ -244,7 +244,7 @@ namespace ProteoformSuite
         {
             //making all columns invisible first - faster
             foreach (DataGridViewColumn column in dgv.Columns) { column.Visible = false; }
-
+            dgv.Columns["mass_shifter"].Visible = true;
             dgv.Columns["peak_deltaM_average"].DefaultCellStyle.Format = "0.####";
             dgv.Columns["peak_group_fdr"].DefaultCellStyle.Format = "0.##";
 

--- a/ProteoformSuiteGUI/DisplayUtility.cs
+++ b/ProteoformSuiteGUI/DisplayUtility.cs
@@ -240,11 +240,15 @@ namespace ProteoformSuite
             dgv.AllowUserToAddRows = false;
         }
 
-        public static void FormatPeakListGridView(DataGridView dgv)
+        public static void FormatPeakListGridView(DataGridView dgv, bool mask_mass_shifter)
         {
             //making all columns invisible first - faster
             foreach (DataGridViewColumn column in dgv.Columns) { column.Visible = false; }
-            dgv.Columns["mass_shifter"].Visible = true;
+            if (!mask_mass_shifter)
+            {
+                dgv.Columns["mass_shifter"].Visible = true;
+                dgv.Columns["mass_shifter"].ReadOnly = false; //user can say how much they want to change monoisotopic by for each
+            }
             dgv.Columns["peak_deltaM_average"].DefaultCellStyle.Format = "0.####";
             dgv.Columns["peak_group_fdr"].DefaultCellStyle.Format = "0.##";
 

--- a/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
@@ -20,8 +20,8 @@ namespace ProteoformSuite
         {
             InitializeComponent();
             this.dgv_EE_Peaks.MouseClick += new MouseEventHandler(dgv_EE_Peak_List_CellClick);
-            this.ct_EE_Histogram.MouseMove += new MouseEventHandler(ct_EE_Histogram_MouseMove);
-            this.ct_EE_peakList.MouseMove += new MouseEventHandler(ct_EE_peakList_MouseMove);
+            this.ct_EE_Histogram.MouseClick += new MouseEventHandler(ct_EE_Histogram_MouseClick);
+            this.ct_EE_peakList.MouseClick += new MouseEventHandler(ct_EE_peakList_MouseClick);
             dgv_EE_Peaks.CurrentCellDirtyStateChanged += new EventHandler(peakListSpecificPeakAcceptanceChanged); //makes the change immediate and automatic
             dgv_EE_Peaks.CellValueChanged += new DataGridViewCellEventHandler(propagatePeakListAcceptedPeakChangeToPairsTable); //when 'acceptance' of an ET peak gets changed, we change the ET pairs table.
         }
@@ -196,13 +196,15 @@ namespace ProteoformSuite
         Point? ct_EE_peakList_prevPosition = null;
         ToolTip ct_EE_Histogram_tt = new ToolTip();
         ToolTip ct_EE_peakList_tt = new ToolTip();
-        private void ct_EE_Histogram_MouseMove(object sender, MouseEventArgs e)
+        private void ct_EE_Histogram_MouseClick(object sender, MouseEventArgs e)
         {
-            DisplayUtility.tooltip_graph_display(ct_EE_peakList_tt, e, ct_EE_Histogram, ct_EE_Histogram_prevPosition);
+            if (e.Button == MouseButtons.Left)
+               DisplayUtility.tooltip_graph_display(ct_EE_Histogram_tt, e, ct_EE_Histogram, ct_EE_Histogram_prevPosition);
         }
-        private void ct_EE_peakList_MouseMove(object sender, MouseEventArgs e)
+        private void ct_EE_peakList_MouseClick(object sender, MouseEventArgs e)
         {
-            DisplayUtility.tooltip_graph_display(ct_EE_peakList_tt, e, ct_EE_peakList, ct_EE_peakList_prevPosition);
+            if (e.Button == MouseButtons.Left)
+              DisplayUtility.tooltip_graph_display(ct_EE_peakList_tt, e, ct_EE_peakList, ct_EE_peakList_prevPosition);
         }
 
         private void EE_update_Click(object sender, EventArgs e)

--- a/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
@@ -44,7 +44,7 @@ namespace ProteoformSuite
             FillEEPeakListTable();
             FillEEPairsGridView();
             DisplayUtility.FormatRelationsGridView(dgv_EE_Relations, false, true);
-            DisplayUtility.FormatPeakListGridView(dgv_EE_Peaks);
+            DisplayUtility.FormatPeakListGridView(dgv_EE_Peaks, true);
             GraphEERelations();
             GraphEEPeaks();
             updateFiguresOfMerit();

--- a/ProteoformSuiteGUI/ExperimentTheoreticalComparison.Designer.cs
+++ b/ProteoformSuiteGUI/ExperimentTheoreticalComparison.Designer.cs
@@ -47,6 +47,7 @@
             this.ct_ET_peakList = new System.Windows.Forms.DataVisualization.Charting.Chart();
             this.ET_update = new System.Windows.Forms.Button();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.bt_masshifter = new System.Windows.Forms.Button();
             this.label4 = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
             this.nUD_PeakWidthBase = new System.Windows.Forms.NumericUpDown();
@@ -299,24 +300,36 @@
             // groupBox4
             // 
             this.groupBox4.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.groupBox4.Controls.Add(this.bt_masshifter);
             this.groupBox4.Controls.Add(this.label4);
             this.groupBox4.Controls.Add(this.label3);
             this.groupBox4.Controls.Add(this.nUD_PeakWidthBase);
             this.groupBox4.Controls.Add(this.nUD_PeakCountMinThreshold);
-            this.groupBox4.Location = new System.Drawing.Point(31, 37);
+            this.groupBox4.Location = new System.Drawing.Point(31, 22);
             this.groupBox4.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBox4.Size = new System.Drawing.Size(221, 83);
+            this.groupBox4.Size = new System.Drawing.Size(242, 101);
             this.groupBox4.TabIndex = 15;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "ET Peak List Parameters";
+            // 
+            // bt_masshifter
+            // 
+            this.bt_masshifter.Location = new System.Drawing.Point(27, 18);
+            this.bt_masshifter.Name = "bt_masshifter";
+            this.bt_masshifter.Size = new System.Drawing.Size(110, 22);
+            this.bt_masshifter.TabIndex = 33;
+            this.bt_masshifter.Text = "Shift Masses";
+            this.bt_masshifter.UseMnemonic = false;
+            this.bt_masshifter.UseVisualStyleBackColor = true;
+            this.bt_masshifter.Click += new System.EventHandler(this.bt_masshifter_Click);
             // 
             // label4
             // 
             this.label4.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(13, 25);
+            this.label4.Location = new System.Drawing.Point(24, 43);
             this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(113, 13);
@@ -327,7 +340,7 @@
             // 
             this.label3.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(13, 51);
+            this.label3.Location = new System.Drawing.Point(24, 69);
             this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(109, 13);
@@ -343,7 +356,7 @@
             0,
             0,
             196608});
-            this.nUD_PeakWidthBase.Location = new System.Drawing.Point(132, 23);
+            this.nUD_PeakWidthBase.Location = new System.Drawing.Point(143, 41);
             this.nUD_PeakWidthBase.Margin = new System.Windows.Forms.Padding(2);
             this.nUD_PeakWidthBase.Maximum = new decimal(new int[] {
             5,
@@ -358,7 +371,7 @@
             // nUD_PeakCountMinThreshold
             // 
             this.nUD_PeakCountMinThreshold.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.nUD_PeakCountMinThreshold.Location = new System.Drawing.Point(132, 50);
+            this.nUD_PeakCountMinThreshold.Location = new System.Drawing.Point(143, 68);
             this.nUD_PeakCountMinThreshold.Margin = new System.Windows.Forms.Padding(2);
             this.nUD_PeakCountMinThreshold.Name = "nUD_PeakCountMinThreshold";
             this.nUD_PeakCountMinThreshold.Size = new System.Drawing.Size(80, 20);
@@ -372,7 +385,7 @@
             this.groupBox3.Controls.Add(this.label6);
             this.groupBox3.Controls.Add(this.nUD_ET_Lower_Bound);
             this.groupBox3.Controls.Add(this.nUD_ET_Upper_Bound);
-            this.groupBox3.Location = new System.Drawing.Point(263, 37);
+            this.groupBox3.Location = new System.Drawing.Point(263, 40);
             this.groupBox3.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.Padding = new System.Windows.Forms.Padding(2);
@@ -445,7 +458,7 @@
             this.groupBox2.Controls.Add(this.xMinET);
             this.groupBox2.Controls.Add(this.yMinET);
             this.groupBox2.Controls.Add(this.xMaxET);
-            this.groupBox2.Location = new System.Drawing.Point(263, 124);
+            this.groupBox2.Location = new System.Drawing.Point(263, 127);
             this.groupBox2.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Padding = new System.Windows.Forms.Padding(2);
@@ -533,7 +546,7 @@
             this.groupBox1.Controls.Add(this.label2);
             this.groupBox1.Controls.Add(this.nUD_NoManLower);
             this.groupBox1.Controls.Add(this.label1);
-            this.groupBox1.Location = new System.Drawing.Point(31, 124);
+            this.groupBox1.Location = new System.Drawing.Point(31, 127);
             this.groupBox1.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Padding = new System.Windows.Forms.Padding(2);
@@ -801,5 +814,6 @@
         private System.Windows.Forms.Button ET_update;
         private System.Windows.Forms.SplitContainer splitContainer6;
         private System.Windows.Forms.DataGridView dgv_psmList;
+        private System.Windows.Forms.Button bt_masshifter;
     }
 }

--- a/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
@@ -66,7 +66,7 @@ namespace ProteoformSuite
             FillETPeakListTable();
             FillETRelationsGridView();
             DisplayUtility.FormatRelationsGridView(dgv_ET_Pairs, true, false);
-            DisplayUtility.FormatPeakListGridView(dgv_ET_Peak_List);
+            DisplayUtility.FormatPeakListGridView(dgv_ET_Peak_List, false);
             GraphETRelations();
             GraphETPeaks();
             updateFiguresOfMerit();
@@ -101,7 +101,6 @@ namespace ProteoformSuite
         private void FillETPeakListTable()
         {
             DisplayUtility.FillDataGridView(dgv_ET_Peak_List, Lollipop.et_peaks);
-            dgv_ET_Peak_List.Columns["mass_shifter"].ReadOnly = false; //user can say how much they want to change monoisotopic by for each
         }
         private void GraphETRelations()
         {
@@ -176,8 +175,7 @@ namespace ProteoformSuite
                     MessageBox.Show("Could not convert mass shift for peak at delta mass " + peak.delta_mass + ". Please enter an integer.");
                     return;
                 }
-                if (int_mass_shifter > 0) massShifter(peak, int_mass_shifter, false);
-                else if (int_mass_shifter < 0) massShifter(peak,  int_mass_shifter, false);
+                massShifter(peak, int_mass_shifter, false);
             }
                 if (Lollipop.neucode_labeled)
                 {

--- a/ProteoformSuiteGUI/NeuCodePairs.cs
+++ b/ProteoformSuiteGUI/NeuCodePairs.cs
@@ -20,8 +20,8 @@ namespace ProteoformSuite
         public NeuCodePairs()
         {
             InitializeComponent();
-            this.ct_IntensityRatio.MouseMove += new MouseEventHandler(ct_IntensityRatio_MouseMove);
-            this.ct_LysineCount.MouseMove += new MouseEventHandler(ct_LysineCount_MouseMove);
+            this.ct_IntensityRatio.MouseClick += new MouseEventHandler(ct_IntensityRatio_MouseClick);
+            this.ct_LysineCount.MouseClick += new MouseEventHandler(ct_LysineCount_MouseClick);
         }
 
         public void NeuCodePairs_Load(object sender, EventArgs e)
@@ -151,17 +151,19 @@ namespace ProteoformSuite
         Point? ct_intensityRatio_prevPosition = null;
         ToolTip ct_intensityRatio_tt = new ToolTip();
 
-        void ct_IntensityRatio_MouseMove(object sender, MouseEventArgs e)
+        void ct_IntensityRatio_MouseClick(object sender, MouseEventArgs e)
         {
-            DisplayUtility.tooltip_graph_display(ct_intensityRatio_tt, e, ct_IntensityRatio, ct_intensityRatio_prevPosition);
+            if (e.Button == MouseButtons.Left)
+                DisplayUtility.tooltip_graph_display(ct_intensityRatio_tt, e, ct_IntensityRatio, ct_intensityRatio_prevPosition);
         }
 
         Point? ct_LysineCount_prevPosition = null;
         ToolTip ct_LysineCount_tt = new ToolTip();
 
-        void ct_LysineCount_MouseMove(object sender, MouseEventArgs e)
+        void ct_LysineCount_MouseClick(object sender, MouseEventArgs e)
         {
-            DisplayUtility.tooltip_graph_display(ct_LysineCount_tt, e, ct_LysineCount, ct_LysineCount_prevPosition);
+            if (e.Button == MouseButtons.Left)
+                DisplayUtility.tooltip_graph_display(ct_LysineCount_tt, e, ct_LysineCount, ct_LysineCount_prevPosition);
         }
 
         private void yMaxKCt_ValueChanged(object sender, EventArgs e)

--- a/ProteoformSuiteInternal/DeltaMassPeak.cs
+++ b/ProteoformSuiteInternal/DeltaMassPeak.cs
@@ -26,6 +26,7 @@ namespace ProteoformSuiteInternal
         public double decoy_relation_count { get; set; }
         public double peak_group_fdr { get; set; }
         public bool peak_accepted { get; set; }
+        public string mass_shifter { get; set; } = "0";
         public List<Modification> possiblePeakAssignments { get; set; }
         public string possiblePeakAssignments_string
         {

--- a/ProteoformSuiteInternal/Lollipop.cs
+++ b/ProteoformSuiteInternal/Lollipop.cs
@@ -184,6 +184,8 @@ namespace ProteoformSuiteInternal
             //Clear out data from potential previous runs
             Lollipop.proteoform_community.theoretical_proteoforms.Clear();
             Lollipop.proteoform_community.decoy_proteoforms.Clear();
+            Lollipop.psm_list.Clear();
+
             ProteomeDatabaseReader.oldPtmlistFilePath = ptmlist_filepath;
             uniprotModificationTable = proteomeDatabaseReader.ReadUniprotPtmlist();
             aaIsotopeMassList = new AminoAcidMasses(methionine_oxidation, carbamidomethylation).AA_Masses;


### PR DESCRIPTION
The mass shift column isn't read only, so you can enter integers to shift each peak by. Then click Shift Masses and they'll all shift and then rerun Aggregate/ET once.