### PR TITLE
Method XML comprised of all fields in Lollipop

### DIFF
--- a/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
@@ -98,7 +98,7 @@ namespace ProteoformSuite
         }
         private void FillEEPeakListTable()
         {
-            DisplayUtility.FillDataGridView(dgv_EE_Peaks, Lollipop.ee_peaks);
+            DisplayUtility.FillDataGridView(dgv_EE_Peaks, Lollipop.ee_peaks.OrderByDescending(p => p.peak_relation_group_count).ToList());
         }
         private void GraphEERelations()
         {

--- a/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
@@ -33,7 +33,7 @@ namespace ProteoformSuite
         public void ExperimentTheoreticalComparison_Load(object sender, EventArgs e)
         { }
 
-        private void compare_et()
+        public void compare_et()
         {
             if (Lollipop.proteoform_community.has_e_and_t_proteoforms)
             {
@@ -44,9 +44,8 @@ namespace ProteoformSuite
                 this.Cursor = Cursors.Default;
                 compared_et = true;
             }
-            else if (Lollipop.proteoform_community.has_e_proteoforms)
-            { MessageBox.Show("Go back and create a theoretical database."); }
-            else { MessageBox.Show("Go back and aggregate experimental proteoforms."); }
+            else if (Lollipop.proteoform_community.has_e_proteoforms) MessageBox.Show("Go back and create a theoretical database.");
+            else MessageBox.Show("Go back and aggregate experimental proteoforms.");
         }
 
         public void FillTablesAndCharts()
@@ -102,7 +101,7 @@ namespace ProteoformSuite
         }
         private void FillETPeakListTable()
         {
-            DisplayUtility.FillDataGridView(dgv_ET_Peak_List, Lollipop.et_peaks);
+            DisplayUtility.FillDataGridView(dgv_ET_Peak_List, Lollipop.et_peaks.OrderByDescending(p => p.peak_relation_group_count).ToList());
         }
         private void GraphETRelations()
         {

--- a/ProteoformSuiteGUI/LoadDeconvolutionResults.Designer.cs
+++ b/ProteoformSuiteGUI/LoadDeconvolutionResults.Designer.cs
@@ -56,6 +56,7 @@
             this.bt_morpheusBUResultsClear = new System.Windows.Forms.Button();
             this.bt_tdResultsAdd = new System.Windows.Forms.Button();
             this.bt_tdResultsClear = new System.Windows.Forms.Button();
+            this.bt_clearResults = new System.Windows.Forms.Button();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dgv_identificationFiles)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgv_quantitationFiles)).BeginInit();
@@ -362,9 +363,20 @@
             this.bt_tdResultsClear.UseVisualStyleBackColor = true;
             this.bt_tdResultsClear.Click += new System.EventHandler(this.bt_tdResultsClear_Click);
             // 
+            // bt_clearResults
+            // 
+            this.bt_clearResults.Location = new System.Drawing.Point(751, 619);
+            this.bt_clearResults.Name = "bt_clearResults";
+            this.bt_clearResults.Size = new System.Drawing.Size(156, 92);
+            this.bt_clearResults.TabIndex = 26;
+            this.bt_clearResults.Text = "Clear Results";
+            this.bt_clearResults.UseVisualStyleBackColor = true;
+            this.bt_clearResults.Click += new System.EventHandler(this.bt_clearResults_Click);
+            // 
             // LoadDeconvolutionResults
             // 
             this.ClientSize = new System.Drawing.Size(1471, 736);
+            this.Controls.Add(this.bt_clearResults);
             this.Controls.Add(this.bt_tdResultsAdd);
             this.Controls.Add(this.bt_tdResultsClear);
             this.Controls.Add(this.bt_morpheusBUResultsAdd);
@@ -432,5 +444,6 @@
         private System.Windows.Forms.DataGridView dgv_tdFiles;
         private System.Windows.Forms.DataGridView dgv_buFiles;
         private System.Windows.Forms.CheckBox cb_td_file;
+        private System.Windows.Forms.Button bt_clearResults;
     }
 }

--- a/ProteoformSuiteGUI/LoadDeconvolutionResults.cs
+++ b/ProteoformSuiteGUI/LoadDeconvolutionResults.cs
@@ -388,5 +388,10 @@ namespace ProteoformSuite
                 }
             }
         }
+
+        private void bt_clearResults_Click(object sender, EventArgs e)
+        {
+            ((ProteoformSweet)MdiParent).clear_lists();
+        }
     }
 }

--- a/ProteoformSuiteGUI/ProteoformFamilies.cs
+++ b/ProteoformSuiteGUI/ProteoformFamilies.cs
@@ -190,7 +190,7 @@ namespace ProteoformSuite
                 MessageBox.Show("Please choose a folder in which the families will be built, so you can load them into Cytoscape.");
                 return false;
             }
-            string time_stamp = DateTime.Now.Year.ToString() + DateTime.Now.Month.ToString() + DateTime.Now.Day.ToString() + DateTime.Now.Hour.ToString() + DateTime.Now.Minute.ToString() + DateTime.Now.Second.ToString();
+            string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
             CytoscapeScript c = new CytoscapeScript(families, time_stamp);
             File.WriteAllText(c.edges_path, c.edge_table);

--- a/ProteoformSuiteGUI/ProteoformFamilies.cs
+++ b/ProteoformSuiteGUI/ProteoformFamilies.cs
@@ -27,7 +27,7 @@ namespace ProteoformSuite
         private void ProteoformFamilies_Load(object sender, EventArgs e)
         { }
 
-        public void initialize_settings()
+        private void initialize_settings()
         {
             this.tb_familyBuildFolder.Text = Lollipop.family_build_folder_path;
             this.nud_decimalRoundingLabels.Value = Convert.ToDecimal(Lollipop.deltaM_edge_display_rounding);
@@ -35,6 +35,7 @@ namespace ProteoformSuite
 
         public void construct_families()
         {
+            initialize_settings();
             if (Lollipop.proteoform_community.families.Count <= 0 && Lollipop.proteoform_community.has_e_proteoforms) run_the_gamut();
         }
 

--- a/ProteoformSuiteGUI/ProteoformSweet.Designer.cs
+++ b/ProteoformSuiteGUI/ProteoformSweet.Designer.cs
@@ -54,6 +54,7 @@
             this.runMethodToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveMethodToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.loadRunToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.loadSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -89,7 +90,7 @@
             this.openCurrentPageToolStripMenuItem,
             this.openAllToolStripMenuItem});
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
             this.openToolStripMenuItem.Text = "Open";
             // 
             // openCurrentPageToolStripMenuItem
@@ -112,7 +113,7 @@
             this.saveCurrentPageToolStripMenuItem,
             this.saveAllToolStripMenuItem1});
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
             this.saveToolStripMenuItem.Text = "Save";
             // 
             // saveCurrentPageToolStripMenuItem
@@ -139,14 +140,14 @@
             // printToolStripMenuItem
             // 
             this.printToolStripMenuItem.Name = "printToolStripMenuItem";
-            this.printToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.printToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
             this.printToolStripMenuItem.Text = "Print";
             this.printToolStripMenuItem.Click += new System.EventHandler(this.printToolStripMenuItem_Click);
             // 
             // closeToolStripMenuItem
             // 
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
-            this.closeToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.closeToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
             this.closeToolStripMenuItem.Text = "Close";
             this.closeToolStripMenuItem.Click += new System.EventHandler(this.closeToolStripMenuItem_Click);
             // 
@@ -241,6 +242,7 @@
             // 
             this.runMethodToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.saveMethodToolStripMenuItem1,
+            this.loadSettingsToolStripMenuItem,
             this.loadRunToolStripMenuItem});
             this.runMethodToolStripMenuItem.Name = "runMethodToolStripMenuItem";
             this.runMethodToolStripMenuItem.Size = new System.Drawing.Size(61, 22);
@@ -249,16 +251,23 @@
             // saveMethodToolStripMenuItem1
             // 
             this.saveMethodToolStripMenuItem1.Name = "saveMethodToolStripMenuItem1";
-            this.saveMethodToolStripMenuItem1.Size = new System.Drawing.Size(143, 22);
+            this.saveMethodToolStripMenuItem1.Size = new System.Drawing.Size(152, 22);
             this.saveMethodToolStripMenuItem1.Text = "Save Method";
             this.saveMethodToolStripMenuItem1.Click += new System.EventHandler(this.saveMethodToolStripMenuItem1_Click);
             // 
             // loadRunToolStripMenuItem
             // 
             this.loadRunToolStripMenuItem.Name = "loadRunToolStripMenuItem";
-            this.loadRunToolStripMenuItem.Size = new System.Drawing.Size(143, 22);
+            this.loadRunToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
             this.loadRunToolStripMenuItem.Text = "Load && Run";
             this.loadRunToolStripMenuItem.Click += new System.EventHandler(this.loadRunToolStripMenuItem_Click);
+            // 
+            // loadSettingsToolStripMenuItem
+            // 
+            this.loadSettingsToolStripMenuItem.Name = "loadSettingsToolStripMenuItem";
+            this.loadSettingsToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.loadSettingsToolStripMenuItem.Text = "Load Settings";
+            this.loadSettingsToolStripMenuItem.Click += new System.EventHandler(this.loadSettingsToolStripMenuItem_Click);
             // 
             // ProteoformSweet
             // 
@@ -308,6 +317,7 @@
         private System.Windows.Forms.ToolStripMenuItem saveCurrentPageToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveAllToolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem exportTablesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem loadSettingsToolStripMenuItem;
     }
 }
 

--- a/ProteoformSuiteGUI/ProteoformSweet.cs
+++ b/ProteoformSuiteGUI/ProteoformSweet.cs
@@ -423,7 +423,7 @@ namespace ProteoformSuite
     
 
         // MISCELLANEOUS
-        private void clear_lists()
+        public void clear_lists()
         {
             Lollipop.raw_experimental_components.Clear();
             Lollipop.raw_neucode_pairs.Clear();

--- a/ProteoformSuiteGUI/ProteoformSweet.cs
+++ b/ProteoformSuiteGUI/ProteoformSweet.cs
@@ -114,7 +114,7 @@ namespace ProteoformSuite
             else if (results_folder == DialogResult.Cancel) return;
             else return;
 
-            foreach (string setting_spec in File.ReadAllLines(working_directory + "\\_method.txt")) Lollipop.load_setting(setting_spec.Trim());
+            SaveState.open_method(File.ReadAllLines(working_directory + "\\_method.xml"));
             
             Lollipop.opening_results = true;
             Lollipop.opened_results_originally = true;
@@ -258,23 +258,6 @@ namespace ProteoformSuite
             }
         }
 
-
-        private bool openMethod()
-        {
-            DialogResult dr = this.methodFileOpen.ShowDialog();
-            if (dr == System.Windows.Forms.DialogResult.OK)
-            {
-                string method_filename = methodFileOpen.FileName;
-                ResultsSummary.loadDescription = method_filename;
-                foreach (string setting_spec in File.ReadAllLines(method_filename))
-                {
-                    Lollipop.load_setting(setting_spec.Trim());
-                }
-                return true;
-            }
-            return false;
-        }
-
         private void saveCurrentPageToolStripMenuItem_Click(object sender, EventArgs e)
         {
             string working_directory;
@@ -294,9 +277,9 @@ namespace ProteoformSuite
             DialogResult results_folder = this.resultsFolderOpen.ShowDialog();
             if (results_folder == DialogResult.OK) working_directory = this.resultsFolderOpen.SelectedPath;
             else return;
-            saveMethod(working_directory + "\\_method.txt");
+            saveMethod(working_directory + "\\_method.xml");
             save_tsv(working_directory, true);
-            File.Copy(ProteomeDatabaseReader.oldPtmlistFilePath, working_directory + "\\ptmlist.txt");
+            File.Copy(ProteomeDatabaseReader.oldPtmlistFilePath, working_directory + "\\ptmlist.txt", true);
             MessageBox.Show("Successfully saved all pages.");
         }
 
@@ -363,7 +346,25 @@ namespace ProteoformSuite
         private void saveMethod(string method_filename)
         {
             using (StreamWriter file = new StreamWriter(method_filename))
-                file.WriteLine(Lollipop.method_toString());
+                file.WriteLine(SaveState.save_method());
+        }
+
+        private void loadSettingsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            load_method();
+        }
+
+        private bool load_method()
+        {
+            DialogResult dr = this.methodFileOpen.ShowDialog();
+            if (dr == System.Windows.Forms.DialogResult.OK)
+            {
+                string method_filename = methodFileOpen.FileName;
+                ResultsSummary.loadDescription = method_filename;
+                SaveState.open_method(File.ReadAllLines(method_filename));
+                return true;
+            }
+            return false;
         }
 
         private void loadRunToolStripMenuItem_Click(object sender, EventArgs e)
@@ -376,12 +377,17 @@ namespace ProteoformSuite
             var result = MessageBox.Show("Choose a method file.", "Method Load and Run", MessageBoxButtons.OKCancel);
             if (result == DialogResult.Cancel) return;
 
-            bool successful_opening = openMethod();
-            if (!successful_opening) return;
+            if (!load_method()) return;
             MessageBox.Show("Successfully loaded method. Will run the method now.\n\nWill show as non-responsive.");
-            bool successful_run = full_run();
-            if (successful_run) { MessageBox.Show("Successfully ran method. Feel free to explore using the Results menu."); }
-            else { MessageBox.Show("Method did not successfully run."); }
+
+            if (full_run())
+            {
+                MessageBox.Show("Successfully ran method. Feel free to explore using the Results menu.");
+            }
+            else
+            {
+                MessageBox.Show("Method did not successfully run.");
+            }
         }
 
         public bool full_run()

--- a/ProteoformSuiteGUI/ProteoformSweet.cs
+++ b/ProteoformSuiteGUI/ProteoformSweet.cs
@@ -79,20 +79,22 @@ namespace ProteoformSuite
         private void aggregatedProteoformsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             showForm(aggregatedProteoforms);
+            aggregatedProteoforms.aggregate_proteoforms();
         }
         private void theoreticalProteoformDatabaseToolStripMenuItem_Click(object sender, EventArgs e) { showForm(theoreticalDatabase); }
         private void experimentTheoreticalComparisonToolStripMenuItem_Click(object sender, EventArgs e)
         {
             showForm(experimentalTheoreticalComparison);
+            experimentalTheoreticalComparison.compare_et();
         }
         private void experimentExperimentComparisonToolStripMenuItem_Click(object sender, EventArgs e)
         {
             showForm(experimentExperimentComparison);
+            experimentExperimentComparison.compare_ee();
         }
         private void proteoformFamilyAssignmentToolStripMenuItem_Click(object sender, EventArgs e)
         {
             showForm(proteoformFamilies);
-            proteoformFamilies.initialize_settings();
             proteoformFamilies.construct_families();
         }
         private void quantificationToolStripMenuItem_Click(object sender, EventArgs e) { showForm(quantification); }

--- a/ProteoformSuiteInternal/Lollipop.cs
+++ b/ProteoformSuiteInternal/Lollipop.cs
@@ -25,12 +25,6 @@ namespace ProteoformSuiteInternal
 
         //RAW EXPERIMENTAL COMPONENTS
         public static List<InputFile> input_files = new List<InputFile>();
-        public static IEnumerable<InputFile> identification_files() { return input_files.Where(f => f.purpose == Purpose.Identification); }
-        public static IEnumerable<InputFile> quantification_files() { return input_files.Where(f => f.purpose == Purpose.Quantification); }
-        public static IEnumerable<InputFile> calibration_files() { return input_files.Where(f => f.purpose == Purpose.Calibration); }
-        public static IEnumerable<InputFile> bottomup_files() { return input_files.Where(f => f.purpose == Purpose.BottomUp); }
-        public static IEnumerable<InputFile> topdown_files() { return input_files.Where(f => f.purpose == Purpose.TopDown); }
-        public static IEnumerable<InputFile> topdownID_files() { return input_files.Where(f => f.purpose == Purpose.TopDownIDResults); }
         public static List<Correction> correctionFactors = null;
         public static List<int> MS1_scans = new List<int>();
         public static List<Component> raw_experimental_components = new List<Component>();
@@ -39,6 +33,14 @@ namespace ProteoformSuiteInternal
         public static bool neucode_labeled = true;
         public static bool td_results = false;
 
+        //input file auxillary methods
+        public static IEnumerable<InputFile> identification_files() { return input_files.Where(f => f.purpose == Purpose.Identification); }
+        public static IEnumerable<InputFile> quantification_files() { return input_files.Where(f => f.purpose == Purpose.Quantification); }
+        public static IEnumerable<InputFile> calibration_files() { return input_files.Where(f => f.purpose == Purpose.Calibration); }
+        public static IEnumerable<InputFile> bottomup_files() { return input_files.Where(f => f.purpose == Purpose.BottomUp); }
+        public static IEnumerable<InputFile> topdown_files() { return input_files.Where(f => f.purpose == Purpose.TopDown); }
+        public static IEnumerable<InputFile> topdownID_files() { return input_files.Where(f => f.purpose == Purpose.TopDownIDResults); }
+       
         public static void process_raw_components()
         {
             if (input_files.Any(f => f.purpose == Purpose.Calibration))
@@ -540,93 +542,5 @@ namespace ProteoformSuiteInternal
         //PROTEOFORM FAMILIES -- see ProteoformCommunity
         public static string family_build_folder_path = "";
         public static int deltaM_edge_display_rounding = 2;
-
-        //METHOD FILE
-        public static string method_toString()
-        {
-            string method = String.Join(System.Environment.NewLine, new string[] {            
-                "NeuCodePairs|max_intensity_ratio\t" + max_intensity_ratio.ToString(),
-                "NeuCodePairs|min_intensity_ratio\t" + min_intensity_ratio.ToString(),
-                "NeuCodePairs|max_lysine_ct\t" + max_lysine_ct.ToString(),
-                "NeuCodePairs|min_lysine_ct\t" + min_lysine_ct.ToString(),
-                "AggregatedProteoforms|mass_tolerance\t" + mass_tolerance.ToString(),
-                "AggregatedProteoforms|retention_time_tolerance\t" + retention_time_tolerance.ToString(),
-                "AggregatedProteoforms|missed_monos\t" + missed_monos.ToString(),
-                "AggregatedProteoforms|missed_lysines\t" + missed_lysines.ToString(),
-                "AggregatedProteoforms|min_rel_abundance\t" + min_rel_abundance.ToString(),
-                "AggregatedProteoforms|min_num_CS\t" + min_num_CS.ToString(),
-                "AggregatedProteoforms|min_agg_count\t" + min_agg_count.ToString(),
-                "TheoreticalDatabase|uniprot_xml_filepath\t" + uniprot_xml_filepath,
-                "TheoreticalDatabase|ptmlist_filepath\t" + ptmlist_filepath,
-                "TheoreticalDatabase|methionine_oxidation\t" + methionine_oxidation.ToString(),
-                "TheoreticalDatabase|carbamidomethylation\t" + carbamidomethylation.ToString(),
-                "TheoreticalDatabase|methionine_cleavage\t" + methionine_cleavage.ToString(),
-                "TheoreticalDatabase|neucode_light_lysine\t" + neucode_light_lysine.ToString(),
-                "TheoreticalDatabase|neucode_heavy_lysine\t" + neucode_heavy_lysine.ToString(),
-                "TheoreticalDatabase|natural_lysine_isotope_abundance\t" + natural_lysine_isotope_abundance.ToString(),
-                "TheoreticalDatabase|max_ptms\t" + max_ptms.ToString(),
-                "TheoreticalDatabase|decoy_databases\t" + decoy_databases.ToString(),
-                "TheoreticalDatabase|min_peptide_length\t" + min_peptide_length.ToString(),
-                "TheoreticalDatabase|combine_identical_sequences\t" + combine_identical_sequences.ToString(),
-                "Comparisons|no_mans_land_lowerBound\t" + no_mans_land_lowerBound.ToString(),
-                "Comparisons|no_mans_land_upperBound\t" + no_mans_land_upperBound.ToString(),
-                "Comparisons|ee_max_mass_difference\t" + ee_max_mass_difference.ToString(),
-                "Comparisons|et_low_mass_difference\t" + et_low_mass_difference.ToString(),
-                "Comparisons|et_high_mass_difference\t" + et_high_mass_difference.ToString(),
-                "Comparisons|relation_group_centering_iterations\t" + relation_group_centering_iterations.ToString(),
-                "Comparisons|peak_width_base_ee\t" + peak_width_base_ee.ToString(),
-                "Comparisons|peak_width_base_et\t" + peak_width_base_et.ToString(),
-                "Comparisons|min_peak_count_ee\t" + min_peak_count_ee.ToString(),
-                "Comparisons|min_peak_count_et\t" + min_peak_count_et.ToString(),
-                "Comparisons|ee_max_RetentionTime_difference\t" + ee_max_RetentionTime_difference.ToString(),
-                "Families|family_build_folder_path\t" + family_build_folder_path, 
-                "Families|deltaM_edge_display_rounding\t" + deltaM_edge_display_rounding.ToString()    
-            });
-            return method; 
-        }
-
-        public static bool use_method_files = true;
-        public static void load_setting(string setting_spec)
-        {
-            string[] fields = setting_spec.Split('\t');
-            switch (fields[0])
-            {
-                case "NeuCodePairs|max_intensity_ratio": max_intensity_ratio = Convert.ToDecimal(fields[1]); break;
-                case "NeuCodePairs|min_intensity_ratio": min_intensity_ratio = Convert.ToDecimal(fields[1]); break;
-                case "NeuCodePairs|max_lysine_ct": max_lysine_ct = Convert.ToDecimal(fields[1]); break;
-                case "NeuCodePairs|min_lysine_ct": min_lysine_ct = Convert.ToDecimal(fields[1]); break;
-                case "AggregatedProteoforms|mass_tolerance": mass_tolerance = Convert.ToDecimal(fields[1]); break;
-                case "AggregatedProteoforms|retention_time_tolerance": retention_time_tolerance = Convert.ToDecimal(fields[1]); break;
-                case "AggregatedProteoforms|missed_monos": missed_monos = Convert.ToDecimal(fields[1]); break;
-                case "AggregatedProteoforms|missed_lysines": missed_lysines = Convert.ToDecimal(fields[1]); break;
-                case "AggregatedProteoforms|min_rel_abundance": min_rel_abundance = Convert.ToDouble(fields[1]); break;
-                case "AggregatedProteoforms|min_num_CS": min_num_CS = Convert.ToInt16(fields[1]); break;
-                case "AggregatedProteoforms|min_agg_count": min_agg_count = Convert.ToInt16(fields[1]); break;
-                case "TheoreticalDatabase|uniprot_xml_filepath": if (fields.Length > 1) uniprot_xml_filepath = fields[1]; break; //make sure path listed
-                case "TheoreticalDatabase|ptmlist_filepath": if (fields.Length > 1) ptmlist_filepath = fields[1]; break;
-                case "TheoreticalDatabase|methionine_oxidation": methionine_oxidation = Convert.ToBoolean(fields[1]); break;
-                case "TheoreticalDatabase|carbamidomethylation": carbamidomethylation = Convert.ToBoolean(fields[1]); break;
-                case "TheoreticalDatabase|methionine_cleavage": methionine_cleavage = Convert.ToBoolean(fields[1]); break;
-                case "TheoreticalDatabase|neucode_light_lysine": neucode_light_lysine = Convert.ToBoolean(fields[1]); break;
-                case "TheoreticalDatabase|neucode_heavy_lysine": neucode_heavy_lysine = Convert.ToBoolean(fields[1]); break;
-                case "TheoreticalDatabase|natural_lysine_isotope_abundance": natural_lysine_isotope_abundance = Convert.ToBoolean(fields[1]); break;
-                case "TheoreticalDatabase|combine_identical_sequences": combine_identical_sequences = Convert.ToBoolean(fields[1]); break;
-                case "TheoreticalDatabase|max_ptms": max_ptms = Convert.ToInt32(fields[1]); break;
-                case "TheoreticalDatabase|decoy_databases": decoy_databases = Convert.ToInt32(fields[1]); break;
-                case "TheoreticalDatabase|min_peptide_length": min_peptide_length = Convert.ToInt32(fields[1]); break;
-                case "Comparisons|no_mans_land_lowerBound": no_mans_land_lowerBound = Convert.ToDouble(fields[1]); break;
-                case "Comparisons|no_mans_land_upperBound": no_mans_land_upperBound = Convert.ToDouble(fields[1]); break;
-                case "Comparisons|peak_width_base_ee": peak_width_base_ee = Convert.ToDouble(fields[1]); break;
-                case "Comparisons|peak_width_base_et": peak_width_base_et = Convert.ToDouble(fields[1]); break;
-                case "Comparisons|min_peak_count_ee": min_peak_count_ee = Convert.ToDouble(fields[1]); break;
-                case "Comparisons|min_peak_count_et": min_peak_count_et = Convert.ToDouble(fields[1]); break;
-                case "Comparisons|ee_max_RetentionTime_difference": ee_max_RetentionTime_difference = Convert.ToDouble(fields[1]); break;
-                case "Comparisons|ee_max_mass_difference": ee_max_mass_difference = Convert.ToDouble(fields[1]); break;
-                case "Comprisons|et_high_mass_diffrence": et_high_mass_difference = Convert.ToDouble(fields[1]); break;
-                case "Comparisons|et_low_mass_difference": et_low_mass_difference = Convert.ToDouble(fields[1]); break;
-                case "Families|family_build_folder_path": if (fields.Length > 1) family_build_folder_path = fields[1]; break; //still works if no path
-                case "Families|deltaM_edge_display_rounding": deltaM_edge_display_rounding = Convert.ToInt32(fields[1]); break;
-            }
-        }
     }
 }

--- a/ProteoformSuiteInternal/ProteoformCommunity.cs
+++ b/ProteoformSuiteInternal/ProteoformCommunity.cs
@@ -9,8 +9,9 @@ namespace ProteoformSuiteInternal
 {
     public class ProteoformCommunity
     {
-        public ExperimentalProteoform[] experimental_proteoforms { get; set; } = new ExperimentalProteoform[0];
-        public TheoreticalProteoform[] theoretical_proteoforms { get; set; } = new TheoreticalProteoform[0];
+        //Please do not list {get;set} for new fields, so they are properly recorded in save all AC161103
+        public ExperimentalProteoform[] experimental_proteoforms = new ExperimentalProteoform[0];
+        public TheoreticalProteoform[] theoretical_proteoforms = new TheoreticalProteoform[0];
         public bool has_e_proteoforms
         {
             get { return experimental_proteoforms.Length > 0; }
@@ -23,7 +24,7 @@ namespace ProteoformSuiteInternal
         public List<ProteoformRelation> relations_in_peaks = new List<ProteoformRelation>();
         public List<DeltaMassPeak> delta_mass_peaks = new List<DeltaMassPeak>();
         public List<ProteoformFamily> families = new List<ProteoformFamily>();
-        public static double maximum_delta_mass_peak_fdr = 25;
+        //public static double maximum_delta_mass_peak_fdr = 25;
 
         //BUILDING RELATIONSHIPS
         public List<ProteoformRelation> relate_et(Proteoform[] pfs1, Proteoform[] pfs2, ProteoformComparison relation_type)

--- a/ProteoformSuiteInternal/ProteoformSuiteInternal.csproj
+++ b/ProteoformSuiteInternal/ProteoformSuiteInternal.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Psm.cs" />
     <Compile Include="RandomExtensions.cs" />
     <Compile Include="Results.cs" />
+    <Compile Include="SaveState.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/ProteoformSuiteInternal/SaveState.cs
+++ b/ProteoformSuiteInternal/SaveState.cs
@@ -1,0 +1,270 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using System.Reflection;
+using System.IO;
+
+namespace ProteoformSuiteInternal
+{
+    public class SaveState
+    {
+        public static Lollipop default_settings = new Lollipop();
+
+        //BASICS FOR XML WRITING
+        public static XmlWriterSettings xmlWriterSettings = new XmlWriterSettings()
+        {
+            Indent = true,
+            IndentChars = "  "
+        };
+
+        public static string time_stamp()
+        {
+            return DateTime.Now.Year.ToString("0000") + "-" + DateTime.Now.Month.ToString("00") + "-" + DateTime.Now.Day.ToString("00") + "-" + DateTime.Now.Hour.ToString("00") + "-" + DateTime.Now.Minute.ToString("00") + "-" + DateTime.Now.Second.ToString("00");
+        }
+
+        private static void initialize_doc(XmlWriter writer)
+        {
+            writer.WriteStartDocument();
+            writer.WriteStartElement("proteoform_suite");
+            writer.WriteAttributeString("documentVersion", "0.01");
+            writer.WriteAttributeString("id", time_stamp());
+        }
+
+        private static void finalize_doc(XmlWriter writer)
+        {
+            writer.WriteEndElement();
+            writer.WriteEndDocument();
+        }
+
+        private static string GetAttribute(XElement element, string attribute_name)
+        {
+            XAttribute attribute = element.Attributes().FirstOrDefault(a => a.Name.LocalName == attribute_name);
+            return attribute == null ? "" : attribute.Value;
+        }
+
+        //METHOD SAVE/LOAD
+        public static StringBuilder save_method(StringBuilder builder)
+        {
+            using (XmlWriter writer = XmlWriter.Create(builder, xmlWriterSettings))
+            {
+                initialize_doc(writer);
+                add_settings(writer);
+                finalize_doc(writer);
+            }
+            return builder;
+        }
+        public static StringBuilder save_method()
+        {
+            return save_method(new StringBuilder());
+        }
+
+        private static void add_settings(XmlWriter writer)
+        {
+            //Gather field type, name, values that are not constants, which are literal, i.e. set at compile time
+            //Note that fields do not have {get;set;} methods, where Properties do.
+            foreach (FieldInfo field in typeof(Lollipop).GetFields().Where(f => !f.IsLiteral))
+            {
+                if (field.FieldType == typeof(int) ||
+                    field.FieldType == typeof(double) ||
+                    field.FieldType == typeof(string) ||
+                    field.FieldType == typeof(decimal) ||
+                    field.FieldType == typeof(bool))
+                {
+                    writer.WriteStartElement("setting");
+                    writer.WriteAttributeString("field_type", field.FieldType.FullName);
+                    writer.WriteAttributeString("field_name", field.Name);
+                    writer.WriteAttributeString("field_default", field.GetValue(default_settings).ToString());
+                    writer.WriteAttributeString("field_value", field.GetValue(null).ToString());
+                    writer.WriteEndElement();
+                }
+            }
+        }
+
+        public static void open_method(string text)
+        {
+            FieldInfo[] lollipop_fields = typeof(Lollipop).GetFields();
+            List<XElement> settings = new List<XElement>();
+            using (XmlReader reader = XmlReader.Create(new StringReader(text)))
+            {
+                reader.MoveToContent();
+                while (reader.Read())
+                {
+                    if (reader.NodeType == XmlNodeType.Element)
+                    {
+                        if (reader.Name == "setting") settings.Add(XElement.ReadFrom(reader) as XElement);
+                        else return; //Settings come first. Return when done
+                    }
+                }
+            }
+
+            foreach (XElement setting in settings)
+            {
+                string type_string = GetAttribute(setting, "field_type");
+                Type type = Type.GetType(type_string); //Takes only full name of type
+                string name = GetAttribute(setting, "field_name");
+                string value = GetAttribute(setting, "field_value");
+                lollipop_fields.FirstOrDefault(p => p.Name == name).SetValue(null, Convert.ChangeType(value, type));
+            }
+        }
+        public static void open_method(string[] lines)
+        {
+            open_method(String.Join(Environment.NewLine, lines));
+        }
+
+        //FULL SAVE STATE -- this is a start, but not implemented or tested, yet
+        public static StringBuilder save_all(StringBuilder builder)
+        {
+            using (XmlWriter writer = XmlWriter.Create(builder, xmlWriterSettings))
+            {
+                initialize_doc(writer);
+                add_settings(writer);
+                add_objects(writer);
+                finalize_doc(writer);
+            }
+            return builder;
+        }
+
+        public static StringBuilder save_all()
+        {
+            return save_all(new StringBuilder());
+        }
+
+        private static void add_objects(XmlWriter writer)
+        {
+            IEnumerable<FieldInfo> lollipop_objects = typeof(Lollipop).GetFields().Where(f => !f.IsLiteral && f.FieldType.IsClass);
+            IEnumerable<FieldInfo> lollipop_enumerables = typeof(Lollipop).GetFields().Where(f => !f.IsLiteral && f.FieldType.IsClass && f.GetValue(null) as IEnumerable != null);
+            object community = lollipop_objects.FirstOrDefault(f => f.FieldType == typeof(ProteoformCommunity)).GetValue(null); //Get the instance of community to check for enumerables. If we start making more than one community, we'll have to do this in a foreach.
+            IEnumerable<FieldInfo> community_enumerables = typeof(ProteoformCommunity).GetFields().Where(f => !f.IsLiteral && f.FieldType.IsClass && f.GetValue(community) as IEnumerable != null);
+
+            List<Type> no_negative_check = new List<Type>();
+            write_enumerable_group(typeof(KeyValuePair<string, Modification>), no_negative_check, lollipop_enumerables, writer);
+            write_enumerable_group(typeof(InputFile), no_negative_check, lollipop_enumerables, writer);
+            write_enumerable_group(typeof(Component), new List<Type> { typeof(NeuCodePair) }, lollipop_enumerables, writer);
+            write_enumerable_group(typeof(NeuCodePair), no_negative_check, lollipop_enumerables, writer);
+            write_enumerable_group(typeof(ExperimentalProteoform), no_negative_check, community_enumerables, writer);
+            write_enumerable_group(typeof(TheoreticalProteoform), no_negative_check, community_enumerables, writer);
+            write_enumerable_group(typeof(KeyValuePair<string, TheoreticalProteoform>), no_negative_check, community_enumerables, writer);
+            write_enumerable_group(typeof(ProteoformRelation), no_negative_check, lollipop_enumerables, writer);
+            write_enumerable_group(typeof(KeyValuePair<string, ProteoformRelation>), no_negative_check, lollipop_enumerables, writer);
+            write_enumerable_group(typeof(DeltaMassPeak), no_negative_check, community_enumerables, writer);
+            write_enumerable_group(typeof(ProteoformFamily), no_negative_check, community_enumerables, writer);
+        }
+
+        //There might be multiple lists with objects of a certain type, so start write out each of those lists
+        private static void write_enumerable_group(Type type, IEnumerable<Type> negative_types, IEnumerable<FieldInfo> context, XmlWriter writer)
+        {
+            IEnumerable<FieldInfo> enumerables = context.Where(e => e.GetType().GetGenericArguments()[0] == type && !negative_types.Contains(e.GetType().GetGenericArguments()[0]));
+            foreach (FieldInfo field in enumerables) write_enumerable(field, field.GetValue(null), writer);
+        }
+
+        //Given a list of a certain type, write out the elements of that list
+        private static void write_enumerable(FieldInfo field, object a, XmlWriter writer)
+        {
+            writer.WriteStartElement("enumerable");
+            writer.WriteAttributeString("field_type", field.FieldType.FullName);
+            writer.WriteAttributeString("field_name", field.Name);
+            IEnumerable<Type> exclusion_list = get_exclusion_lists()[field.FieldType.FullName];
+            foreach (object item in a as IEnumerable) write_object_properties(field.FieldType, exclusion_list, item, writer);
+            writer.WriteEndElement();
+        }
+
+        //For an object in a list, write out the object properties, maintaining the same exclusion list
+        private static void write_object_properties(Type type, IEnumerable<Type> exclusion_list, object a, XmlWriter writer)
+        {
+            foreach (PropertyInfo property in type.GetProperties()) //get all of the properties of this object type
+            {
+                 Type property_type = property.PropertyType;
+                string type_name = property_type.FullName;
+                string property_name = property.Name;
+                if (property.GetValue(a) as IEnumerable != null)
+                {
+                    writer.WriteStartElement("enumerable");
+                    writer.WriteAttributeString("property_type", type_name);
+                    writer.WriteAttributeString("property_name", property_name);
+                    if (!exclusion_list.Contains(property.GetType().GetGenericArguments()[0]))
+                        foreach (object item in property.GetValue(null) as IEnumerable) write_object_properties(property_type, exclusion_list, property.GetValue(item), writer);
+                    writer.WriteEndElement();
+                }
+                else if (property_type.IsClass) //If not an enumerable, is it still a class?
+                {
+                    writer.WriteStartElement("object");
+                    writer.WriteAttributeString("property_type", type_name);
+                    writer.WriteAttributeString("property_name", property_name);
+                    if (!exclusion_list.Contains(property_type))
+                        write_object_properties(property_type, exclusion_list, property.GetValue(a), writer);
+                    writer.WriteEndElement();
+                }
+                else
+                {
+                    writer.WriteStartElement("scalar");
+                    writer.WriteAttributeString("property_type", type_name);
+                    writer.WriteAttributeString("property_name", property_name);
+                    writer.WriteAttributeString("property_value", property.GetValue(a).ToString());
+                    writer.WriteEndElement();
+                }
+            }
+        }
+
+        //Exclusion list for each type, so that we don't write info that isn't needed to construct the heirarchy of objects
+        private static Dictionary<string, IEnumerable<Type>> get_exclusion_lists()
+        {
+            Dictionary<string, IEnumerable<Type>> exclusion_list = new Dictionary<string, IEnumerable<Type>>();
+
+            //Exclude stuff contained in Components from NeuCodePairs and ExperimentalProteoforms
+            exclusion_list.Add(typeof(NeuCodePair).FullName, 
+                new List<Type> { typeof(ChargeState), typeof(InputFile) }
+                .Concat(typeof(ChargeState).GetProperties().Where(p => p.PropertyType.IsClass).Select(p => p.PropertyType))
+                .Concat(typeof(InputFile).GetProperties().Where(p => p.PropertyType.IsClass).Select(p => p.PropertyType)));
+            exclusion_list.Add(typeof(ExperimentalProteoform).FullName, exclusion_list[typeof(NeuCodePair).FullName]);
+
+            //Also exclude stuff contained in TheoreticalProteoforms from relations, peaks, and families
+            exclusion_list.Add(typeof(ProteoformRelation).FullName, exclusion_list[typeof(ExperimentalProteoform).FullName]);
+            exclusion_list[typeof(ProteoformRelation).FullName]
+                .Concat(typeof(TheoreticalProteoform).GetProperties().Where(p => p.PropertyType.IsClass).Select(p => p.PropertyType));
+            exclusion_list.Add(typeof(DeltaMassPeak).FullName, exclusion_list[typeof(ProteoformRelation).FullName]);
+            exclusion_list.Add(typeof(ProteoformFamily).FullName, exclusion_list[typeof(ProteoformRelation).FullName]);
+
+            return exclusion_list;
+        }
+
+        //OPEN SAVE STATE -- incomplete
+        //Requires that each field with a complex setter method also have a field that can be directly set.
+        public static void open_all(string text, string path)
+        {
+            FieldInfo[] lollipop_fields = typeof(Lollipop).GetFields();
+            List<XElement> settings = new List<XElement>();
+            string ptmlist = "";
+            List<XElement> enumerables = new List<XElement>();
+            using (XmlReader reader = XmlReader.Create(new StringReader(text)))
+            {
+                reader.MoveToContent();
+                while (reader.Read())
+                {
+                    if (reader.NodeType == XmlNodeType.Element)
+                    {
+                        if (reader.Name == "setting") settings.Add(XElement.ReadFrom(reader) as XElement);
+                        else if (reader.Name == "ptmlist") ptmlist = (XElement.ReadFrom(reader) as XElement).Value;
+                        else if (reader.Name == "enumerable") enumerables.Add(XElement.ReadFrom(reader) as XElement);
+                        else return; //that's it for now
+                    }
+                }
+            }
+
+            foreach (XElement setting in settings)
+            {
+                string type_string = GetAttribute(setting, "field_type");
+                Type type = Type.GetType(type_string); //Takes only full name of type
+                string name = GetAttribute(setting, "field_name");
+                string value = GetAttribute(setting, "field_value");
+                lollipop_fields.FirstOrDefault(p => p.Name == name).SetValue(null, Convert.ChangeType(value, type));
+            }
+
+
+        }
+    }
+}

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -79,6 +79,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TestSaveState.cs" />
     <Compile Include="TestExperimentalProteoform.cs" />
     <Compile Include="TestFindRawComponentsAndNeuCodePairs.cs" />
     <Compile Include="TestCorrectionFactorInterpolation.cs" />

--- a/Test/TestLoadAndRun.cs
+++ b/Test/TestLoadAndRun.cs
@@ -13,7 +13,6 @@ namespace Test
     class TestLoadAndRun
     {
         [Test]
-
         public void test_load_and_run()
         {
             //set parameters -- change some parameters to other than the current defaults... 
@@ -35,7 +34,7 @@ namespace Test
             Lollipop.ee_max_RetentionTime_difference = 10;
 
             //save method
-            string saved_method = Lollipop.method_toString();
+            string saved_method = SaveState.save_method().ToString();
 
             //change parameters back to defaults
             Lollipop.min_intensity_ratio = 1.4m;
@@ -51,10 +50,7 @@ namespace Test
             Lollipop.ee_max_RetentionTime_difference = 2.5;
             Lollipop.peak_width_base_ee = 0.015;
             //load method --> should switch parametetrs to saved 
-            foreach (string setting_spec in saved_method.Split('\n'))
-            {
-                Lollipop.load_setting(setting_spec.Trim());
-            }
+            SaveState.open_method(saved_method);
 
             //tests that the method settings properly a) saved b)loaded up above
             Assert.AreEqual(3, Lollipop.min_lysine_ct);
@@ -74,7 +70,6 @@ namespace Test
             Assert.AreEqual(0.001, Lollipop.peak_width_base_ee);
             Assert.AreEqual(10, Lollipop.ee_max_RetentionTime_difference);
         }
-
     }
 }
 

--- a/Test/TestSaveState.cs
+++ b/Test/TestSaveState.cs
@@ -1,0 +1,92 @@
+﻿using NUnit.Framework;
+using ProteoformSuiteInternal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Reflection;
+
+namespace Test
+{
+    [TestFixture]
+    class TestSaveState
+    {
+        [OneTimeSetUp]
+        public void setup()
+        {
+            Environment.CurrentDirectory = TestContext.CurrentContext.TestDirectory;
+        }
+
+        //[Test]
+        //public void save_and_load_grouped_components()
+        //{
+        //    //reading in test excel file, process raw components before testing neucode pairs.
+        //    Lollipop.correctionFactors = null;
+        //    Lollipop.raw_experimental_components.Clear();
+        //    Func<InputFile, IEnumerable<Component>> componentReader = c => new ExcelReader().read_components_from_xlsx(c, Lollipop.correctionFactors);
+        //    Lollipop.input_files.Add(new InputFile("UnitTestFiles\\noisy.xlsx", Labeling.NeuCode, Purpose.Identification));
+
+        //    string inFileId = Lollipop.input_files[0].UniqueId.ToString();
+
+        //    Lollipop.neucode_labeled = true;
+        //    Lollipop.process_raw_components();
+        //    Assert.AreEqual(224, Lollipop.raw_experimental_components.Count);
+        //    Lollipop.raw_experimental_components.Clear();
+
+        //    StringBuilder builder = SaveState.save_all();
+        //    SaveState.open_all(builder.ToString().Split(new string[] { Environment.NewLine }, StringSplitOptions.None));
+        //}
+
+        [Test]
+        public void restore_lollipop_settings()
+        {
+            Lollipop defaults = new Lollipop();
+            StringBuilder builder = SaveState.save_method();
+            foreach (PropertyInfo property in typeof(Lollipop).GetProperties())
+            {
+                if (property.PropertyType == typeof(int))
+                {
+                    property.SetValue(null, Convert.ToInt32(property.GetValue(null)) + 1);
+                    Assert.AreEqual(Convert.ToInt32(property.GetValue(defaults)) + 1, Convert.ToInt32(property.GetValue(null))); //the int values were changed in the current program
+                }
+                else if (property.PropertyType == typeof(double))
+                {
+                    property.SetValue(null, Convert.ToDouble(property.GetValue(null)) + 1);
+                    Assert.AreEqual(Convert.ToDouble(property.GetValue(defaults)) + 1, Convert.ToDouble(property.GetValue(null))); //the double values were changed in the current program
+                }
+                else if (property.PropertyType == typeof(string))
+                {
+                    property.SetValue(null, property.GetValue(null).ToString() + "hello");
+                    Assert.AreEqual(property.GetValue(defaults).ToString() + "hello", Convert.ToDouble(property.GetValue(null)).ToString()); //the string values were changed in the current program
+                }
+                else if (property.PropertyType == typeof(decimal))
+                {
+                    property.SetValue(null, Convert.ToDecimal(property.GetValue(null)) + 1);
+                    Assert.AreEqual(Convert.ToDecimal(property.GetValue(defaults)) + 1, Convert.ToDecimal(property.GetValue(null))); //the decimal value were changed in the current program
+                }
+                else if (property.PropertyType == typeof(bool))
+                {
+                    property.SetValue(null, !Convert.ToBoolean(property.GetValue(null)));
+                    Assert.AreEqual(!Convert.ToBoolean(property.GetValue(defaults)), Convert.ToBoolean(property.GetValue(null))); //the bool value were changed in the current program
+                }
+                else continue;
+            }
+
+            SaveState.open_method(builder.ToString());
+            foreach (PropertyInfo property in typeof(Lollipop).GetProperties())
+            {
+                if (property.PropertyType == typeof(int))
+                    Assert.AreEqual(Convert.ToInt32(property.GetValue(defaults)), Convert.ToInt32(property.GetValue(null))); //the int values were changed back
+                else if (property.PropertyType == typeof(double))
+                    Assert.AreEqual(Convert.ToDouble(property.GetValue(defaults)), Convert.ToDouble(property.GetValue(null))); //the double values were changed back
+                else if (property.PropertyType == typeof(string))
+                    Assert.AreEqual(property.GetValue(defaults).ToString(), Convert.ToDouble(property.GetValue(null)).ToString()); //the string values were changed back
+                else if (property.PropertyType == typeof(decimal))
+                    Assert.AreEqual(Convert.ToDecimal(property.GetValue(defaults)), Convert.ToDecimal(property.GetValue(null))); //the decimal value were changed back
+                else if (property.PropertyType == typeof(bool))
+                    Assert.AreEqual(Convert.ToBoolean(property.GetValue(defaults)), Convert.ToBoolean(property.GetValue(null))); //the bool value were changed back
+                else continue;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a Clear Results button, so we can reload results and go through the process again. Might be nice for new users to try one file, and then go through with them all without having to pop open a new instance.

Restored processing upon opening a new Results page. I think we should solve the problem of not seeing a beat of life before it's done by adding background threading to the Forms. I'll add that to the Issues list if it's not already there.

(In the new SaveState class, I also included a draft of how we could Save All / Open All using XML structure. It doesn't look like it will be much more flexible than Results at this point, unlike the Method XML, which pulls out even recently added settings. With the new XSLX export, I'm not sure XML SaveState is even useful for this version-zero ProteoformSuite.)