### PR TITLE
load in TD, mark accession of interest, mark missed monoisotopics

### DIFF
--- a/ProteoformSuiteGUI/AggregatedProteoforms.Designer.cs
+++ b/ProteoformSuiteGUI/AggregatedProteoforms.Designer.cs
@@ -31,6 +31,7 @@
             this.dgv_AggregatedProteoforms = new System.Windows.Forms.DataGridView();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
+            this.button_update = new System.Windows.Forms.Button();
             this.label5 = new System.Windows.Forms.Label();
             this.tb_totalAggregatedProteoforms = new System.Windows.Forms.TextBox();
             this.nUD_Missed_Ks = new System.Windows.Forms.NumericUpDown();
@@ -42,7 +43,7 @@
             this.label2 = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.dgv_AcceptNeuCdLtProteoforms = new System.Windows.Forms.DataGridView();
-            this.button_update = new System.Windows.Forms.Button();
+            this.bt_targed_TD_list = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.dgv_AggregatedProteoforms)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
@@ -68,7 +69,7 @@
             this.dgv_AggregatedProteoforms.Margin = new System.Windows.Forms.Padding(2, 1, 2, 1);
             this.dgv_AggregatedProteoforms.Name = "dgv_AggregatedProteoforms";
             this.dgv_AggregatedProteoforms.RowTemplate.Height = 28;
-            this.dgv_AggregatedProteoforms.Size = new System.Drawing.Size(461, 190);
+            this.dgv_AggregatedProteoforms.Size = new System.Drawing.Size(633, 341);
             this.dgv_AggregatedProteoforms.TabIndex = 0;
             this.dgv_AggregatedProteoforms.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dgv_AggregatedProteoforms_CellContentClick);
             this.dgv_AggregatedProteoforms.CellMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.dgv_AggregatedProteoforms_CellMouseClick);
@@ -89,8 +90,8 @@
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.dgv_AcceptNeuCdLtProteoforms);
-            this.splitContainer1.Size = new System.Drawing.Size(744, 382);
-            this.splitContainer1.SplitterDistance = 194;
+            this.splitContainer1.Size = new System.Drawing.Size(1016, 680);
+            this.splitContainer1.SplitterDistance = 345;
             this.splitContainer1.SplitterWidth = 3;
             this.splitContainer1.TabIndex = 1;
             // 
@@ -104,6 +105,7 @@
             // 
             // splitContainer2.Panel1
             // 
+            this.splitContainer2.Panel1.Controls.Add(this.bt_targed_TD_list);
             this.splitContainer2.Panel1.Controls.Add(this.button_update);
             this.splitContainer2.Panel1.Controls.Add(this.label5);
             this.splitContainer2.Panel1.Controls.Add(this.tb_totalAggregatedProteoforms);
@@ -119,10 +121,21 @@
             // splitContainer2.Panel2
             // 
             this.splitContainer2.Panel2.Controls.Add(this.dgv_AggregatedProteoforms);
-            this.splitContainer2.Size = new System.Drawing.Size(744, 194);
-            this.splitContainer2.SplitterDistance = 276;
+            this.splitContainer2.Size = new System.Drawing.Size(1016, 345);
+            this.splitContainer2.SplitterDistance = 376;
             this.splitContainer2.SplitterWidth = 3;
             this.splitContainer2.TabIndex = 0;
+            // 
+            // button_update
+            // 
+            this.button_update.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.button_update.Location = new System.Drawing.Point(0, 318);
+            this.button_update.Name = "button_update";
+            this.button_update.Size = new System.Drawing.Size(372, 23);
+            this.button_update.TabIndex = 2;
+            this.button_update.Text = "Update";
+            this.button_update.UseVisualStyleBackColor = true;
+            this.button_update.Click += new System.EventHandler(this.button_update_Click);
             // 
             // label5
             // 
@@ -233,26 +246,25 @@
             this.dgv_AcceptNeuCdLtProteoforms.Margin = new System.Windows.Forms.Padding(2, 1, 2, 1);
             this.dgv_AcceptNeuCdLtProteoforms.Name = "dgv_AcceptNeuCdLtProteoforms";
             this.dgv_AcceptNeuCdLtProteoforms.RowTemplate.Height = 28;
-            this.dgv_AcceptNeuCdLtProteoforms.Size = new System.Drawing.Size(740, 181);
+            this.dgv_AcceptNeuCdLtProteoforms.Size = new System.Drawing.Size(1012, 328);
             this.dgv_AcceptNeuCdLtProteoforms.TabIndex = 0;
             this.dgv_AcceptNeuCdLtProteoforms.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dgv_AcceptNeuCdLtProteoforms_CellContentClick);
             // 
-            // button_update
+            // bt_targed_TD_list
             // 
-            this.button_update.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.button_update.Location = new System.Drawing.Point(0, 167);
-            this.button_update.Name = "button_update";
-            this.button_update.Size = new System.Drawing.Size(272, 23);
-            this.button_update.TabIndex = 2;
-            this.button_update.Text = "Update";
-            this.button_update.UseVisualStyleBackColor = true;
-            this.button_update.Click += new System.EventHandler(this.button_update_Click);
+            this.bt_targed_TD_list.Location = new System.Drawing.Point(20, 182);
+            this.bt_targed_TD_list.Name = "bt_targed_TD_list";
+            this.bt_targed_TD_list.Size = new System.Drawing.Size(148, 23);
+            this.bt_targed_TD_list.TabIndex = 10;
+            this.bt_targed_TD_list.Text = "Export Targed TD List";
+            this.bt_targed_TD_list.UseVisualStyleBackColor = true;
+            this.bt_targed_TD_list.Click += new System.EventHandler(this.bt_targed_TD_list_Click);
             // 
             // AggregatedProteoforms
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(744, 382);
+            this.ClientSize = new System.Drawing.Size(1016, 680);
             this.ControlBox = false;
             this.Controls.Add(this.splitContainer1);
             this.Margin = new System.Windows.Forms.Padding(2, 1, 2, 1);
@@ -295,5 +307,6 @@
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.TextBox tb_totalAggregatedProteoforms;
         private System.Windows.Forms.Button button_update;
+        private System.Windows.Forms.Button bt_targed_TD_list;
     }
 }

--- a/ProteoformSuiteGUI/AggregatedProteoforms.cs
+++ b/ProteoformSuiteGUI/AggregatedProteoforms.cs
@@ -114,7 +114,6 @@ namespace ProteoformSuite
 
 
             dgv_AcceptNeuCdLtProteoforms.AllowUserToAddRows = false;
-            dgv_AcceptNeuCdLtProteoforms.Columns["id"].Visible = false;
             dgv_AcceptNeuCdLtProteoforms.Columns["_manual_mass_shift"].Visible = false;
             dgv_AcceptNeuCdLtProteoforms.Columns["intensity_sum"].Visible = false;
             dgv_AcceptNeuCdLtProteoforms.Columns["num_charge_states_fromFile"].Visible = false;

--- a/ProteoformSuiteGUI/AggregatedProteoforms.cs
+++ b/ProteoformSuiteGUI/AggregatedProteoforms.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using System.IO;
 
 namespace ProteoformSuite
 {
@@ -180,6 +181,32 @@ namespace ProteoformSuite
         private void button_update_Click(object sender, EventArgs e)
         {
             RunTheGamut();
+        }
+
+        SaveFileDialog saveFile = new SaveFileDialog();
+        private void bt_targed_TD_list_Click(object sender, EventArgs e)
+        {            
+            //take max 500-intensities items (hard coded in for now, make changeable parameter later if targeted works well?
+            string[] mz_targets = new string[500];
+
+            //sort by intensity, take 500 highest intensity aggs
+            List<ExperimentalProteoform> agg_by_I = Lollipop.proteoform_community.experimental_proteoforms.OrderByDescending(a => a.agg_intensity).ToList();
+            for (int i = 0; i < 500; i++ )
+            {
+                //take highest intensity charge state of highest intensity raw component
+                List<ProteoformSuiteInternal.Component> raw_by_I = agg_by_I[i].aggregated_components.OrderByDescending(c => c.intensity_sum).ToList();
+                List<ChargeState> cs_by_I = raw_by_I[0].charge_states.OrderByDescending(s => s.intensity).ToList();
+                mz_targets[i] = cs_by_I[0].mz_centroid.ToString();
+            }
+
+            MessageBox.Show("Choose a folder for target m/z list.");
+            DialogResult results_folder = this.saveFile.ShowDialog();
+            string working_directory;
+            if (results_folder == DialogResult.OK) working_directory = this.saveFile.FileName;
+            else return;
+            File.WriteAllLines(working_directory, mz_targets);
+            MessageBox.Show("Successfully saved target m/z list.");
+
         }
     }
 }

--- a/ProteoformSuiteGUI/DisplayUtility.cs
+++ b/ProteoformSuiteGUI/DisplayUtility.cs
@@ -261,6 +261,7 @@ namespace ProteoformSuite
             {
                 dgv.Columns["mass_shifter"].Visible = true;
                 dgv.Columns["mass_shifter"].ReadOnly = false; //user can say how much they want to change monoisotopic by for each
+                dgv.Columns["num_missed_monos"].Visible = true;
             }
             dgv.Columns["peak_deltaM_average"].DefaultCellStyle.Format = "0.####";
             dgv.Columns["peak_group_fdr"].DefaultCellStyle.Format = "0.##";
@@ -280,7 +281,11 @@ namespace ProteoformSuite
             dgv.Columns["peak_accepted"].Visible = true;
             dgv.Columns["possiblePeakAssignments_string"].Visible = true;
             dgv.Columns["peak_width"].Visible = false;
-
+            if (mask_mass_shifter)
+            {
+                dgv.Columns["missed_mono"].Visible = true;
+                dgv.Columns["missed_mono"].ReadOnly = false;
+            }
             dgv.AllowUserToAddRows = false;
         }
 

--- a/ProteoformSuiteGUI/DisplayUtility.cs
+++ b/ProteoformSuiteGUI/DisplayUtility.cs
@@ -57,6 +57,19 @@ namespace ProteoformSuite
             { }           
         }
 
+        public static void EditInputFileDGVs(DataGridView dgv, Purpose purpose)
+        {
+            if (purpose == Purpose.TopDown)
+            {
+                DataGridViewComboBoxColumn cmCol = new DataGridViewComboBoxColumn();
+                cmCol.HeaderText = "TD Program";
+                cmCol.DataSource = Enum.GetValues(typeof(TDProgram));
+                cmCol.ValueType = typeof(TDProgram);
+                dgv.Columns.Add(cmCol);
+            }
+        }
+
+
         public static void GraphRelationsChart(Chart ct, List<ProteoformRelation> relations, string series)
         {
             ct.Series[series].Points.Clear();

--- a/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
@@ -28,6 +28,7 @@ namespace ProteoformSuite
         }
 
         bool initial_load = true;
+        bool loading;
         public void ExperimentExperimentComparison_Load(object sender, EventArgs e)
         {
             InitializeParameterSet();
@@ -53,11 +54,13 @@ namespace ProteoformSuite
 
         private void RunTheGamut()
         {
+            loading = true;
             this.Cursor = Cursors.WaitCursor;
             ClearListsAndTables();
             Lollipop.make_ee_relationships();
             this.FillTablesAndCharts();
             this.Cursor = Cursors.Default;
+            loading = false;
         }
 
         private void ClearListsAndTables()
@@ -101,7 +104,9 @@ namespace ProteoformSuite
         private void dgv_EE_Peak_List_CellClick(object sender, MouseEventArgs e)
         {
             int clickedRow = dgv_EE_Peaks.HitTest(e.X, e.Y).RowIndex;
-            if (e.Button == MouseButtons.Left && clickedRow >= 0 && clickedRow < Lollipop.ee_relations.Count)
+            int clickedCol = dgv_EE_Peaks.HitTest(e.X, e.Y).ColumnIndex;
+            if (e.Button == MouseButtons.Left && clickedRow >= 0 && clickedRow < Lollipop.ee_relations.Count 
+                && clickedCol < dgv_EE_Peaks.ColumnCount && clickedCol >= 0)
             {
                 ct_EE_peakList.ChartAreas[0].AxisX.StripLines.Clear();
                 DeltaMassPeak selected_peak = (DeltaMassPeak)this.dgv_EE_Peaks.Rows[clickedRow].DataBoundItem;
@@ -160,7 +165,7 @@ namespace ProteoformSuite
 
         private void peakListMissedMonoChanged(object sender, DataGridViewCellEventArgs e)
         {
-            if (!initial_load)
+            if (!initial_load && !loading)
             { DeltaMassPeak peak = (DeltaMassPeak)this.dgv_EE_Peaks.Rows[e.RowIndex].DataBoundItem;
             Parallel.ForEach<ProteoformRelation>(peak.grouped_relations, ee =>
             {

--- a/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
@@ -24,6 +24,7 @@ namespace ProteoformSuite
             this.ct_EE_peakList.MouseClick += new MouseEventHandler(ct_EE_peakList_MouseClick);
             dgv_EE_Peaks.CurrentCellDirtyStateChanged += new EventHandler(peakListSpecificPeakAcceptanceChanged); //makes the change immediate and automatic
             dgv_EE_Peaks.CellValueChanged += new DataGridViewCellEventHandler(propagatePeakListAcceptedPeakChangeToPairsTable); //when 'acceptance' of an ET peak gets changed, we change the ET pairs table.
+            dgv_EE_Peaks.CellValueChanged += new DataGridViewCellEventHandler(peakListMissedMonoChanged);
         }
 
         bool initial_load = true;
@@ -155,6 +156,18 @@ namespace ProteoformSuite
         private void propagatePeakListAcceptedPeakChangeToPairsTable(object sender, DataGridViewCellEventArgs e)
         {
             updateFiguresOfMerit();
+        }
+
+        private void peakListMissedMonoChanged(object sender, DataGridViewCellEventArgs e)
+        {
+            if (!initial_load)
+            { DeltaMassPeak peak = (DeltaMassPeak)this.dgv_EE_Peaks.Rows[e.RowIndex].DataBoundItem;
+            Parallel.ForEach<ProteoformRelation>(peak.grouped_relations, ee =>
+            {
+                ((ExperimentalProteoform)ee.connected_proteoforms[0]).missed_mono = peak.missed_mono;
+                ((ExperimentalProteoform)ee.connected_proteoforms[1]).missed_mono = peak.missed_mono;
+            });
+            }
         }
 
         private void peakListSpecificPeakAcceptanceChanged(object sender, EventArgs e)

--- a/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
@@ -131,30 +131,32 @@ namespace ProteoformSuite
         private void dgv_ET_Peak_List_CellClick(object sender, MouseEventArgs e)
         {
             int clickedRow = dgv_ET_Peak_List.HitTest(e.X, e.Y).RowIndex;
-            if (e.Button == MouseButtons.Left && clickedRow >= 0 && clickedRow < Lollipop.et_relations.Count)
+            int clickedCol = dgv_ET_Peak_List.HitTest(e.X, e.Y).ColumnIndex;
+            if (clickedRow < Lollipop.et_relations.Count && clickedRow >= 0 && clickedCol >=0 && clickedCol < dgv_ET_Peak_List.ColumnCount)
             {
-                ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Clear();
-                DeltaMassPeak selected_peak = (DeltaMassPeak)this.dgv_ET_Peak_List.Rows[clickedRow].DataBoundItem;
-                DisplayUtility.GraphSelectedDeltaMassPeak(ct_ET_peakList, selected_peak, Lollipop.et_relations);
-            }
-            else
-            {
-                if (e.Button == MouseButtons.Right && clickedRow >= 0 && clickedRow < Lollipop.et_relations.Count)
+                if (e.Button == MouseButtons.Left)
                 {
-                    ContextMenuStrip ET_peak_List_Menu = new ContextMenuStrip();
-                    int position_xy_mouse_row = dgv_ET_Peak_List.HitTest(e.X, e.Y).RowIndex;
-
+                    ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Clear();
                     DeltaMassPeak selected_peak = (DeltaMassPeak)this.dgv_ET_Peak_List.Rows[clickedRow].DataBoundItem;
-
-                    if (position_xy_mouse_row > 0)
+                    DisplayUtility.GraphSelectedDeltaMassPeak(ct_ET_peakList, selected_peak, Lollipop.et_relations);
+                }
+                else if (e.Button == MouseButtons.Right)
                     {
-                        ET_peak_List_Menu.Items.Add("Increase Experimenal Mass 1.0015 Da").Name = "IncreaseMass";
-                        ET_peak_List_Menu.Items.Add("Decrease Experimenal Mass 1.0015 Da").Name = "DecreaseMass";
-                    }
-                    ET_peak_List_Menu.Show(dgv_ET_Peak_List, new Point(e.X, e.Y));
+                        ContextMenuStrip ET_peak_List_Menu = new ContextMenuStrip();
+                        int position_xy_mouse_row = dgv_ET_Peak_List.HitTest(e.X, e.Y).RowIndex;
 
-                    //event menu click
-                    ET_peak_List_Menu.ItemClicked += new ToolStripItemClickedEventHandler((s, ev) => ET_peak_List_Menu_ItemClicked(s, ev, selected_peak));
+                        DeltaMassPeak selected_peak = (DeltaMassPeak)this.dgv_ET_Peak_List.Rows[clickedRow].DataBoundItem;
+
+                        if (position_xy_mouse_row > 0)
+                        {
+                            ET_peak_List_Menu.Items.Add("Increase Experimenal Mass 1.0015 Da").Name = "IncreaseMass";
+                            ET_peak_List_Menu.Items.Add("Decrease Experimenal Mass 1.0015 Da").Name = "DecreaseMass";
+                        }
+                        ET_peak_List_Menu.Show(dgv_ET_Peak_List, new Point(e.X, e.Y));
+
+                        //event menu click
+                        ET_peak_List_Menu.ItemClicked += new ToolStripItemClickedEventHandler((s, ev) => ET_peak_List_Menu_ItemClicked(s, ev, selected_peak));
+                    
                 }
             }
         }

--- a/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
@@ -133,31 +133,33 @@ namespace ProteoformSuite
             int clickedRow = dgv_ET_Peak_List.HitTest(e.X, e.Y).RowIndex;
             int clickedCol = dgv_ET_Peak_List.HitTest(e.X, e.Y).ColumnIndex;
             if (clickedRow < Lollipop.et_relations.Count && clickedRow >= 0 && clickedCol >=0 && clickedCol < dgv_ET_Peak_List.ColumnCount)
+            { 
+            if (e.Button == MouseButtons.Left)
             {
-                if (e.Button == MouseButtons.Left)
+                ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Clear();
+                DeltaMassPeak selected_peak = (DeltaMassPeak)this.dgv_ET_Peak_List.Rows[clickedRow].DataBoundItem;
+                DisplayUtility.GraphSelectedDeltaMassPeak(ct_ET_peakList, selected_peak, Lollipop.et_relations);
+            }
+            else
+            {
+                if (e.Button == MouseButtons.Right && clickedRow >= 0 && clickedRow < Lollipop.et_relations.Count)
                 {
-                    ct_ET_peakList.ChartAreas[0].AxisX.StripLines.Clear();
+                    ContextMenuStrip ET_peak_List_Menu = new ContextMenuStrip();
+                    int position_xy_mouse_row = dgv_ET_Peak_List.HitTest(e.X, e.Y).RowIndex;
+
                     DeltaMassPeak selected_peak = (DeltaMassPeak)this.dgv_ET_Peak_List.Rows[clickedRow].DataBoundItem;
-                    DisplayUtility.GraphSelectedDeltaMassPeak(ct_ET_peakList, selected_peak, Lollipop.et_relations);
-                }
-                else if (e.Button == MouseButtons.Right)
+
+                    if (position_xy_mouse_row > 0)
                     {
-                        ContextMenuStrip ET_peak_List_Menu = new ContextMenuStrip();
-                        int position_xy_mouse_row = dgv_ET_Peak_List.HitTest(e.X, e.Y).RowIndex;
+                        ET_peak_List_Menu.Items.Add("Increase Experimenal Mass 1.0015 Da").Name = "IncreaseMass";
+                        ET_peak_List_Menu.Items.Add("Decrease Experimenal Mass 1.0015 Da").Name = "DecreaseMass";
+                    }
+                    ET_peak_List_Menu.Show(dgv_ET_Peak_List, new Point(e.X, e.Y));
 
-                        DeltaMassPeak selected_peak = (DeltaMassPeak)this.dgv_ET_Peak_List.Rows[clickedRow].DataBoundItem;
-
-                        if (position_xy_mouse_row > 0)
-                        {
-                            ET_peak_List_Menu.Items.Add("Increase Experimenal Mass 1.0015 Da").Name = "IncreaseMass";
-                            ET_peak_List_Menu.Items.Add("Decrease Experimenal Mass 1.0015 Da").Name = "DecreaseMass";
-                        }
-                        ET_peak_List_Menu.Show(dgv_ET_Peak_List, new Point(e.X, e.Y));
-
-                        //event menu click
-                        ET_peak_List_Menu.ItemClicked += new ToolStripItemClickedEventHandler((s, ev) => ET_peak_List_Menu_ItemClicked(s, ev, selected_peak));
-                    
+                    //event menu click
+                    ET_peak_List_Menu.ItemClicked += new ToolStripItemClickedEventHandler((s, ev) => ET_peak_List_Menu_ItemClicked(s, ev, selected_peak));
                 }
+                } 
             }
         }
 
@@ -209,8 +211,10 @@ namespace ProteoformSuite
             List<ExperimentalProteoform> expProtList = new List<ExperimentalProteoform>();
             foreach (ProteoformRelation relation in Lollipop.et_relations.Where(p => p.peak == peak).ToList())
             {
-                if (relation.connected_proteoforms[0] is ExperimentalProteoform)
+                if (relation.connected_proteoforms[0] is ExperimentalProteoform 
+                    && ((ExperimentalProteoform)relation.connected_proteoforms[0]).mass_shifted == false)
                 {
+                    ((ExperimentalProteoform)relation.connected_proteoforms[0]).mass_shifted = true; //if shifting multiple peaks @ once, won't shift same E more than once if it's in multiple peaks.
                     expProtList.Add(relation.connected_proteoforms[0] as ExperimentalProteoform);
                 }
             }

--- a/ProteoformSuiteGUI/LoadDeconvolutionResults.Designer.cs
+++ b/ProteoformSuiteGUI/LoadDeconvolutionResults.Designer.cs
@@ -293,17 +293,17 @@
             // 
             this.label4.AutoSize = true;
             this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label4.Location = new System.Drawing.Point(1205, 13);
+            this.label4.Location = new System.Drawing.Point(1246, 13);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(248, 20);
+            this.label4.Size = new System.Drawing.Size(183, 20);
             this.label4.TabIndex = 20;
-            this.label4.Text = "ProSight Top-Down Results (.xlsx)";
+            this.label4.Text = "Top-Down Results (.xlsx)";
             // 
             // label5
             // 
             this.label5.AutoSize = true;
             this.label5.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label5.Location = new System.Drawing.Point(909, 13);
+            this.label5.Location = new System.Drawing.Point(923, 13);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(258, 20);
             this.label5.TabIndex = 21;

--- a/ProteoformSuiteGUI/LoadDeconvolutionResults.Designer.cs
+++ b/ProteoformSuiteGUI/LoadDeconvolutionResults.Designer.cs
@@ -55,6 +55,7 @@
             this.bt_morpheusBUResultsClear = new System.Windows.Forms.Button();
             this.bt_tdResultsAdd = new System.Windows.Forms.Button();
             this.bt_tdResultsClear = new System.Windows.Forms.Button();
+            this.cb_td_file = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dgv_identificationFiles)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgv_quantitationFiles)).BeginInit();
@@ -66,6 +67,7 @@
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.cb_td_file);
             this.groupBox1.Controls.Add(this.btn_unlabeled);
             this.groupBox1.Controls.Add(this.btn_neucode);
             this.groupBox1.Location = new System.Drawing.Point(13, 610);
@@ -349,6 +351,17 @@
             this.bt_tdResultsClear.UseVisualStyleBackColor = true;
             this.bt_tdResultsClear.Click += new System.EventHandler(this.bt_tdResultsClear_Click);
             // 
+            // cb_td_file
+            // 
+            this.cb_td_file.AutoSize = true;
+            this.cb_td_file.Location = new System.Drawing.Point(23, 91);
+            this.cb_td_file.Name = "cb_td_file";
+            this.cb_td_file.Size = new System.Drawing.Size(165, 17);
+            this.cb_td_file.TabIndex = 2;
+            this.cb_td_file.Text = "Top-down Deconvolution File";
+            this.cb_td_file.UseVisualStyleBackColor = true;
+            this.cb_td_file.CheckedChanged += new System.EventHandler(this.cb_td_file_CheckedChanged);
+            // 
             // LoadDeconvolutionResults
             // 
             this.ClientSize = new System.Drawing.Size(1471, 736);
@@ -418,5 +431,6 @@
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.DataGridView dgv_tdFiles;
         private System.Windows.Forms.DataGridView dgv_buFiles;
+        private System.Windows.Forms.CheckBox cb_td_file;
     }
 }

--- a/ProteoformSuiteGUI/LoadDeconvolutionResults.cs
+++ b/ProteoformSuiteGUI/LoadDeconvolutionResults.cs
@@ -124,9 +124,9 @@ namespace ProteoformSuite
             // Look for results files with the same filename as a calibration file, and show that they're matched
             foreach (InputFile file in Lollipop.calibration_files())
             {
-                if (Lollipop.input_files.Where(f => f.purpose != Purpose.Calibration).Select(f => f.filename).Contains(file.filename))
+                if (Lollipop.input_files.Where(f => f.purpose != Purpose.Calibration && f.purpose != Purpose.TopDownIDResults).Select(f => f.filename).Contains(file.filename))
                 {
-                    IEnumerable<InputFile> matching_files = Lollipop.input_files.Where(f => f.purpose != Purpose.Calibration && f.filename == file.filename);
+                    IEnumerable<InputFile> matching_files = Lollipop.input_files.Where(f => f.purpose != Purpose.Calibration && f.purpose != Purpose.TopDownIDResults && f.filename == file.filename);
                     InputFile matching_file = matching_files.First();
                     if (matching_files.Count() != 1) MessageBox.Show("Warning: There is more than one results file named " + file.filename + ". Will only match calibration to the first one from " + matching_file.purpose.ToString() + ".");
                     file.matchingCalibrationFile = true;
@@ -345,6 +345,43 @@ namespace ProteoformSuite
                 "Above is another info-button on how to process results without using presets.\n\n"+
                 "We hope you enjoy trying Proteoform Suite! Please contact us if you have any questions. The public repository for this program is hosted on GitHub at https://github.com/smith-chem-wisc/proteoform-suite.", "How To Use Presets.", MessageBoxButtons.OK);
             ((ProteoformSweet)MdiParent).display_methodMenu();
+        }
+
+        private void cb_td_file_CheckedChanged(object sender, EventArgs e)
+        {
+            Lollipop.td_results = cb_td_file.Checked;
+            if (Lollipop.td_results)
+            {
+                MessageBox.Show("Please select the a list of scan #'s corresponding to MS1 scans.");
+                OpenFileDialog openFileDialog1 = new OpenFileDialog();
+                openFileDialog1.Title = "MS1 Scans";
+                openFileDialog1.Filter = "MS1 Scans (.txt) | *.txt";
+                openFileDialog1.Multiselect = true; //TODO: ADD THERMO RAW FILE READER OPTION TO FIND MS-1 SCAN #'S IN SUITE?
+                DialogResult dr = openFileDialog1.ShowDialog();
+                if (dr == DialogResult.OK)
+                    enter_input_files(openFileDialog1.FileNames, new List<string> { ".txt" }, Purpose.TopDownIDResults);
+                else { cb_td_file.Checked = false; Lollipop.td_results = false; return; }
+                //Make sure those files matched. 
+                foreach (InputFile file in Lollipop.topdownID_files())
+                {
+                    int matching_files = Lollipop.identification_files().Where(f => f.filename == file.filename).ToList().Count;
+                    if (matching_files > 1)
+                    {
+                        MessageBox.Show("There is more than one results file named " + file.filename + ". Please try again and choose one file per one identification result file.");
+                        Lollipop.input_files.RemoveAll(p => p.purpose == Purpose.TopDownIDResults); //start over....
+                        cb_td_file.Checked = false; Lollipop.td_results = false;
+                        return;
+                    }
+                    else if (matching_files < 1)
+                    {
+                        MessageBox.Show("There is no matching deconvolution result for the file " + file.filename + ". Please try again and select a file with the same name as the identification result file.");
+                        Lollipop.input_files.RemoveAll(p => p.purpose == Purpose.TopDownIDResults); //start over....
+                        cb_td_file.Checked = false; Lollipop.td_results = false;
+                        return;
+                    }
+                    else continue;
+                }
+            }
         }
     }
 }

--- a/ProteoformSuiteGUI/LoadDeconvolutionResults.cs
+++ b/ProteoformSuiteGUI/LoadDeconvolutionResults.cs
@@ -12,6 +12,7 @@ using System.Security;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+//using 
 using Excel = Microsoft.Office.Interop.Excel; //Right click Solution/Explorer/References. Then Add  "Reference". Assemblies/Extension/Microsoft.Office.Interop.Excel
 
 
@@ -19,10 +20,12 @@ namespace ProteoformSuite
 {
     public partial class LoadDeconvolutionResults : Form
     {
-
+        
         public LoadDeconvolutionResults()
         {
             InitializeComponent();
+            this.dgv_tdFiles.CurrentCellDirtyStateChanged += new EventHandler(this.dgv_tdFiles_CurrentCellDirtyStateChanged); //makes the change immediate and automatic
+            this.dgv_tdFiles.CellValueChanged += new DataGridViewCellEventHandler(this.dgv_tdFiles_ComboBoxChanged);
         }
 
         public void LoadDeconvolutionResults_Load(object sender, EventArgs e)
@@ -112,8 +115,8 @@ namespace ProteoformSuite
 
                     InputFile file = new InputFile(path, filename, extension, label, purpose);
                     Lollipop.input_files.Add(file);
-                }
-            }
+                    }
+              }
         }
 
         private void match_files() //for dgv
@@ -150,6 +153,8 @@ namespace ProteoformSuite
             DisplayUtility.FillDataGridView(dgv_identificationFiles, Lollipop.identification_files());
             DisplayUtility.FillDataGridView(dgv_quantitationFiles, Lollipop.quantification_files());
             DisplayUtility.FillDataGridView(dgv_calibrationFiles, Lollipop.calibration_files());
+            DisplayUtility.FillDataGridView(dgv_buFiles, Lollipop.bottomup_files());
+            DisplayUtility.FillDataGridView(dgv_tdFiles, Lollipop.topdown_files());
         }
 
 
@@ -188,6 +193,21 @@ namespace ProteoformSuite
                 PropertyInfo propertyInfo = propertyType.GetProperty(propertyName);
                 return propertyInfo.GetValue(property, null).ToString();
             }
+        }
+
+        private void dgv_tdFiles_ComboBoxChanged(object sender, DataGridViewCellEventArgs e)
+        {
+            if (e.ColumnIndex == 0 && e.RowIndex >= 0) //make sure it's combobox
+            {
+                TDProgram selectedValue = (TDProgram)dgv_tdFiles.Rows[e.RowIndex].Cells[e.ColumnIndex].Value;
+                InputFile selectedFile = (InputFile)this.dgv_tdFiles.Rows[e.RowIndex].DataBoundItem;
+                selectedFile.td_program = selectedValue;
+            }
+        }
+
+        private void dgv_tdFiles_CurrentCellDirtyStateChanged(object sender, EventArgs e)
+        {
+            if (dgv_tdFiles.IsCurrentCellDirty) dgv_tdFiles.CommitEdit(DataGridViewDataErrorContexts.Commit);
         }
 
 
@@ -257,8 +277,10 @@ namespace ProteoformSuite
             DialogResult dr = openFileDialog1.ShowDialog();
             if (dr == DialogResult.OK)
                 enter_input_files(openFileDialog1.FileNames, new List<string> { ".xlsx" }, Purpose.TopDown);
-
+            int i = Lollipop.input_files.Where(f => f.purpose == Purpose.TopDown).ToList().Count;
+            if (i == 1) DisplayUtility.EditInputFileDGVs(dgv_tdFiles, Purpose.TopDown);  //adds drop-down column for dataresults first time td file added
             DisplayUtility.FillDataGridView(dgv_tdFiles, Lollipop.topdown_files());
+            for (int j = 0; j < i; j++ ) {InputFile input = (InputFile)dgv_tdFiles.Rows[j].DataBoundItem; dgv_tdFiles.Rows[j].Cells[0].Value = input.td_program; }
         }
 
         // CLEAR BUTTONS

--- a/ProteoformSuiteGUI/ProteoformSweet.Designer.cs
+++ b/ProteoformSuiteGUI/ProteoformSweet.Designer.cs
@@ -97,7 +97,7 @@
             this.saveAllToolStripMenuItem.Name = "saveAllToolStripMenuItem";
             this.saveAllToolStripMenuItem.Size = new System.Drawing.Size(159, 30);
             this.saveAllToolStripMenuItem.Text = "Save All";
-            this.saveAllToolStripMenuItem.Click += new System.EventHandler(this.saveMethodToolStripMenuItem1_Click);
+            this.saveAllToolStripMenuItem.Click += new System.EventHandler(this.saveAllToolStripMenuItem_Click);
             // 
             // printToolStripMenuItem
             // 

--- a/ProteoformSuiteGUI/ProteoformSweet.cs
+++ b/ProteoformSuiteGUI/ProteoformSweet.cs
@@ -275,7 +275,7 @@ namespace ProteoformSuite
             theoreticalDatabase.make_databases();
             Lollipop.make_et_relationships();
             Lollipop.make_ee_relationships();
-           //proteoformFamilies.construct_families();
+           //proteoformFamilies.construct_families();  I have commented this out for now  bc it is slower than the others -LVS
             prepare_figures_and_tables();
             this.enable_neuCodeProteoformPairsToolStripMenuItem(Lollipop.neucode_labeled);
         }

--- a/ProteoformSuiteGUI/ProteoformSweet.cs
+++ b/ProteoformSuiteGUI/ProteoformSweet.cs
@@ -109,6 +109,24 @@ namespace ProteoformSuite
             Results.read_raw_components(File.ReadAllLines(working_directory + "\\raw_experimental_components.tsv"));
             if (Lollipop.neucode_labeled) Results.read_raw_neucode_pairs(File.ReadAllLines(working_directory + "\\raw_neucode_pairs.tsv"));
             Results.read_aggregated_proteoforms(File.ReadAllLines(working_directory + "\\aggregated_experimental_proteoforms.tsv"));
+            //need to read in ptm list
+            try
+            {
+                ProteomeDatabaseReader.oldPtmlistFilePath = working_directory + "\\ptmlist.txt";
+                Lollipop.uniprotModificationTable = Lollipop.proteomeDatabaseReader.ReadUniprotPtmlist();
+            }
+            catch
+            {
+                MessageBox.Show("Please select a Uniprot ptm list.");
+                DialogResult dr = this.methodFileOpen.ShowDialog();
+                if (dr == System.Windows.Forms.DialogResult.OK)
+                {
+                    string ptm_list = methodFileOpen.FileName;
+                    ProteomeDatabaseReader.oldPtmlistFilePath = ptm_list;
+                    Lollipop.uniprotModificationTable = Lollipop.proteomeDatabaseReader.ReadUniprotPtmlist();
+                }
+                else { return; }
+            }   
             Results.read_theoretical_proteoforms(File.ReadAllLines(working_directory + "\\theoretical_proteoforms.tsv"));
             Results.read_theoretical_proteoforms(File.ReadAllLines(working_directory + "\\decoy_proteoforms.tsv"));
             Results.read_relationships(File.ReadAllLines(working_directory + "\\experimental_theoretical_relationships.tsv"), ProteoformComparison.et);
@@ -257,7 +275,7 @@ namespace ProteoformSuite
             theoreticalDatabase.make_databases();
             Lollipop.make_et_relationships();
             Lollipop.make_ee_relationships();
-            proteoformFamilies.construct_families();
+           //proteoformFamilies.construct_families();
             prepare_figures_and_tables();
             this.enable_neuCodeProteoformPairsToolStripMenuItem(Lollipop.neucode_labeled);
         }
@@ -269,10 +287,13 @@ namespace ProteoformSuite
                 () => aggregatedProteoforms.FillAggregatesTable(),
                 () => theoreticalDatabase.FillDataBaseTable("Target"),
                 () => experimentalTheoreticalComparison.FillTablesAndCharts(),
-                () => experimentExperimentComparison.FillTablesAndCharts(),
-                () => proteoformFamilies.fill_proteoform_families()
+                () => experimentExperimentComparison.FillTablesAndCharts()
             );
-            if (Lollipop.neucode_labeled) neuCodePairs.GraphNeuCodePairs();
+            if (Lollipop.neucode_labeled)
+            {
+                neuCodePairs.GraphNeuCodePairs();
+             //   proteoformFamilies.fill_proteoform_families();
+            }
         }
     
 

--- a/ProteoformSuiteGUI/RawExperimentalComponents.cs
+++ b/ProteoformSuiteGUI/RawExperimentalComponents.cs
@@ -46,8 +46,8 @@ namespace ProteoformSuite
                     MessageBox.Show(ex.Message);
                 }
             }
-
-            this.FillRawQuantificationComponentsTable();
+            if (Lollipop.raw_quantification_components. Count > 0)
+             this.FillRawQuantificationComponentsTable();
 
         }
 

--- a/ProteoformSuiteGUI/RawExperimentalComponents.cs
+++ b/ProteoformSuiteGUI/RawExperimentalComponents.cs
@@ -22,16 +22,19 @@ namespace ProteoformSuite
         {
             if (Lollipop.raw_experimental_components.Count == 0)
             {
-                try
-                {
+                //try
+                //{
+                //    Lollipop.process_raw_components(); //Includes reading correction factors if present
+                //}
+                //catch (Exception ex)
+                //{
+                //    MessageBox.Show(ex.Message);
+                //}
+
                     Lollipop.process_raw_components(); //Includes reading correction factors if present
-                }
-                catch (Exception ex)
-                {
-                    MessageBox.Show(ex.Message);
-                }
+
             }
-                
+
             this.FillRawExpComponentsTable();
 
 

--- a/ProteoformSuiteGUI/TheoreticalDatabase.Designer.cs
+++ b/ProteoformSuiteGUI/TheoreticalDatabase.Designer.cs
@@ -29,6 +29,10 @@
         private void InitializeComponent()
         {
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.tb_interest_label = new System.Windows.Forms.TextBox();
+            this.label5 = new System.Windows.Forms.Label();
+            this.tb_proteins_of_interest_path = new System.Windows.Forms.TextBox();
+            this.bt_proteins_of_interest = new System.Windows.Forms.Button();
             this.ckbx_aggregateProteoforms = new System.Windows.Forms.CheckBox();
             this.label4 = new System.Windows.Forms.Label();
             this.nUD_MinPeptideLength = new System.Windows.Forms.NumericUpDown();
@@ -72,6 +76,10 @@
             // 
             // splitContainer1.Panel1
             // 
+            this.splitContainer1.Panel1.Controls.Add(this.tb_interest_label);
+            this.splitContainer1.Panel1.Controls.Add(this.label5);
+            this.splitContainer1.Panel1.Controls.Add(this.tb_proteins_of_interest_path);
+            this.splitContainer1.Panel1.Controls.Add(this.bt_proteins_of_interest);
             this.splitContainer1.Panel1.Controls.Add(this.ckbx_aggregateProteoforms);
             this.splitContainer1.Panel1.Controls.Add(this.label4);
             this.splitContainer1.Panel1.Controls.Add(this.nUD_MinPeptideLength);
@@ -94,15 +102,54 @@
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.dgv_Database);
-            this.splitContainer1.Size = new System.Drawing.Size(788, 478);
-            this.splitContainer1.SplitterDistance = 262;
+            this.splitContainer1.Size = new System.Drawing.Size(1370, 753);
+            this.splitContainer1.SplitterDistance = 455;
             this.splitContainer1.SplitterWidth = 3;
             this.splitContainer1.TabIndex = 0;
+            // 
+            // tb_interest_label
+            // 
+            this.tb_interest_label.Location = new System.Drawing.Point(239, 124);
+            this.tb_interest_label.Margin = new System.Windows.Forms.Padding(2);
+            this.tb_interest_label.Name = "tb_interest_label";
+            this.tb_interest_label.Size = new System.Drawing.Size(215, 20);
+            this.tb_interest_label.TabIndex = 21;
+            this.tb_interest_label.Visible = false;
+            this.tb_interest_label.TextChanged += new System.EventHandler(this.tb_interest_label_TextChanged);
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(155, 104);
+            this.label5.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(50, 13);
+            this.label5.TabIndex = 20;
+            this.label5.Text = "(optional)";
+            // 
+            // tb_proteins_of_interest_path
+            // 
+            this.tb_proteins_of_interest_path.Location = new System.Drawing.Point(7, 124);
+            this.tb_proteins_of_interest_path.Margin = new System.Windows.Forms.Padding(2);
+            this.tb_proteins_of_interest_path.Name = "tb_proteins_of_interest_path";
+            this.tb_proteins_of_interest_path.Size = new System.Drawing.Size(228, 20);
+            this.tb_proteins_of_interest_path.TabIndex = 19;
+            // 
+            // bt_proteins_of_interest
+            // 
+            this.bt_proteins_of_interest.Location = new System.Drawing.Point(7, 100);
+            this.bt_proteins_of_interest.Margin = new System.Windows.Forms.Padding(2);
+            this.bt_proteins_of_interest.Name = "bt_proteins_of_interest";
+            this.bt_proteins_of_interest.Size = new System.Drawing.Size(144, 20);
+            this.bt_proteins_of_interest.TabIndex = 18;
+            this.bt_proteins_of_interest.Text = "Get Proteins of Interest List";
+            this.bt_proteins_of_interest.UseVisualStyleBackColor = true;
+            this.bt_proteins_of_interest.Click += new System.EventHandler(this.bt_genes_of_interest_Click);
             // 
             // ckbx_aggregateProteoforms
             // 
             this.ckbx_aggregateProteoforms.AutoSize = true;
-            this.ckbx_aggregateProteoforms.Location = new System.Drawing.Point(15, 419);
+            this.ckbx_aggregateProteoforms.Location = new System.Drawing.Point(7, 470);
             this.ckbx_aggregateProteoforms.Margin = new System.Windows.Forms.Padding(2);
             this.ckbx_aggregateProteoforms.Name = "ckbx_aggregateProteoforms";
             this.ckbx_aggregateProteoforms.Size = new System.Drawing.Size(203, 17);
@@ -114,7 +161,7 @@
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(70, 337);
+            this.label4.Location = new System.Drawing.Point(62, 388);
             this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(123, 13);
@@ -123,7 +170,7 @@
             // 
             // nUD_MinPeptideLength
             // 
-            this.nUD_MinPeptideLength.Location = new System.Drawing.Point(17, 334);
+            this.nUD_MinPeptideLength.Location = new System.Drawing.Point(9, 385);
             this.nUD_MinPeptideLength.Margin = new System.Windows.Forms.Padding(2);
             this.nUD_MinPeptideLength.Name = "nUD_MinPeptideLength";
             this.nUD_MinPeptideLength.Size = new System.Drawing.Size(48, 20);
@@ -132,7 +179,7 @@
             // 
             // btn_Make_Databases
             // 
-            this.btn_Make_Databases.Location = new System.Drawing.Point(15, 444);
+            this.btn_Make_Databases.Location = new System.Drawing.Point(7, 495);
             this.btn_Make_Databases.Margin = new System.Windows.Forms.Padding(2);
             this.btn_Make_Databases.Name = "btn_Make_Databases";
             this.btn_Make_Databases.Size = new System.Drawing.Size(207, 22);
@@ -163,7 +210,7 @@
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(15, 373);
+            this.label3.Location = new System.Drawing.Point(7, 424);
             this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(102, 13);
@@ -173,7 +220,7 @@
             // cmbx_DisplayWhichDB
             // 
             this.cmbx_DisplayWhichDB.FormattingEnabled = true;
-            this.cmbx_DisplayWhichDB.Location = new System.Drawing.Point(17, 388);
+            this.cmbx_DisplayWhichDB.Location = new System.Drawing.Point(9, 439);
             this.cmbx_DisplayWhichDB.Margin = new System.Windows.Forms.Padding(2);
             this.cmbx_DisplayWhichDB.Name = "cmbx_DisplayWhichDB";
             this.cmbx_DisplayWhichDB.Size = new System.Drawing.Size(205, 21);
@@ -183,7 +230,7 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(70, 311);
+            this.label2.Location = new System.Drawing.Point(62, 362);
             this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(144, 13);
@@ -192,7 +239,7 @@
             // 
             // nUD_NumDecoyDBs
             // 
-            this.nUD_NumDecoyDBs.Location = new System.Drawing.Point(17, 308);
+            this.nUD_NumDecoyDBs.Location = new System.Drawing.Point(9, 359);
             this.nUD_NumDecoyDBs.Margin = new System.Windows.Forms.Padding(2);
             this.nUD_NumDecoyDBs.Name = "nUD_NumDecoyDBs";
             this.nUD_NumDecoyDBs.Size = new System.Drawing.Size(48, 20);
@@ -202,7 +249,7 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(70, 287);
+            this.label1.Location = new System.Drawing.Point(62, 338);
             this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(130, 13);
@@ -211,7 +258,7 @@
             // 
             // nUD_MaxPTMs
             // 
-            this.nUD_MaxPTMs.Location = new System.Drawing.Point(17, 283);
+            this.nUD_MaxPTMs.Location = new System.Drawing.Point(9, 334);
             this.nUD_MaxPTMs.Margin = new System.Windows.Forms.Padding(2);
             this.nUD_MaxPTMs.Name = "nUD_MaxPTMs";
             this.nUD_MaxPTMs.Size = new System.Drawing.Size(48, 20);
@@ -223,7 +270,7 @@
             this.groupBox1.Controls.Add(this.btn_NeuCode_Hv);
             this.groupBox1.Controls.Add(this.btn_NeuCode_Lt);
             this.groupBox1.Controls.Add(this.btn_NaturalIsotopes);
-            this.groupBox1.Location = new System.Drawing.Point(7, 168);
+            this.groupBox1.Location = new System.Drawing.Point(-1, 219);
             this.groupBox1.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Padding = new System.Windows.Forms.Padding(2);
@@ -274,7 +321,7 @@
             // ckbx_Meth_Cleaved
             // 
             this.ckbx_Meth_Cleaved.AutoSize = true;
-            this.ckbx_Meth_Cleaved.Location = new System.Drawing.Point(17, 148);
+            this.ckbx_Meth_Cleaved.Location = new System.Drawing.Point(9, 199);
             this.ckbx_Meth_Cleaved.Margin = new System.Windows.Forms.Padding(2);
             this.ckbx_Meth_Cleaved.Name = "ckbx_Meth_Cleaved";
             this.ckbx_Meth_Cleaved.Size = new System.Drawing.Size(131, 17);
@@ -286,7 +333,7 @@
             // ckbx_Carbam
             // 
             this.ckbx_Carbam.AutoSize = true;
-            this.ckbx_Carbam.Location = new System.Drawing.Point(17, 122);
+            this.ckbx_Carbam.Location = new System.Drawing.Point(9, 173);
             this.ckbx_Carbam.Margin = new System.Windows.Forms.Padding(2);
             this.ckbx_Carbam.Name = "ckbx_Carbam";
             this.ckbx_Carbam.Size = new System.Drawing.Size(129, 17);
@@ -298,7 +345,7 @@
             // ckbx_OxidMeth
             // 
             this.ckbx_OxidMeth.AutoSize = true;
-            this.ckbx_OxidMeth.Location = new System.Drawing.Point(17, 97);
+            this.ckbx_OxidMeth.Location = new System.Drawing.Point(9, 148);
             this.ckbx_OxidMeth.Margin = new System.Windows.Forms.Padding(2);
             this.ckbx_OxidMeth.Name = "ckbx_OxidMeth";
             this.ckbx_OxidMeth.Size = new System.Drawing.Size(121, 17);
@@ -338,14 +385,14 @@
             this.dgv_Database.Name = "dgv_Database";
             this.dgv_Database.ReadOnly = true;
             this.dgv_Database.RowTemplate.Height = 28;
-            this.dgv_Database.Size = new System.Drawing.Size(519, 474);
+            this.dgv_Database.Size = new System.Drawing.Size(908, 749);
             this.dgv_Database.TabIndex = 0;
             // 
             // TheoreticalDatabase
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(788, 478);
+            this.ClientSize = new System.Drawing.Size(1370, 753);
             this.ControlBox = false;
             this.Controls.Add(this.splitContainer1);
             this.Margin = new System.Windows.Forms.Padding(2);
@@ -392,5 +439,9 @@
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.NumericUpDown nUD_MinPeptideLength;
         private System.Windows.Forms.CheckBox ckbx_aggregateProteoforms;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.TextBox tb_proteins_of_interest_path;
+        private System.Windows.Forms.Button bt_proteins_of_interest;
+        private System.Windows.Forms.TextBox tb_interest_label;
     }
 }

--- a/ProteoformSuiteGUI/TheoreticalDatabase.cs
+++ b/ProteoformSuiteGUI/TheoreticalDatabase.cs
@@ -92,9 +92,9 @@ namespace ProteoformSuite
 
         private void InitializeGeneListDialog()
         {
-            this.openAccessionListDialog.Filter = "List of Genes of Interest (*.txt)|*.txt";
+            this.openAccessionListDialog.Filter = "List of Proteins of Interest (*.txt)|*.txt";
             this.openAccessionListDialog.Multiselect = false;
-            this.openAccessionListDialog.Title = "List of Genes of Interest";
+            this.openAccessionListDialog.Title = "List of Proteins of Interest";
         }
 
         public void FillDataBaseTable(string table)

--- a/ProteoformSuiteGUI/TheoreticalDatabase.cs
+++ b/ProteoformSuiteGUI/TheoreticalDatabase.cs
@@ -34,6 +34,7 @@ namespace ProteoformSuite
             btn_Make_Databases.Enabled = false;
             InitializeOpenXmlDialog();
             InitializeOpenPtmlistDialog();
+            InitializeAccessionListDialog();
             InitializeSettings();
 
             if (Lollipop.opened_results_originally)
@@ -90,7 +91,7 @@ namespace ProteoformSuite
             this.openPtmlistDialog.Title = "UniProt PTM List";
         }
 
-        private void InitializeGeneListDialog()
+        private void InitializeAccessionListDialog()
         {
             this.openAccessionListDialog.Filter = "List of Proteins of Interest (*.txt)|*.txt";
             this.openAccessionListDialog.Multiselect = false;

--- a/ProteoformSuiteGUI/TheoreticalDatabase.cs
+++ b/ProteoformSuiteGUI/TheoreticalDatabase.cs
@@ -19,6 +19,7 @@ namespace ProteoformSuite
     {
         OpenFileDialog openXmlDialog = new OpenFileDialog();
         OpenFileDialog openPtmlistDialog = new OpenFileDialog();
+        OpenFileDialog openAccessionListDialog = new OpenFileDialog();
         public bool gotPTMlistFilePath = false;
         public bool gotXMLFilePath = false;
         bool initial_load = true;
@@ -54,6 +55,7 @@ namespace ProteoformSuite
                 btn_NaturalIsotopes.Checked = true;
             }
             
+            tb_interest_label.Text = "Type a label here. Ex: mitochondrial proteins";
 
             ckbx_OxidMeth.Checked = Lollipop.methionine_oxidation;
             ckbx_Carbam.Checked = Lollipop.carbamidomethylation;
@@ -86,6 +88,13 @@ namespace ProteoformSuite
             this.openPtmlistDialog.Filter = "UniProt PTM List (*.txt)|*.txt";
             this.openPtmlistDialog.Multiselect = false;
             this.openPtmlistDialog.Title = "UniProt PTM List";
+        }
+
+        private void InitializeGeneListDialog()
+        {
+            this.openAccessionListDialog.Filter = "List of Genes of Interest (*.txt)|*.txt";
+            this.openAccessionListDialog.Multiselect = false;
+            this.openAccessionListDialog.Title = "List of Genes of Interest";
         }
 
         public void FillDataBaseTable(string table)
@@ -155,6 +164,34 @@ namespace ProteoformSuite
                 {
                     // Could not load the result file - probably related to Windows file system permissions.
                     MessageBox.Show("Cannot display the file: " + ptmlist_filename.Substring(ptmlist_filename.LastIndexOf('\\'))
+                        + ". You may not have permission to read the file, or it may be corrupt.\n\nReported error: " + ex.Message);
+                }
+            }
+        }
+
+        private void bt_genes_of_interest_Click(object sender, EventArgs e)
+        {
+            MessageBox.Show("Please select a text file with the accession numbers of your proteins of interest, one per line.");
+            DialogResult dr = this.openAccessionListDialog.ShowDialog();
+            if (dr == System.Windows.Forms.DialogResult.OK)
+            {
+                string accessions_path = openAccessionListDialog.FileName;
+                try
+                {
+                    tb_proteins_of_interest_path.Text = accessions_path;
+                    Lollipop.accessions_of_interest_list_filepath = accessions_path;
+                    tb_interest_label.Visible = true;
+                }
+                catch (SecurityException ex)
+                {
+                    // The user lacks appropriate permissions to read files, discover paths, etc.
+                    MessageBox.Show("Security error. Please contact your administrator for details.\n\nError message: " + ex.Message + "\n\n" +
+                        "Details (send to Support):\n\n" + ex.StackTrace);
+                }
+                catch (Exception ex)
+                {
+                    // Could not load the result file - probably related to Windows file system permissions.
+                    MessageBox.Show("Cannot display the file: " + accessions_path.Substring(accessions_path.LastIndexOf('\\'))
                         + ". You may not have permission to read the file, or it may be corrupt.\n\nReported error: " + ex.Message);
                 }
             }
@@ -238,6 +275,12 @@ namespace ProteoformSuite
         private void nUD_MinPeptideLength_ValueChanged(object sender, EventArgs e)
         {
             Lollipop.min_peptide_length = Convert.ToInt32(nUD_MinPeptideLength.Value);
+        }
+
+        private void tb_interest_label_TextChanged(object sender, EventArgs e)
+        {
+            if (!initial_load)
+                Lollipop.interest_type = tb_interest_label.Text;
         }
     }
 }

--- a/ProteoformSuiteInternal/DeltaMassPeak.cs
+++ b/ProteoformSuiteInternal/DeltaMassPeak.cs
@@ -27,6 +27,8 @@ namespace ProteoformSuiteInternal
         public double peak_group_fdr { get; set; }
         public bool peak_accepted { get; set; }
         public string mass_shifter { get; set; } = "0";
+        public bool missed_mono { get; set; } //can mark EE peak as a missed mono --> see how many E's in ET peaks are missed monos... maybe helpful
+        public int num_missed_monos { get { return grouped_relations.Where(p => ((ExperimentalProteoform)p.connected_proteoforms[0]).missed_mono == true).ToList().Count; } } //want to know ## missed monos in ET peak
         public List<Modification> possiblePeakAssignments { get; set; }
         public string possiblePeakAssignments_string
         {
@@ -38,7 +40,7 @@ namespace ProteoformSuiteInternal
         {
             this.base_relation = base_relation;
 
-            if (!Lollipop.opened_results) this.find_nearby_relations(relations_to_group);
+            if (!Lollipop.opened_results && !Lollipop.opened_results_originally) this.find_nearby_relations(relations_to_group);
             else this.grouped_relations = relations_to_group; 
 
             foreach (ProteoformRelation relation in this.grouped_relations)

--- a/ProteoformSuiteInternal/DeltaMassPeak.cs
+++ b/ProteoformSuiteInternal/DeltaMassPeak.cs
@@ -40,7 +40,7 @@ namespace ProteoformSuiteInternal
         {
             this.base_relation = base_relation;
 
-            if (!Lollipop.opened_results && !Lollipop.opened_results_originally) this.find_nearby_relations(relations_to_group);
+            if (!Lollipop.opened_results) this.find_nearby_relations(relations_to_group);
             else this.grouped_relations = relations_to_group; 
 
             foreach (ProteoformRelation relation in this.grouped_relations)

--- a/ProteoformSuiteInternal/ExcelReader.cs
+++ b/ProteoformSuiteInternal/ExcelReader.cs
@@ -76,6 +76,7 @@ namespace ProteoformSuiteInternal
                 return value;
         }
 
+
         public double GetCorrectionFactor(string filename, string scan_range, IEnumerable<Correction> correctionFactors)
         {
             if(correctionFactors == null) return 0D;
@@ -100,6 +101,42 @@ namespace ProteoformSuiteInternal
             if (allCorrectionFactors.Count() <= 0) return 0D;
 
             return allCorrectionFactors.Average();                
+        }
+
+        //Reading in Top-down excel
+        public static List<Psm> ReadTDFile(string filename, TDProgram td_program)
+        {
+            List<Psm> psm_list = new List<Psm>();
+            using (SpreadsheetDocument spreadsheetDocument = SpreadsheetDocument.Open(filename, false))
+            {
+                // Get Data in Sheet1 of Excel file
+                IEnumerable<Sheet> sheetcollection = spreadsheetDocument.WorkbookPart.Workbook.GetFirstChild<Sheets>().Elements<Sheet>(); // Get all sheets in spread sheet document 
+                WorksheetPart worksheet_1 = (WorksheetPart)spreadsheetDocument.WorkbookPart.GetPartById(sheetcollection.First().Id.Value); // Get sheet1 Part of Spread Sheet Document
+                SheetData sheet_1 = worksheet_1.Worksheet.Elements<SheetData>().First();
+                List<Row> rowcollection = worksheet_1.Worksheet.Descendants<Row>().ToList();
+                for (int i = 1; i < rowcollection.Count; i++)   //skip first row (headers)
+                {
+                    List<string> cellStrings = new List<string>();
+                    for (int k = 0; k < rowcollection[i].Descendants<Cell>().Count(); k++)
+                    {
+                        cellStrings.Add(GetCellValue(spreadsheetDocument, rowcollection[i].Descendants<Cell>().ElementAt(k)));
+                    }
+
+                    if (td_program == TDProgram.NRTDP)
+                    {
+                        Psm new_psm = new Psm(cellStrings[4] + cellStrings[5], filename, Convert.ToInt16(cellStrings[5]), Convert.ToInt16(cellStrings[6]),
+                            0, 0, Convert.ToDouble(cellStrings[14]), 0, cellStrings[2], Convert.ToDouble(cellStrings[12]), 0, 0, PsmType.TopDown);
+                        psm_list.Add(new_psm);
+                    }
+
+                    else if (td_program == TDProgram.ProSight)
+                    {
+                        Psm new_psm = new Psm(cellStrings[6] + cellStrings[8], cellStrings[14], 0, 0, 0, 0, Convert.ToDouble(cellStrings[20]), 0, cellStrings[4], Convert.ToDouble(cellStrings[9]), 0, Convert.ToDouble(cellStrings[11]), PsmType.TopDown);
+                        psm_list.Add(new_psm);
+                    }
+                }
+            }
+            return psm_list;
         }
 
         private void add_component(Component c)

--- a/ProteoformSuiteInternal/ExcelReader.cs
+++ b/ProteoformSuiteInternal/ExcelReader.cs
@@ -124,7 +124,7 @@ namespace ProteoformSuiteInternal
 
                     if (td_program == TDProgram.NRTDP)
                     {
-                        Psm new_psm = new Psm(cellStrings[4] + cellStrings[5], filename, Convert.ToInt16(cellStrings[5]), Convert.ToInt16(cellStrings[6]),
+                        Psm new_psm = new Psm(cellStrings[8] + cellStrings[4], filename, Convert.ToInt16(cellStrings[5]), Convert.ToInt16(cellStrings[6]),
                             0, 0, Convert.ToDouble(cellStrings[14]), 0, cellStrings[2], Convert.ToDouble(cellStrings[12]), 0, 0, PsmType.TopDown);
                         psm_list.Add(new_psm);
                     }

--- a/ProteoformSuiteInternal/Lollipop.cs
+++ b/ProteoformSuiteInternal/Lollipop.cs
@@ -216,7 +216,14 @@ namespace ProteoformSuiteInternal
             //Read the Morpheus BU data into PSM list
             foreach (InputFile file in Lollipop.bottomup_files())
             {
-                List<Psm> psm_from_file = ProteomeDatabaseReader.ReadpsmFile(file.path + "\\" + file.filename + file.extension);
+                List<Psm> psm_from_file = ProteomeDatabaseReader.ReadBUFile(file.path + "\\" + file.filename + file.extension);
+                psm_list.AddRange(psm_from_file);
+            }
+
+            //Read TD data into PSM list
+            foreach (InputFile file in Lollipop.topdown_files())
+            {
+                List<Psm> psm_from_file = ExcelReader.ReadTDFile(file.path + "\\" + file.filename + file.extension, file.td_program);
                 psm_list.AddRange(psm_from_file);
             }
 
@@ -242,7 +249,6 @@ namespace ProteoformSuiteInternal
                 string[] accession_to_search = tp.accession.Split('_');
                 tp.psm_list = Lollipop.psm_list.Where(p => p.protein_description.Contains(accession_to_search[0])).ToList();
             });
-
         }
 
         private static ProteinSequenceGroup[] group_proteins_by_sequence(IEnumerable<Protein> proteins)

--- a/ProteoformSuiteInternal/Lollipop.cs
+++ b/ProteoformSuiteInternal/Lollipop.cs
@@ -188,6 +188,8 @@ namespace ProteoformSuiteInternal
         public static bool combine_identical_sequences = true;
         public static string uniprot_xml_filepath = "";
         public static string ptmlist_filepath = "";
+        public static string accessions_of_interest_list_filepath = "";
+        public static string interest_type = "Of interest"; //label for proteins of interest. can be changed 
         //public static List<TheoreticalProteoform> theoretical_proteoforms = new List<TheoreticalProteoform>();
         //public static Dictionary<string, List<TheoreticalProteoform>> decoy_proteoforms = new Dictionary<string, List<TheoreticalProteoform>>();
         static Protein[] proteins;
@@ -239,6 +241,10 @@ namespace ProteoformSuiteInternal
                 decoys = decoys.Where(d => d != null).ToList()
             );
             if (psm_list.Count > 0) { match_psms_and_theoreticals(); }   //if BU data loaded in, match PSMs to theoretical accessions
+            if (Lollipop.accessions_of_interest_list_filepath.Length > 0)
+            {
+                mark_accessions_of_interest();
+            }
         }
 
         private static void match_psms_and_theoreticals()
@@ -248,6 +254,16 @@ namespace ProteoformSuiteInternal
                 //PSMs in BU data with that protein accession
                 string[] accession_to_search = tp.accession.Split('_');
                 tp.psm_list = Lollipop.psm_list.Where(p => p.protein_description.Contains(accession_to_search[0])).ToList();
+            });
+        }
+
+        private static void mark_accessions_of_interest()
+        {
+            string[] lines = File.ReadAllLines(Lollipop.accessions_of_interest_list_filepath);
+            Parallel.ForEach<string>(lines, accession =>
+            {
+                List<TheoreticalProteoform> theoreticals = Lollipop.proteoform_community.theoretical_proteoforms.Where(p => p.accession.Contains(accession)).ToList();
+                foreach(TheoreticalProteoform theoretical in theoreticals) { theoretical.of_interest = Lollipop.interest_type; }
             });
         }
 

--- a/ProteoformSuiteInternal/Lollipop.cs
+++ b/ProteoformSuiteInternal/Lollipop.cs
@@ -193,7 +193,7 @@ namespace ProteoformSuiteInternal
         static Protein[] proteins;
         public static List<Psm> psm_list = new List<Psm>();
 
-        static ProteomeDatabaseReader proteomeDatabaseReader = new ProteomeDatabaseReader();
+        public static ProteomeDatabaseReader proteomeDatabaseReader = new ProteomeDatabaseReader();
         public static Dictionary<string, Modification> uniprotModificationTable;
         static Dictionary<char, double> aaIsotopeMassList;
 

--- a/ProteoformSuiteInternal/Lollipop.cs
+++ b/ProteoformSuiteInternal/Lollipop.cs
@@ -72,7 +72,7 @@ namespace ProteoformSuiteInternal
         {
             int i = 1;
             List<Component> reduced_raw_exp_comps = new List<Component>();
-            foreach (Component comp in raw_experimental_components.Where(f => f.file_origin == filename).ToList())
+            foreach (Component comp in raw_experimental_components.Where(f => (f.input_file.path + "\\" + f.input_file.filename + f.input_file.extension) == filename).ToList())
             {
                 string[] scans = comp.scan_range.Split('-');
                 if (scans[0].Equals(scans[1]) && MS1_scans.Contains(Convert.ToInt32(scans[0])))  //make sure same scan # in range (one scan) and that it's MS1 scan

--- a/ProteoformSuiteInternal/PSM.cs
+++ b/ProteoformSuiteInternal/PSM.cs
@@ -20,8 +20,9 @@ namespace ProteoformSuiteInternal
         public double precursor_mz { get; set; }
         public int precursor_charge { get; set; }
         public double precursor_mass_error { get; set; }
+        public PsmType psm_type { get; set; }
 
-        public Psm (string sequence, string filename, int start_residue, int stop_residue, double total_intensity, double precursor_intensity, double morpheus_score, int spectrum,string protein_description, double precursor_mz, int precursor_charge, double precursor_mass_error )
+        public Psm (string sequence, string filename, int start_residue, int stop_residue, double total_intensity, double precursor_intensity, double morpheus_score, int spectrum,string protein_description, double precursor_mz, int precursor_charge, double precursor_mass_error, PsmType psm_type )
         {
             this.sequence = sequence;
             this.filename = filename;
@@ -35,6 +36,13 @@ namespace ProteoformSuiteInternal
             this.precursor_mz = precursor_mz;
             this.precursor_charge = precursor_charge;
             this.precursor_mass_error = precursor_mass_error;
+            this.psm_type = psm_type;
         }
+    }
+
+    public enum PsmType
+    {
+        BottomUp,
+        TopDown
     }
 }

--- a/ProteoformSuiteInternal/Proteoform.cs
+++ b/ProteoformSuiteInternal/Proteoform.cs
@@ -54,6 +54,7 @@ namespace ProteoformSuiteInternal
         {
             get { return aggregated_components.Count; }
         }
+        public bool missed_mono { get; set; } = false;
 
         public ExperimentalProteoform(string accession, Component root, List<Component> candidate_observations, List<Component> quantitative_observations, bool is_target) : base(accession)
         {

--- a/ProteoformSuiteInternal/Proteoform.cs
+++ b/ProteoformSuiteInternal/Proteoform.cs
@@ -213,7 +213,8 @@ namespace ProteoformSuiteInternal
             get { return ptm_list_string(); }
         }
         public List<Psm> psm_list { get; set; } = new List<Psm>();
-        public int psm_count { get { return psm_list.Count; } }
+        private int _psm_count;
+        public int psm_count { set { _psm_count = value; } get { if (!Lollipop.opened_results_originally) return psm_list.Count; else { return _psm_count; } } }
 
 
         public TheoreticalProteoform(string accession, string description, string name, string fragment, int begin, int end, double unmodified_mass, int lysine_count, PtmSet ptm_set, double modified_mass, bool is_target) : 

--- a/ProteoformSuiteInternal/Proteoform.cs
+++ b/ProteoformSuiteInternal/Proteoform.cs
@@ -55,7 +55,7 @@ namespace ProteoformSuiteInternal
             get { return aggregated_components.Count; }
         }
         public bool missed_mono { get; set; } = false;
-
+        public bool mass_shifted { get; set; } //make sure in ET if shifting multiple peaks, not shifting same E > once. 
         public ExperimentalProteoform(string accession, Component root, List<Component> candidate_observations, List<Component> quantitative_observations, bool is_target) : base(accession)
         {
             this.root = root;
@@ -214,8 +214,10 @@ namespace ProteoformSuiteInternal
             get { return ptm_list_string(); }
         }
         public List<Psm> psm_list { get; set; } = new List<Psm>();
-        private int _psm_count;
-        public int psm_count { set { _psm_count = value; } get { if (!Lollipop.opened_results_originally) return psm_list.Count; else { return _psm_count; } } }
+        private int _psm_count_BU;
+        private int _psm_count_TD;
+        public int psm_count_BU { set { _psm_count_BU = value; } get { if (!Lollipop.opened_results_originally) return psm_list.Where(p => p.psm_type == PsmType.BottomUp).ToList().Count; else return _psm_count_BU; } } 
+        public int psm_count_TD { set { _psm_count_TD = value; } get { if (!Lollipop.opened_results_originally) return psm_list.Where(p => p.psm_type == PsmType.TopDown).ToList().Count; else return _psm_count_TD; } } 
         public string of_interest { get; set; } = "";
 
         public TheoreticalProteoform(string accession, string description, string name, string fragment, int begin, int end, double unmodified_mass, int lysine_count, PtmSet ptm_set, double modified_mass, bool is_target) : 

--- a/ProteoformSuiteInternal/Proteoform.cs
+++ b/ProteoformSuiteInternal/Proteoform.cs
@@ -215,7 +215,7 @@ namespace ProteoformSuiteInternal
         public List<Psm> psm_list { get; set; } = new List<Psm>();
         private int _psm_count;
         public int psm_count { set { _psm_count = value; } get { if (!Lollipop.opened_results_originally) return psm_list.Count; else { return _psm_count; } } }
-
+        public string of_interest { get; set; } = "";
 
         public TheoreticalProteoform(string accession, string description, string name, string fragment, int begin, int end, double unmodified_mass, int lysine_count, PtmSet ptm_set, double modified_mass, bool is_target) : 
             base(accession, modified_mass, lysine_count, is_target)

--- a/ProteoformSuiteInternal/ProteoformRelation.cs
+++ b/ProteoformSuiteInternal/ProteoformRelation.cs
@@ -172,7 +172,7 @@ namespace ProteoformSuiteInternal
         {
             get { try { return ((TheoreticalProteoform)connected_proteoforms[1]).psm_count.ToString(); } catch { return null; }}
         }
-        public string gene_of_interest
+        public string of_interest
         {
             get { try { return ((TheoreticalProteoform)connected_proteoforms[1]).of_interest; } catch { return null; } }
         }

--- a/ProteoformSuiteInternal/ProteoformRelation.cs
+++ b/ProteoformSuiteInternal/ProteoformRelation.cs
@@ -172,5 +172,9 @@ namespace ProteoformSuiteInternal
         {
             get { try { return ((TheoreticalProteoform)connected_proteoforms[1]).psm_count.ToString(); } catch { return null; }}
         }
+        public string gene_of_interest
+        {
+            get { try { return ((TheoreticalProteoform)connected_proteoforms[1]).of_interest; } catch { return null; } }
+        }
     }
 }

--- a/ProteoformSuiteInternal/ProteoformRelation.cs
+++ b/ProteoformSuiteInternal/ProteoformRelation.cs
@@ -168,9 +168,13 @@ namespace ProteoformSuiteInternal
         {
             get { try { return ((TheoreticalProteoform)connected_proteoforms[1]).ptm_descriptions; } catch { return null; } }
         }
-        public string psm_count
+        public int psm_count_BU
         {
-            get { try { return ((TheoreticalProteoform)connected_proteoforms[1]).psm_count.ToString(); } catch { return null; }}
+            get { try { return ((TheoreticalProteoform)connected_proteoforms[1]).psm_count_BU; } catch { return 0; }}
+        }
+        public int psm_count_TD
+        {
+            get { try { return ((TheoreticalProteoform)connected_proteoforms[1]).psm_count_TD; } catch { return 0; } }
         }
         public string of_interest
         {

--- a/ProteoformSuiteInternal/ProteomeDatabaseReader.cs
+++ b/ProteoformSuiteInternal/ProteomeDatabaseReader.cs
@@ -8,6 +8,8 @@ using System.Net;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
 
 //Inspired by the class by the same name from Morpheus (http://cwenger.github.io/Morpheus) by Craig Wenger
 namespace ProteoformSuiteInternal
@@ -242,7 +244,7 @@ namespace ProteoformSuiteInternal
         }
 
         //READING IN BOTTOM-UP MORPHEUS FILE
-        public static List<Psm> ReadpsmFile(string filename)
+        public static List<Psm> ReadBUFile(string filename)
         {
             List<Psm> psm_list = new List<Psm>();
             string[] lines = File.ReadAllLines(filename);
@@ -259,8 +261,8 @@ namespace ProteoformSuiteInternal
                     if (Convert.ToBoolean(parts[26]))
                     {
                         Psm new_psm = new Psm(parts[11].ToString(), parts[0].ToString(), Convert.ToInt32(parts[14]), Convert.ToInt32(parts[15]),
-                            Convert.ToDouble(parts[10]), Convert.ToDouble(parts[6]), Convert.ToDouble(parts[25]), Convert.ToInt32(parts[1]),
-                            parts[13].ToString(), Convert.ToDouble(parts[5]), Convert.ToInt32(parts[7]), Convert.ToDouble(parts[18]));
+                            Convert.ToDouble(parts[10]), Convert.ToDouble(parts[6]), Convert.ToDouble(parts[25]),0,
+                            parts[1].ToString(), Convert.ToDouble(parts[5]), Convert.ToInt32(parts[7]), Convert.ToDouble(parts[18]), PsmType.BottomUp);
                         psm_list.Add(new_psm);
                     }
                     i++;

--- a/ProteoformSuiteInternal/ProteomeDatabaseReader.cs
+++ b/ProteoformSuiteInternal/ProteomeDatabaseReader.cs
@@ -8,8 +8,7 @@ using System.Net;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
-using DocumentFormat.OpenXml.Packaging;
-using DocumentFormat.OpenXml.Spreadsheet;
+
 
 //Inspired by the class by the same name from Morpheus (http://cwenger.github.io/Morpheus) by Craig Wenger
 namespace ProteoformSuiteInternal

--- a/ProteoformSuiteInternal/ProteomeDatabaseReader.cs
+++ b/ProteoformSuiteInternal/ProteomeDatabaseReader.cs
@@ -260,8 +260,8 @@ namespace ProteoformSuiteInternal
                     if (Convert.ToBoolean(parts[26]))
                     {
                         Psm new_psm = new Psm(parts[11].ToString(), parts[0].ToString(), Convert.ToInt32(parts[14]), Convert.ToInt32(parts[15]),
-                            Convert.ToDouble(parts[10]), Convert.ToDouble(parts[6]), Convert.ToDouble(parts[25]),0,
-                            parts[1].ToString(), Convert.ToDouble(parts[5]), Convert.ToInt32(parts[7]), Convert.ToDouble(parts[18]), PsmType.BottomUp);
+                            Convert.ToDouble(parts[10]), Convert.ToDouble(parts[6]), Convert.ToDouble(parts[25]),Convert.ToInt32(parts[1]),
+                            parts[13].ToString(), Convert.ToDouble(parts[5]), Convert.ToInt32(parts[7]), Convert.ToDouble(parts[18]), PsmType.BottomUp);
                         psm_list.Add(new_psm);
                     }
                     i++;

--- a/ProteoformSuiteInternal/Results.cs
+++ b/ProteoformSuiteInternal/Results.cs
@@ -221,7 +221,7 @@ namespace ProteoformSuiteInternal
         public static string theoretical_proteoforms_results(bool target)
         {
             string tsv_header = String.Join("\t", new List<string> { "accession", "modified_mass", "lysine_count", "is_target", "is_decoy",
-                "description", "name", "fragment", "begin", "end", "unmodified_mass", "ptm_list", "ptm_mass", "database_name", "psm_count" });
+                "description", "name", "fragment", "begin", "end", "unmodified_mass", "ptm_list", "ptm_mass", "database_name", "BU_psm_count", "TD_psm_count" });
             if (target)
             {
                 return tsv_header + Environment.NewLine +

--- a/ProteoformSuiteInternal/Results.cs
+++ b/ProteoformSuiteInternal/Results.cs
@@ -203,7 +203,8 @@ namespace ProteoformSuiteInternal
                     if (line[11] != "unmodified") { ptm_set = new PtmSet(new List<Ptm>(from ptm_description in line[11].Split(';') select new Ptm(-1, Lollipop.uniprotModificationTable[ptm_description.Trim().TrimEnd(';')]))); }
                     else ptm_set = new PtmSet(unmodified);
                     TheoreticalProteoform theoretical_proteoform = new TheoreticalProteoform(line[0], line[5], line[6], line[7], Convert.ToInt32(line[8]), Convert.ToInt32(line[9]), Convert.ToDouble(line[10]), Convert.ToInt32(line[2]), ptm_set, Convert.ToDouble(line[1]), Convert.ToBoolean(line[3]));
-                    theoretical_proteoform.psm_count = Convert.ToInt32(line[14]);
+                    theoretical_proteoform.psm_count_BU = Convert.ToInt32(line[14]);
+                    theoretical_proteoform.psm_count_TD = Convert.ToInt32(line[15]);
                     string database = line[13];
                     if (database == "Target") lock (lockThread)
                         Lollipop.proteoform_community.theoretical_proteoforms.Add(theoretical_proteoform);
@@ -238,7 +239,7 @@ namespace ProteoformSuiteInternal
         private static string theoretical_proteoform_as_tsv_row(TheoreticalProteoform t, string database)
         {
             return String.Join("\t", new List<string> { t.accession.ToString(), t.modified_mass.ToString(), t.lysine_count.ToString(), t.is_target.ToString(), t.is_decoy.ToString(),
-                t.description.ToString(), t.name.ToString(), t.fragment.ToString(), t.begin.ToString(), t.end.ToString(), t.unmodified_mass.ToString(), t.ptm_descriptions.ToString(), t.ptm_mass.ToString(), database, t.psm_count.ToString() });
+                t.description.ToString(), t.name.ToString(), t.fragment.ToString(), t.begin.ToString(), t.end.ToString(), t.unmodified_mass.ToString(), t.ptm_descriptions.ToString(), t.ptm_mass.ToString(), database, t.psm_count_BU.ToString(), t.psm_count_TD.ToString() });
         }
 
         // PROTEOFORM RELATION I/O

--- a/ProteoformSuiteInternal/Results.cs
+++ b/ProteoformSuiteInternal/Results.cs
@@ -198,8 +198,12 @@ namespace ProteoformSuiteInternal
                 string[] line = lines[x].Split('\t');
                 if (line.Length == header.Length)
                 {
-                    PtmSet ptm_set = new PtmSet(new List<Ptm>(from ptm_description in line[11].Split(';') select new Ptm(-1, Lollipop.uniprotModificationTable[ptm_description.Trim().TrimEnd(';')])));
+                    PtmSet ptm_set;
+                    List<Ptm> unmodified = new List<Ptm>();
+                    if (line[11] != "unmodified") { ptm_set = new PtmSet(new List<Ptm>(from ptm_description in line[11].Split(';') select new Ptm(-1, Lollipop.uniprotModificationTable[ptm_description.Trim().TrimEnd(';')]))); }
+                    else ptm_set = new PtmSet(unmodified);
                     TheoreticalProteoform theoretical_proteoform = new TheoreticalProteoform(line[0], line[5], line[6], line[7], Convert.ToInt32(line[8]), Convert.ToInt32(line[9]), Convert.ToDouble(line[10]), Convert.ToInt32(line[2]), ptm_set, Convert.ToDouble(line[1]), Convert.ToBoolean(line[3]));
+                    theoretical_proteoform.psm_count = Convert.ToInt32(line[14]);
                     string database = line[13];
                     if (database == "Target") lock (lockThread)
                         Lollipop.proteoform_community.theoretical_proteoforms.Add(theoretical_proteoform);
@@ -216,7 +220,7 @@ namespace ProteoformSuiteInternal
         public static string theoretical_proteoforms_results(bool target)
         {
             string tsv_header = String.Join("\t", new List<string> { "accession", "modified_mass", "lysine_count", "is_target", "is_decoy",
-                "description", "name", "fragment", "begin", "end", "unmodified_mass", "ptm_list", "ptm_mass", "database_name" });
+                "description", "name", "fragment", "begin", "end", "unmodified_mass", "ptm_list", "ptm_mass", "database_name", "psm_count" });
             if (target)
             {
                 return tsv_header + Environment.NewLine +
@@ -234,7 +238,7 @@ namespace ProteoformSuiteInternal
         private static string theoretical_proteoform_as_tsv_row(TheoreticalProteoform t, string database)
         {
             return String.Join("\t", new List<string> { t.accession.ToString(), t.modified_mass.ToString(), t.lysine_count.ToString(), t.is_target.ToString(), t.is_decoy.ToString(),
-                t.description.ToString(), t.name.ToString(), t.fragment.ToString(), t.begin.ToString(), t.end.ToString(), t.unmodified_mass.ToString(), t.ptm_descriptions.ToString(), t.ptm_mass.ToString(), database });
+                t.description.ToString(), t.name.ToString(), t.fragment.ToString(), t.begin.ToString(), t.end.ToString(), t.unmodified_mass.ToString(), t.ptm_descriptions.ToString(), t.ptm_mass.ToString(), database, t.psm_count.ToString() });
         }
 
         // PROTEOFORM RELATION I/O

--- a/ProteoformSuiteInternal/inputFile.cs
+++ b/ProteoformSuiteInternal/inputFile.cs
@@ -100,7 +100,8 @@ namespace ProteoformSuiteInternal
         Quantification,
         Calibration,
         BottomUp,
-        TopDown
+        TopDown,
+        TopDownIDResults
     }
 
     public enum Labeling

--- a/ProteoformSuiteInternal/inputFile.cs
+++ b/ProteoformSuiteInternal/inputFile.cs
@@ -35,6 +35,7 @@ namespace ProteoformSuiteInternal
         public string extension { get; set; }
         public Purpose purpose { get; set; } //ID, Quant, Calib, Bottom-Up or Top-Down
         public Labeling label { get; set; }
+        public TDProgram td_program { get; set; } = TDProgram.NRTDP;
 
         public InputFile(string path, string filename, string extension, Labeling label, Purpose purpose)
         {
@@ -84,6 +85,13 @@ namespace ProteoformSuiteInternal
 
         public InputFile()
         { }
+    }
+
+    //for TD 
+    public enum TDProgram
+    {
+        ProSight,
+        NRTDP //NU software
     }
 
     public enum Purpose

--- a/Test/TestSaveAndLoadResults.cs
+++ b/Test/TestSaveAndLoadResults.cs
@@ -159,6 +159,10 @@ namespace Test
             pf2.is_target = true;
             pf1.is_decoy = false;
             pf2.is_decoy = false;
+            pf1.psm_count_BU = 0;
+            pf2.psm_count_BU = 0;
+            pf1.psm_count_TD = 0;
+            pf2.psm_count_TD = 0;
             Lollipop.proteoform_community.theoretical_proteoforms = new List<TheoreticalProteoform> { pf1, pf2 };
             string[] theoretical_proteoform_results = Results.theoretical_proteoforms_results(true).Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
             Assert.AreEqual(3, theoretical_proteoform_results.Length);


### PR DESCRIPTION
1) load in TD - for now just ProSight and the NU TD software we're using in the future 
2) mark accession of interest - you can load in a list of accessions you're interested in and they're marked in a column if they appear in ET pairs (I did this so I can easily see which proteins are known mitochondrial in my samples)
3) mark missed monoisotopics - they're easy to spot in EE for label free, so check the box for missed mono peaks in the dgv. Then in ET peaks, there's a sum of the ET relations for that peak that had an E that was in an EE missed mono peak. This should make finding the missed monoisotopics in ET a little easier if you sort by that column. 