### PR TITLE
rawlockmass updates, option to load page before processing

### DIFF
--- a/ProteoformSuiteGUI/LoadDeconvolutionResults.Designer.cs
+++ b/ProteoformSuiteGUI/LoadDeconvolutionResults.Designer.cs
@@ -57,6 +57,7 @@
             this.bt_tdResultsAdd = new System.Windows.Forms.Button();
             this.bt_tdResultsClear = new System.Windows.Forms.Button();
             this.bt_clearResults = new System.Windows.Forms.Button();
+            this.cb_run_when_load = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dgv_identificationFiles)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgv_quantitationFiles)).BeginInit();
@@ -373,9 +374,23 @@
             this.bt_clearResults.UseVisualStyleBackColor = true;
             this.bt_clearResults.Click += new System.EventHandler(this.bt_clearResults_Click);
             // 
+            // cb_run_when_load
+            // 
+            this.cb_run_when_load.AutoSize = true;
+            this.cb_run_when_load.Checked = true;
+            this.cb_run_when_load.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cb_run_when_load.Location = new System.Drawing.Point(16, 587);
+            this.cb_run_when_load.Name = "cb_run_when_load";
+            this.cb_run_when_load.Size = new System.Drawing.Size(157, 17);
+            this.cb_run_when_load.TabIndex = 27;
+            this.cb_run_when_load.Text = "Process when loading page";
+            this.cb_run_when_load.UseVisualStyleBackColor = true;
+            this.cb_run_when_load.CheckedChanged += new System.EventHandler(this.cb_run_when_load_CheckedChanged);
+            // 
             // LoadDeconvolutionResults
             // 
-            this.ClientSize = new System.Drawing.Size(1471, 736);
+            this.ClientSize = new System.Drawing.Size(1362, 736);
+            this.Controls.Add(this.cb_run_when_load);
             this.Controls.Add(this.bt_clearResults);
             this.Controls.Add(this.bt_tdResultsAdd);
             this.Controls.Add(this.bt_tdResultsClear);
@@ -445,5 +460,6 @@
         private System.Windows.Forms.DataGridView dgv_buFiles;
         private System.Windows.Forms.CheckBox cb_td_file;
         private System.Windows.Forms.Button bt_clearResults;
+        private System.Windows.Forms.CheckBox cb_run_when_load;
     }
 }

--- a/ProteoformSuiteGUI/LoadDeconvolutionResults.cs
+++ b/ProteoformSuiteGUI/LoadDeconvolutionResults.cs
@@ -32,6 +32,16 @@ namespace ProteoformSuite
         
         private void btn_neucode_CheckedChanged(object sender, EventArgs e)
         {
+            if (btn_unlabeled.Checked)
+            {
+                ProteoformSweet.run_when_form_loads = false; //if unlabeled, don't run automatically. 
+                cb_run_when_load.Checked = false;
+            }
+            else
+            {
+                ProteoformSweet.run_when_form_loads = true; //if unlabeled, don't run automatically. 
+                cb_run_when_load.Checked = true;
+            }
             ((ProteoformSweet)MdiParent).enable_neuCodeProteoformPairsToolStripMenuItem(btn_neucode.Checked);
             Lollipop.neucode_labeled = btn_neucode.Checked;
             Lollipop.neucode_light_lysine = btn_neucode.Checked;
@@ -392,6 +402,11 @@ namespace ProteoformSuite
         private void bt_clearResults_Click(object sender, EventArgs e)
         {
             ((ProteoformSweet)MdiParent).clear_lists();
+        }
+
+        private void cb_run_when_load_CheckedChanged(object sender, EventArgs e)
+        {
+            ProteoformSweet.run_when_form_loads = cb_run_when_load.Checked;
         }
     }
 }

--- a/ProteoformSuiteGUI/ProteoformSweet.cs
+++ b/ProteoformSuiteGUI/ProteoformSweet.cs
@@ -34,7 +34,9 @@ namespace ProteoformSuite
         SaveFileDialog methodFileSave = new SaveFileDialog();
         SaveFileDialog saveDialog = new SaveFileDialog();
 
-        Form current_form; 
+        Form current_form;
+
+        public static bool run_when_form_loads = true;
 
         public ProteoformSweet()
         {
@@ -79,18 +81,18 @@ namespace ProteoformSuite
         private void aggregatedProteoformsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             showForm(aggregatedProteoforms);
-            aggregatedProteoforms.aggregate_proteoforms();
+            if (run_when_form_loads) aggregatedProteoforms.aggregate_proteoforms();
         }
         private void theoreticalProteoformDatabaseToolStripMenuItem_Click(object sender, EventArgs e) { showForm(theoreticalDatabase); }
         private void experimentTheoreticalComparisonToolStripMenuItem_Click(object sender, EventArgs e)
         {
             showForm(experimentalTheoreticalComparison);
-            experimentalTheoreticalComparison.compare_et();
+            if (run_when_form_loads) experimentalTheoreticalComparison.compare_et();
         }
         private void experimentExperimentComparisonToolStripMenuItem_Click(object sender, EventArgs e)
         {
             showForm(experimentExperimentComparison);
-            experimentExperimentComparison.compare_ee();
+            if (run_when_form_loads) experimentExperimentComparison.compare_ee();
         }
         private void proteoformFamilyAssignmentToolStripMenuItem_Click(object sender, EventArgs e)
         {

--- a/ProteoformSuiteInternal/Lollipop.cs
+++ b/ProteoformSuiteInternal/Lollipop.cs
@@ -131,14 +131,10 @@ namespace ProteoformSuiteInternal
             for (int i = 1; i < correction_lines.Length; i++)
             {
                 string[] parts = correction_lines[i].Split('\t');
-                if (parts.Length < 3) continue;
+                if (parts.Length < 2) continue;
                 int scan_number = Convert.ToInt32(parts[0]);
                 double correction = Double.NaN;
-                //two corrections can be available for each scan. The correction in column 3 is preferred
-                //if column three is NaN, then column 2 is selected.
-                //if column 2 is also NaN, then the correction for the scan will be interpolated from adjacent scans
-                correction = Convert.ToDouble(parts[2]);
-                if (Double.IsNaN(correction)) correction = Convert.ToDouble(parts[1]);
+                correction = Convert.ToDouble(parts[1]);
                 yield return new Correction(filename, scan_number, correction);
             }
         }


### PR DESCRIPTION
Stefan's most recent version of rawlockmass only has one column of shifts - he said he found that it didn't make a big difference trying to make the second column. Now just reads in the one column 
Also for label free I like adjusting parameteres before running forms since sometimes it's really slow so that's an option (default set to false, switches to true if you set unlabeled but can also be false for unlabeled if you want)