### PR TITLE
ProteoformFamilies update button

### DIFF
--- a/ProteoformSuiteGUI/AggregatedProteoforms.cs
+++ b/ProteoformSuiteGUI/AggregatedProteoforms.cs
@@ -19,28 +19,26 @@ namespace ProteoformSuite
         public AggregatedProteoforms()
         {
             InitializeComponent();
+            InitializeSettings();
         }
 
         public void AggregatedProteoforms_Load(object sender, EventArgs e)
-        {
-            InitializeSettings();
-            aggregate_proteoforms();
-            FillAggregatesTable();
-        }
+        { }
 
         public void aggregate_proteoforms()
         {
-            if (Lollipop.proteoform_community.experimental_proteoforms.Count() == 0) Lollipop.aggregate_proteoforms();
-            updateFiguresOfMerit();
-            initial_load = false;
+            if (Lollipop.proteoform_community.experimental_proteoforms.Count() == 0) RunTheGamut();
         }
 
         private void RunTheGamut()
         {
+            this.Cursor = Cursors.WaitCursor;
             ClearListsAndTables();
             Lollipop.aggregate_proteoforms();
             FillAggregatesTable();
             updateFiguresOfMerit();
+            this.Cursor = Cursors.Default;
+            initial_load = false;
         }
 
         private void InitializeSettings()

--- a/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
@@ -28,6 +28,8 @@ namespace ProteoformSuite
             this.ct_ET_peakList.MouseClick += new MouseEventHandler(ct_ET_peakList_MouseClick);
             dgv_ET_Peak_List.CurrentCellDirtyStateChanged += new EventHandler(ET_Peak_List_DirtyStateChanged); //makes the change immediate and automatic
             ETPeakAcceptabilityChanged += ExperimentTheoreticalComparison_ETPeakAcceptabilityChanged;
+            InitializeParameterSet();
+            InitializeMassWindow();
         }
 
         protected void ExperimentTheoreticalComparison_ETPeakAcceptabilityChanged(object sender, ETPeakAcceptabilityChangedEventArgs e)
@@ -40,15 +42,11 @@ namespace ProteoformSuite
         }
 
         public void ExperimentTheoreticalComparison_Load(object sender, EventArgs e)
+        { }
+
+        public void compare_et()
         {
-            InitializeParameterSet();
-            if (Lollipop.et_relations.Count == 0)
-            {
-                InitializeMassWindow();
-                Lollipop.make_et_relationships();
-            }
-            this.FillTablesAndCharts();
-            initial_load = false;
+            if (Lollipop.et_relations.Count == 0) RunTheGamut();
         }
 
         private void RunTheGamut()
@@ -58,6 +56,7 @@ namespace ProteoformSuite
             Lollipop.make_et_relationships();
             this.FillTablesAndCharts();
             this.Cursor = Cursors.Default;
+            initial_load = false;
         }
 
         public void FillTablesAndCharts()
@@ -78,8 +77,11 @@ namespace ProteoformSuite
             Lollipop.et_relations.Clear();
             Lollipop.et_peaks.Clear();
             Lollipop.ed_relations.Clear();
-            Lollipop.proteoform_community.relations_in_peaks.Clear();
-            Lollipop.proteoform_community.delta_mass_peaks.Clear();
+            Lollipop.proteoform_community.families.Clear();
+            foreach (Proteoform p in Lollipop.proteoform_community.experimental_proteoforms) p.relationships.RemoveAll(r => r.relation_type == ProteoformComparison.et || r.relation_type == ProteoformComparison.ed);
+            foreach (Proteoform p in Lollipop.proteoform_community.theoretical_proteoforms) p.relationships.RemoveAll(r => r.relation_type == ProteoformComparison.et || r.relation_type == ProteoformComparison.ed);
+            Lollipop.proteoform_community.relations_in_peaks.RemoveAll(r => r.relation_type == ProteoformComparison.et || r.relation_type == ProteoformComparison.ed);
+            Lollipop.proteoform_community.delta_mass_peaks.RemoveAll(k => k.relation_type == ProteoformComparison.et || k.relation_type == ProteoformComparison.ed);
 
             dgv_ET_Pairs.DataSource = null;
             dgv_ET_Peak_List.DataSource = null;

--- a/ProteoformSuiteGUI/LoadDeconvolutionResults.cs
+++ b/ProteoformSuiteGUI/LoadDeconvolutionResults.cs
@@ -12,7 +12,6 @@ using System.Security;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-//using 
 using Excel = Microsoft.Office.Interop.Excel; //Right click Solution/Explorer/References. Then Add  "Reference". Assemblies/Extension/Microsoft.Office.Interop.Excel
 
 
@@ -29,10 +28,7 @@ namespace ProteoformSuite
         }
 
         public void LoadDeconvolutionResults_Load(object sender, EventArgs e)
-        {
-            //Nothing happens now because this form is automatically loaded at startup
-        }
-
+        { }
         
         private void btn_neucode_CheckedChanged(object sender, EventArgs e)
         {

--- a/ProteoformSuiteGUI/ProteoformFamilies.Designer.cs
+++ b/ProteoformSuiteGUI/ProteoformFamilies.Designer.cs
@@ -34,6 +34,11 @@
             this.pictureBox_familyDisplay = new System.Windows.Forms.PictureBox();
             this.splitContainer3 = new System.Windows.Forms.SplitContainer();
             this.dgv_proteoform_family_members = new System.Windows.Forms.DataGridView();
+            this.Families_update = new System.Windows.Forms.Button();
+            this.tb_IdentifiedFamilies = new System.Windows.Forms.TextBox();
+            this.tb_TotalFamilies = new System.Windows.Forms.TextBox();
+            this.label8 = new System.Windows.Forms.Label();
+            this.label7 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -46,6 +51,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox_familyDisplay)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer3)).BeginInit();
             this.splitContainer3.Panel1.SuspendLayout();
+            this.splitContainer3.Panel2.SuspendLayout();
             this.splitContainer3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dgv_proteoform_family_members)).BeginInit();
             this.SuspendLayout();
@@ -66,7 +72,7 @@
             // 
             this.splitContainer1.Panel2.Controls.Add(this.splitContainer3);
             this.splitContainer1.Size = new System.Drawing.Size(953, 677);
-            this.splitContainer1.SplitterDistance = 347;
+            this.splitContainer1.SplitterDistance = 335;
             this.splitContainer1.TabIndex = 3;
             // 
             // splitContainer2
@@ -84,7 +90,7 @@
             // splitContainer2.Panel2
             // 
             this.splitContainer2.Panel2.Controls.Add(this.pictureBox_familyDisplay);
-            this.splitContainer2.Size = new System.Drawing.Size(953, 347);
+            this.splitContainer2.Size = new System.Drawing.Size(953, 335);
             this.splitContainer2.SplitterDistance = 552;
             this.splitContainer2.TabIndex = 5;
             // 
@@ -97,7 +103,7 @@
             this.dgv_proteoform_families.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dgv_proteoform_families.Location = new System.Drawing.Point(0, 0);
             this.dgv_proteoform_families.Name = "dgv_proteoform_families";
-            this.dgv_proteoform_families.Size = new System.Drawing.Size(548, 343);
+            this.dgv_proteoform_families.Size = new System.Drawing.Size(548, 331);
             this.dgv_proteoform_families.TabIndex = 2;
             this.dgv_proteoform_families.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dgv_proteoform_families_CellContentClick);
             this.dgv_proteoform_families.CellMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.dgv_proteoform_families_CellMouseClick);
@@ -107,7 +113,7 @@
             this.pictureBox_familyDisplay.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pictureBox_familyDisplay.Location = new System.Drawing.Point(0, 0);
             this.pictureBox_familyDisplay.Name = "pictureBox_familyDisplay";
-            this.pictureBox_familyDisplay.Size = new System.Drawing.Size(393, 343);
+            this.pictureBox_familyDisplay.Size = new System.Drawing.Size(393, 331);
             this.pictureBox_familyDisplay.TabIndex = 4;
             this.pictureBox_familyDisplay.TabStop = false;
             // 
@@ -120,7 +126,15 @@
             // splitContainer3.Panel1
             // 
             this.splitContainer3.Panel1.Controls.Add(this.dgv_proteoform_family_members);
-            this.splitContainer3.Size = new System.Drawing.Size(949, 322);
+            // 
+            // splitContainer3.Panel2
+            // 
+            this.splitContainer3.Panel2.Controls.Add(this.tb_IdentifiedFamilies);
+            this.splitContainer3.Panel2.Controls.Add(this.tb_TotalFamilies);
+            this.splitContainer3.Panel2.Controls.Add(this.label8);
+            this.splitContainer3.Panel2.Controls.Add(this.label7);
+            this.splitContainer3.Panel2.Controls.Add(this.Families_update);
+            this.splitContainer3.Size = new System.Drawing.Size(949, 334);
             this.splitContainer3.SplitterDistance = 543;
             this.splitContainer3.TabIndex = 7;
             // 
@@ -133,8 +147,58 @@
             this.dgv_proteoform_family_members.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dgv_proteoform_family_members.Location = new System.Drawing.Point(0, 0);
             this.dgv_proteoform_family_members.Name = "dgv_proteoform_family_members";
-            this.dgv_proteoform_family_members.Size = new System.Drawing.Size(543, 322);
+            this.dgv_proteoform_family_members.Size = new System.Drawing.Size(543, 334);
             this.dgv_proteoform_family_members.TabIndex = 3;
+            // 
+            // Families_update
+            // 
+            this.Families_update.AllowDrop = true;
+            this.Families_update.Location = new System.Drawing.Point(2, 301);
+            this.Families_update.Name = "Families_update";
+            this.Families_update.Size = new System.Drawing.Size(402, 23);
+            this.Families_update.TabIndex = 33;
+            this.Families_update.Text = "Update";
+            this.Families_update.UseMnemonic = false;
+            this.Families_update.UseVisualStyleBackColor = true;
+            this.Families_update.Click += new System.EventHandler(this.Families_update_Click);
+            // 
+            // tb_IdentifiedFamilies
+            // 
+            this.tb_IdentifiedFamilies.Location = new System.Drawing.Point(190, 260);
+            this.tb_IdentifiedFamilies.Margin = new System.Windows.Forms.Padding(2);
+            this.tb_IdentifiedFamilies.Name = "tb_IdentifiedFamilies";
+            this.tb_IdentifiedFamilies.ReadOnly = true;
+            this.tb_IdentifiedFamilies.Size = new System.Drawing.Size(86, 20);
+            this.tb_IdentifiedFamilies.TabIndex = 37;
+            // 
+            // tb_TotalFamilies
+            // 
+            this.tb_TotalFamilies.Location = new System.Drawing.Point(190, 228);
+            this.tb_TotalFamilies.Margin = new System.Windows.Forms.Padding(2);
+            this.tb_TotalFamilies.Name = "tb_TotalFamilies";
+            this.tb_TotalFamilies.ReadOnly = true;
+            this.tb_TotalFamilies.Size = new System.Drawing.Size(86, 20);
+            this.tb_TotalFamilies.TabIndex = 36;
+            // 
+            // label8
+            // 
+            this.label8.AutoSize = true;
+            this.label8.Location = new System.Drawing.Point(80, 267);
+            this.label8.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(90, 13);
+            this.label8.TabIndex = 35;
+            this.label8.Text = "Identified Families";
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(80, 235);
+            this.label7.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(71, 13);
+            this.label7.TabIndex = 34;
+            this.label7.Text = "Total Families";
             // 
             // ProteoformFamilies
             // 
@@ -156,6 +220,8 @@
             ((System.ComponentModel.ISupportInitialize)(this.dgv_proteoform_families)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox_familyDisplay)).EndInit();
             this.splitContainer3.Panel1.ResumeLayout(false);
+            this.splitContainer3.Panel2.ResumeLayout(false);
+            this.splitContainer3.Panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer3)).EndInit();
             this.splitContainer3.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dgv_proteoform_family_members)).EndInit();
@@ -171,5 +237,10 @@
         private System.Windows.Forms.SplitContainer splitContainer3;
         private System.Windows.Forms.DataGridView dgv_proteoform_family_members;
         private System.Windows.Forms.PictureBox pictureBox_familyDisplay;
+        private System.Windows.Forms.Button Families_update;
+        private System.Windows.Forms.TextBox tb_IdentifiedFamilies;
+        private System.Windows.Forms.TextBox tb_TotalFamilies;
+        private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.Label label7;
     }
 }

--- a/ProteoformSuiteGUI/ProteoformFamilies.cs
+++ b/ProteoformSuiteGUI/ProteoformFamilies.cs
@@ -19,20 +19,32 @@ namespace ProteoformSuite
         }
 
         private void ProteoformFamilies_Load(object sender, EventArgs e)
-        {
-            construct_families();
-            fill_proteoform_families();
-        }
+        { }
 
         public void construct_families()
         {
-            if (Lollipop.proteoform_community.families.Count == 0) Lollipop.proteoform_community.construct_families();
+            if (Lollipop.proteoform_community.families.Count == 0) run_the_gamut();
         }
 
-        public void fill_proteoform_families()
+        private void run_the_gamut()
+        {
+            this.Cursor = Cursors.WaitCursor;
+            Lollipop.proteoform_community.construct_families();
+            fill_proteoform_families();
+            update_figures_of_merit();
+            this.Cursor = Cursors.Default;
+        }
+
+        private void fill_proteoform_families()
         {
             DisplayUtility.FillDataGridView(dgv_proteoform_families, Lollipop.proteoform_community.families);
             format_families_dgv();
+        }
+
+        private void update_figures_of_merit()
+        {
+            this.tb_TotalFamilies.Text = Lollipop.proteoform_community.families.Count().ToString();
+            this.tb_IdentifiedFamilies.Text = Lollipop.proteoform_community.families.Count(f => f.theoretical_count > 0).ToString();
         }
 
         private void format_families_dgv()
@@ -85,6 +97,12 @@ namespace ProteoformSuite
                 }
                 else dgv_proteoform_family_members.Rows.Clear();
             }
+        }
+
+        private void Families_update_Click(object sender, EventArgs e)
+        {
+            Lollipop.proteoform_community.families.Clear();
+            run_the_gamut();
         }
     }
 }

--- a/ProteoformSuiteGUI/ProteoformSuiteGUI.csproj
+++ b/ProteoformSuiteGUI/ProteoformSuiteGUI.csproj
@@ -47,6 +47,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <UseVSHostingProcess>true</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>

--- a/ProteoformSuiteGUI/ProteoformSweet.cs
+++ b/ProteoformSuiteGUI/ProteoformSweet.cs
@@ -67,11 +67,27 @@ namespace ProteoformSuite
         public void loadDeconvolutionResultsToolStripMenuItem_Click(object sender, EventArgs e) { showForm(loadDeconvolutionResults); }
         private void rawExperimentalProteoformsToolStripMenuItem_Click(object sender, EventArgs e) { showForm(rawExperimentalComponents); }
         private void neuCodeProteoformPairsToolStripMenuItem_Click(object sender, EventArgs e) { showForm(neuCodePairs); }
-        private void aggregatedProteoformsToolStripMenuItem_Click(object sender, EventArgs e) { showForm(aggregatedProteoforms); }
+        private void aggregatedProteoformsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            showForm(aggregatedProteoforms);
+            aggregatedProteoforms.aggregate_proteoforms();
+        }
         private void theoreticalProteoformDatabaseToolStripMenuItem_Click(object sender, EventArgs e) { showForm(theoreticalDatabase); }
-        private void experimentTheoreticalComparisonToolStripMenuItem_Click(object sender, EventArgs e) { showForm(experimentalTheoreticalComparison); }
-        private void experimentExperimentComparisonToolStripMenuItem_Click(object sender, EventArgs e) { showForm(experimentExperimentComparison); }
-        private void proteoformFamilyAssignmentToolStripMenuItem_Click(object sender, EventArgs e) { showForm(proteoformFamilies); }
+        private void experimentTheoreticalComparisonToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            showForm(experimentalTheoreticalComparison);
+            experimentalTheoreticalComparison.compare_et();
+        }
+        private void experimentExperimentComparisonToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            showForm(experimentExperimentComparison);
+            experimentExperimentComparison.compare_et();
+        }
+        private void proteoformFamilyAssignmentToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            showForm(proteoformFamilies);
+            proteoformFamilies.construct_families();
+        }
         private void quantificationToolStripMenuItem_Click(object sender, EventArgs e) { showForm(quantification); }
 
         private void resultsSummaryToolStripMenuItem_Click(object sender, EventArgs e)

--- a/ProteoformSuiteInternal/ProteoformSuiteInternal.csproj
+++ b/ProteoformSuiteInternal/ProteoformSuiteInternal.csproj
@@ -21,6 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>true</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -21,6 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>true</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Corrected ET/EE clear to only clear relations of that type from ProteoformCommunity. Implemented ProteoformFamilies update button. Standardized load behavior of several forms, using ProteoformSweet instead of Load events.