### PR TITLE
FDR displayed & cleaned up outdated td code

### DIFF
--- a/Examples/ptmlist.txt
+++ b/Examples/ptmlist.txt
@@ -9,7 +9,7 @@
 
 Description: Controlled vocabulary of posttranslational modifications (PTM)
 Name:        ptmlist.txt
-Release:     2016_10 of 02-Nov-2016
+Release:     2017_01 of 18-Jan-2017
 
 ---------------------------------------------------------------------------
 
@@ -5294,6 +5294,49 @@ KW   Palmitate.
 DR   RESID; AA0079.
 DR   PSI-MOD; 00088.
 //
+ID   O-UMP-histidine
+AC   PTM-0500
+FT   MOD_RES
+TG   Histidine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C9 H11 N2 O8 P1
+MM   306.025302
+MA   306.17
+LC   Intracellular localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+KW   Nucleotide-binding; Phosphoprotein.
+DR   RESID; AA0372.
+DR   PSI-MOD; 00377.
+//
+ID   O-UMP-serine
+AC   PTM-0501
+FT   MOD_RES
+TG   Serine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C9 H11 N2 O8 P1
+MM   306.025302
+MA   306.17
+LC   Intracellular localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+TR   Eukaryota; taxId:33090 (Viridiplantae).
+KW   Nucleotide-binding; Phosphoprotein.
+//
+ID   O-UMP-threonine
+AC   PTM-0502
+FT   MOD_RES
+TG   Threonine.
+PA   Amino acid side chain.
+PP   Anywhere.
+CF   C9 H11 N2 O8 P1
+MM   306.025302
+MA   306.17
+LC   Intracellular localisation.
+TR   Bacteria; taxId:2 (Bacteria).
+TR   Eukaryota; taxId:33090 (Viridiplantae).
+KW   Nucleotide-binding; Phosphoprotein.
+//
 ID   O-UMP-tyrosine
 AC   PTM-0333
 FT   MOD_RES
@@ -5307,6 +5350,7 @@ LC   Intracellular localisation.
 TR   Archaea; taxId:2157 (Archaea).
 TR   Bacteria; taxId:2 (Bacteria).
 TR   Eukaryota; taxId:2797 (Bangiophyceae).
+TR   Viruses and phages; taxId:10239 (Viruses).
 KW   Nucleotide-binding; Phosphoprotein.
 DR   RESID; AA0256.
 DR   PSI-MOD; 00261.

--- a/ProteoformSuiteGUI/ExperimentExperimentComparison.Designer.cs
+++ b/ProteoformSuiteGUI/ExperimentExperimentComparison.Designer.cs
@@ -73,6 +73,8 @@
             this.nUD_MaxRetTimeDifference = new System.Windows.Forms.NumericUpDown();
             this.label1 = new System.Windows.Forms.Label();
             this.splitContainer3 = new System.Windows.Forms.SplitContainer();
+            this.tb_max_accepted_fdr = new System.Windows.Forms.TextBox();
+            this.label9 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgv_EE_Peaks)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nUD_EE_Upper_Bound)).BeginInit();
@@ -257,7 +259,7 @@
             this.cb_Graph_lowerThreshold.AutoSize = true;
             this.cb_Graph_lowerThreshold.Checked = true;
             this.cb_Graph_lowerThreshold.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cb_Graph_lowerThreshold.Location = new System.Drawing.Point(52, 98);
+            this.cb_Graph_lowerThreshold.Location = new System.Drawing.Point(117, 52);
             this.cb_Graph_lowerThreshold.Name = "cb_Graph_lowerThreshold";
             this.cb_Graph_lowerThreshold.Size = new System.Drawing.Size(55, 17);
             this.cb_Graph_lowerThreshold.TabIndex = 27;
@@ -547,6 +549,8 @@
             // groupBox1
             // 
             this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.groupBox1.Controls.Add(this.tb_max_accepted_fdr);
+            this.groupBox1.Controls.Add(this.label9);
             this.groupBox1.Controls.Add(this.nUD_MaxRetTimeDifference);
             this.groupBox1.Controls.Add(this.label1);
             this.groupBox1.Controls.Add(this.nUD_PeakCountMinThreshold);
@@ -610,6 +614,26 @@
             this.splitContainer3.Size = new System.Drawing.Size(470, 660);
             this.splitContainer3.SplitterDistance = 409;
             this.splitContainer3.TabIndex = 17;
+            // 
+            // tb_max_accepted_fdr
+            // 
+            this.tb_max_accepted_fdr.Location = new System.Drawing.Point(132, 96);
+            this.tb_max_accepted_fdr.Margin = new System.Windows.Forms.Padding(2);
+            this.tb_max_accepted_fdr.Name = "tb_max_accepted_fdr";
+            this.tb_max_accepted_fdr.ReadOnly = true;
+            this.tb_max_accepted_fdr.Size = new System.Drawing.Size(86, 20);
+            this.tb_max_accepted_fdr.TabIndex = 31;
+            // 
+            // label9
+            // 
+            this.label9.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.label9.AutoSize = true;
+            this.label9.Location = new System.Drawing.Point(-1, 99);
+            this.label9.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(129, 13);
+            this.label9.TabIndex = 30;
+            this.label9.Text = "Max Accepted Peak FDR";
             // 
             // ExperimentExperimentComparison
             // 
@@ -710,6 +734,8 @@
         private System.Windows.Forms.Button bt_compare_EE;
         private System.Windows.Forms.NumericUpDown nUD_MaxRetTimeDifference;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TextBox tb_max_accepted_fdr;
+        private System.Windows.Forms.Label label9;
     }
 }
 

--- a/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
@@ -90,6 +90,7 @@ namespace ProteoformSuite
             List<DeltaMassPeak> big_peaks = Lollipop.ee_peaks.Where(p => p.peak_accepted).ToList();
             tb_IdentifiedProteoforms.Text = big_peaks.Select(p => p.grouped_relations.Count).Sum().ToString();
             tb_TotalPeaks.Text = big_peaks.Count.ToString();
+            tb_max_accepted_fdr.Text = Lollipop.ee_peaks.Where(p => p.peak_accepted).Max(p => p.peak_group_fdr).ToString();
         }
 
         private void FillEEPairsGridView()

--- a/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
@@ -90,7 +90,7 @@ namespace ProteoformSuite
             List<DeltaMassPeak> big_peaks = Lollipop.ee_peaks.Where(p => p.peak_accepted).ToList();
             tb_IdentifiedProteoforms.Text = big_peaks.Select(p => p.grouped_relations.Count).Sum().ToString();
             tb_TotalPeaks.Text = big_peaks.Count.ToString();
-            tb_max_accepted_fdr.Text = Lollipop.ee_peaks.Where(p => p.peak_accepted).Max(p => p.peak_group_fdr).ToString();
+            if (Lollipop.ef_relations.Count > 0) tb_max_accepted_fdr.Text = Math.Round(big_peaks.Max(p => p.peak_group_fdr), 3).ToString();
         }
 
         private void FillEEPairsGridView()

--- a/ProteoformSuiteGUI/ExperimentTheoreticalComparison.Designer.cs
+++ b/ProteoformSuiteGUI/ExperimentTheoreticalComparison.Designer.cs
@@ -28,13 +28,13 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataVisualization.Charting.ChartArea chartArea3 = new System.Windows.Forms.DataVisualization.Charting.ChartArea();
-            System.Windows.Forms.DataVisualization.Charting.Legend legend2 = new System.Windows.Forms.DataVisualization.Charting.Legend();
-            System.Windows.Forms.DataVisualization.Charting.Series series5 = new System.Windows.Forms.DataVisualization.Charting.Series();
-            System.Windows.Forms.DataVisualization.Charting.Series series6 = new System.Windows.Forms.DataVisualization.Charting.Series();
-            System.Windows.Forms.DataVisualization.Charting.Series series7 = new System.Windows.Forms.DataVisualization.Charting.Series();
-            System.Windows.Forms.DataVisualization.Charting.ChartArea chartArea4 = new System.Windows.Forms.DataVisualization.Charting.ChartArea();
-            System.Windows.Forms.DataVisualization.Charting.Series series8 = new System.Windows.Forms.DataVisualization.Charting.Series();
+            System.Windows.Forms.DataVisualization.Charting.ChartArea chartArea1 = new System.Windows.Forms.DataVisualization.Charting.ChartArea();
+            System.Windows.Forms.DataVisualization.Charting.Legend legend1 = new System.Windows.Forms.DataVisualization.Charting.Legend();
+            System.Windows.Forms.DataVisualization.Charting.Series series1 = new System.Windows.Forms.DataVisualization.Charting.Series();
+            System.Windows.Forms.DataVisualization.Charting.Series series2 = new System.Windows.Forms.DataVisualization.Charting.Series();
+            System.Windows.Forms.DataVisualization.Charting.Series series3 = new System.Windows.Forms.DataVisualization.Charting.Series();
+            System.Windows.Forms.DataVisualization.Charting.ChartArea chartArea2 = new System.Windows.Forms.DataVisualization.Charting.ChartArea();
+            System.Windows.Forms.DataVisualization.Charting.Series series4 = new System.Windows.Forms.DataVisualization.Charting.Series();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.splitContainer3 = new System.Windows.Forms.SplitContainer();
             this.splitContainer4 = new System.Windows.Forms.SplitContainer();
@@ -71,6 +71,8 @@
             this.dgv_ET_Pairs = new System.Windows.Forms.DataGridView();
             this.dgv_psmList = new System.Windows.Forms.DataGridView();
             this.ct_ET_Histogram = new System.Windows.Forms.DataVisualization.Charting.Chart();
+            this.label9 = new System.Windows.Forms.Label();
+            this.tb_max_accepted_fdr = new System.Windows.Forms.TextBox();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -254,32 +256,32 @@
             // 
             // ct_ET_peakList
             // 
-            chartArea3.Name = "ChartArea1";
-            this.ct_ET_peakList.ChartAreas.Add(chartArea3);
+            chartArea1.Name = "ChartArea1";
+            this.ct_ET_peakList.ChartAreas.Add(chartArea1);
             this.ct_ET_peakList.Dock = System.Windows.Forms.DockStyle.Fill;
-            legend2.Docking = System.Windows.Forms.DataVisualization.Charting.Docking.Top;
-            legend2.Name = "Legend1";
-            this.ct_ET_peakList.Legends.Add(legend2);
+            legend1.Docking = System.Windows.Forms.DataVisualization.Charting.Docking.Top;
+            legend1.Name = "Legend1";
+            this.ct_ET_peakList.Legends.Add(legend1);
             this.ct_ET_peakList.Location = new System.Drawing.Point(0, 0);
             this.ct_ET_peakList.Name = "ct_ET_peakList";
-            series5.ChartArea = "ChartArea1";
-            series5.ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Point;
-            series5.Legend = "Legend1";
-            series5.MarkerSize = 10;
-            series5.Name = "Peak Count";
-            series5.YValuesPerPoint = 2;
-            series6.ChartArea = "ChartArea1";
-            series6.ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Line;
-            series6.Legend = "Legend1";
-            series6.Name = "Nearby Relations";
-            series7.ChartArea = "ChartArea1";
-            series7.ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Point;
-            series7.Legend = "Legend1";
-            series7.MarkerSize = 10;
-            series7.Name = "Median Decoy Count";
-            this.ct_ET_peakList.Series.Add(series5);
-            this.ct_ET_peakList.Series.Add(series6);
-            this.ct_ET_peakList.Series.Add(series7);
+            series1.ChartArea = "ChartArea1";
+            series1.ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Point;
+            series1.Legend = "Legend1";
+            series1.MarkerSize = 10;
+            series1.Name = "Peak Count";
+            series1.YValuesPerPoint = 2;
+            series2.ChartArea = "ChartArea1";
+            series2.ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Line;
+            series2.Legend = "Legend1";
+            series2.Name = "Nearby Relations";
+            series3.ChartArea = "ChartArea1";
+            series3.ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Point;
+            series3.Legend = "Legend1";
+            series3.MarkerSize = 10;
+            series3.Name = "Median Decoy Count";
+            this.ct_ET_peakList.Series.Add(series1);
+            this.ct_ET_peakList.Series.Add(series2);
+            this.ct_ET_peakList.Series.Add(series3);
             this.ct_ET_peakList.Size = new System.Drawing.Size(264, 369);
             this.ct_ET_peakList.TabIndex = 1;
             this.ct_ET_peakList.Text = "chart1";
@@ -299,11 +301,13 @@
             // groupBox4
             // 
             this.groupBox4.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.groupBox4.Controls.Add(this.tb_max_accepted_fdr);
+            this.groupBox4.Controls.Add(this.label9);
             this.groupBox4.Controls.Add(this.label4);
             this.groupBox4.Controls.Add(this.label3);
             this.groupBox4.Controls.Add(this.nUD_PeakWidthBase);
             this.groupBox4.Controls.Add(this.nUD_PeakCountMinThreshold);
-            this.groupBox4.Location = new System.Drawing.Point(31, 30);
+            this.groupBox4.Location = new System.Drawing.Point(31, 31);
             this.groupBox4.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.Padding = new System.Windows.Forms.Padding(2);
@@ -316,7 +320,7 @@
             // 
             this.label4.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(24, 43);
+            this.label4.Location = new System.Drawing.Point(16, 18);
             this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(113, 13);
@@ -327,7 +331,7 @@
             // 
             this.label3.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(24, 69);
+            this.label3.Location = new System.Drawing.Point(16, 48);
             this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(105, 13);
@@ -343,7 +347,7 @@
             0,
             0,
             196608});
-            this.nUD_PeakWidthBase.Location = new System.Drawing.Point(143, 41);
+            this.nUD_PeakWidthBase.Location = new System.Drawing.Point(133, 16);
             this.nUD_PeakWidthBase.Margin = new System.Windows.Forms.Padding(2);
             this.nUD_PeakWidthBase.Maximum = new decimal(new int[] {
             5,
@@ -363,7 +367,7 @@
             // nUD_PeakCountMinThreshold
             // 
             this.nUD_PeakCountMinThreshold.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.nUD_PeakCountMinThreshold.Location = new System.Drawing.Point(143, 68);
+            this.nUD_PeakCountMinThreshold.Location = new System.Drawing.Point(133, 43);
             this.nUD_PeakCountMinThreshold.Margin = new System.Windows.Forms.Padding(2);
             this.nUD_PeakCountMinThreshold.Name = "nUD_PeakCountMinThreshold";
             this.nUD_PeakCountMinThreshold.Size = new System.Drawing.Size(80, 20);
@@ -377,7 +381,7 @@
             this.groupBox3.Controls.Add(this.label6);
             this.groupBox3.Controls.Add(this.nUD_ET_Lower_Bound);
             this.groupBox3.Controls.Add(this.nUD_ET_Upper_Bound);
-            this.groupBox3.Location = new System.Drawing.Point(263, 48);
+            this.groupBox3.Location = new System.Drawing.Point(263, 49);
             this.groupBox3.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.Padding = new System.Windows.Forms.Padding(2);
@@ -450,7 +454,7 @@
             this.groupBox2.Controls.Add(this.xMinET);
             this.groupBox2.Controls.Add(this.yMinET);
             this.groupBox2.Controls.Add(this.xMaxET);
-            this.groupBox2.Location = new System.Drawing.Point(263, 135);
+            this.groupBox2.Location = new System.Drawing.Point(263, 136);
             this.groupBox2.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Padding = new System.Windows.Forms.Padding(2);
@@ -538,7 +542,7 @@
             this.groupBox1.Controls.Add(this.label2);
             this.groupBox1.Controls.Add(this.nUD_NoManLower);
             this.groupBox1.Controls.Add(this.label1);
-            this.groupBox1.Location = new System.Drawing.Point(31, 135);
+            this.groupBox1.Location = new System.Drawing.Point(31, 136);
             this.groupBox1.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Padding = new System.Windows.Forms.Padding(2);
@@ -692,19 +696,39 @@
             // 
             // ct_ET_Histogram
             // 
-            chartArea4.Name = "ChartArea1";
-            this.ct_ET_Histogram.ChartAreas.Add(chartArea4);
+            chartArea2.Name = "ChartArea1";
+            this.ct_ET_Histogram.ChartAreas.Add(chartArea2);
             this.ct_ET_Histogram.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ct_ET_Histogram.Location = new System.Drawing.Point(0, 0);
             this.ct_ET_Histogram.Margin = new System.Windows.Forms.Padding(2);
             this.ct_ET_Histogram.Name = "ct_ET_Histogram";
-            series8.ChartArea = "ChartArea1";
-            series8.ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Line;
-            series8.Name = "relations";
-            this.ct_ET_Histogram.Series.Add(series8);
+            series4.ChartArea = "ChartArea1";
+            series4.ChartType = System.Windows.Forms.DataVisualization.Charting.SeriesChartType.Line;
+            series4.Name = "relations";
+            this.ct_ET_Histogram.Series.Add(series4);
             this.ct_ET_Histogram.Size = new System.Drawing.Size(422, 247);
             this.ct_ET_Histogram.TabIndex = 0;
             this.ct_ET_Histogram.Text = "chart1";
+            // 
+            // label9
+            // 
+            this.label9.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.label9.AutoSize = true;
+            this.label9.Location = new System.Drawing.Point(0, 74);
+            this.label9.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(129, 13);
+            this.label9.TabIndex = 14;
+            this.label9.Text = "Max Accepted Peak FDR";
+            // 
+            // tb_max_accepted_fdr
+            // 
+            this.tb_max_accepted_fdr.Location = new System.Drawing.Point(133, 71);
+            this.tb_max_accepted_fdr.Margin = new System.Windows.Forms.Padding(2);
+            this.tb_max_accepted_fdr.Name = "tb_max_accepted_fdr";
+            this.tb_max_accepted_fdr.ReadOnly = true;
+            this.tb_max_accepted_fdr.Size = new System.Drawing.Size(86, 20);
+            this.tb_max_accepted_fdr.TabIndex = 15;
             // 
             // ExperimentTheoreticalComparison
             // 
@@ -806,5 +830,7 @@
         private System.Windows.Forms.Button bt_compare_ET;
         private System.Windows.Forms.SplitContainer splitContainer6;
         private System.Windows.Forms.DataGridView dgv_psmList;
+        private System.Windows.Forms.TextBox tb_max_accepted_fdr;
+        private System.Windows.Forms.Label label9;
     }
 }

--- a/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
@@ -93,7 +93,7 @@ namespace ProteoformSuite
             List<DeltaMassPeak> big_peaks = Lollipop.et_peaks.Where(p => p.peak_accepted).ToList();
             tb_IdentifiedProteoforms.Text = big_peaks.Select(p => p.grouped_relations.Count).Sum().ToString();
             tb_TotalPeaks.Text = big_peaks.Count.ToString();
-            tb_max_accepted_fdr.Text = Lollipop.et_peaks.Where(p => p.peak_accepted).Max(p => p.peak_group_fdr).ToString();
+            if (Lollipop.ed_relations.Count > 0) tb_max_accepted_fdr.Text = Math.Round( big_peaks.Max(p => p.peak_group_fdr) , 3).ToString();
         }
 
         private void FillETRelationsGridView()

--- a/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
@@ -93,6 +93,7 @@ namespace ProteoformSuite
             List<DeltaMassPeak> big_peaks = Lollipop.et_peaks.Where(p => p.peak_accepted).ToList();
             tb_IdentifiedProteoforms.Text = big_peaks.Select(p => p.grouped_relations.Count).Sum().ToString();
             tb_TotalPeaks.Text = big_peaks.Count.ToString();
+            tb_max_accepted_fdr.Text = Lollipop.et_peaks.Where(p => p.peak_accepted).Max(p => p.peak_group_fdr).ToString();
         }
 
         private void FillETRelationsGridView()
@@ -202,6 +203,7 @@ namespace ProteoformSuite
                 }
                 Lollipop.regroup_components();
             }
+            tb_max_accepted_fdr.Text = Lollipop.et_peaks.Where(p => p.peak_accepted).Max(p => p.peak_group_fdr).ToString();
         }
 
         //will leave option to change one at a time by right clicking

--- a/ProteoformSuiteGUI/LoadDeconvolutionResults.Designer.cs
+++ b/ProteoformSuiteGUI/LoadDeconvolutionResults.Designer.cs
@@ -59,10 +59,11 @@
             this.bt_clearResults = new System.Windows.Forms.Button();
             this.cb_run_when_load = new System.Windows.Forms.CheckBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
-            this.tb_identificationFilter = new System.Windows.Forms.TextBox();
-            this.tb_quantFilter = new System.Windows.Forms.TextBox();
-            this.label6 = new System.Windows.Forms.Label();
             this.label7 = new System.Windows.Forms.Label();
+            this.label6 = new System.Windows.Forms.Label();
+            this.tb_quantFilter = new System.Windows.Forms.TextBox();
+            this.tb_identificationFilter = new System.Windows.Forms.TextBox();
+            this.cb_advanced_user = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dgv_identificationFiles)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgv_quantitationFiles)).BeginInit();
@@ -94,6 +95,7 @@
             this.cb_td_file.TabIndex = 2;
             this.cb_td_file.Text = "Top-down Deconvolution File";
             this.cb_td_file.UseVisualStyleBackColor = true;
+            this.cb_td_file.Visible = false;
             this.cb_td_file.CheckedChanged += new System.EventHandler(this.cb_td_file_CheckedChanged);
             // 
             // btn_unlabeled
@@ -197,6 +199,7 @@
             this.btn_protCalibResultsAdd.TabIndex = 12;
             this.btn_protCalibResultsAdd.Text = "Add";
             this.btn_protCalibResultsAdd.UseVisualStyleBackColor = true;
+            this.btn_protCalibResultsAdd.Visible = false;
             this.btn_protCalibResultsAdd.Click += new System.EventHandler(this.btn_protCalibResultsAdd_Click);
             // 
             // btn_protCalibResultsClear
@@ -207,6 +210,7 @@
             this.btn_protCalibResultsClear.TabIndex = 11;
             this.btn_protCalibResultsClear.Text = "Clear";
             this.btn_protCalibResultsClear.UseVisualStyleBackColor = true;
+            this.btn_protCalibResultsClear.Visible = false;
             this.btn_protCalibResultsClear.Click += new System.EventHandler(this.btn_protCalibResultsClear_Click);
             // 
             // dgv_identificationFiles
@@ -245,6 +249,7 @@
             this.dgv_calibrationFiles.Name = "dgv_calibrationFiles";
             this.dgv_calibrationFiles.Size = new System.Drawing.Size(287, 463);
             this.dgv_calibrationFiles.TabIndex = 15;
+            this.dgv_calibrationFiles.Visible = false;
             this.dgv_calibrationFiles.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.dgv_calibrationResults_CellFormatting);
             this.dgv_calibrationFiles.DragDrop += new System.Windows.Forms.DragEventHandler(this.dgv_calibrationResults_DragDrop);
             this.dgv_calibrationFiles.DragEnter += new System.Windows.Forms.DragEventHandler(this.dgv_calibrationResults_DragEnter);
@@ -299,6 +304,7 @@
             this.dgv_buFiles.Name = "dgv_buFiles";
             this.dgv_buFiles.Size = new System.Drawing.Size(287, 463);
             this.dgv_buFiles.TabIndex = 18;
+            this.dgv_buFiles.Visible = false;
             // 
             // dgv_tdFiles
             // 
@@ -309,6 +315,7 @@
             this.dgv_tdFiles.Name = "dgv_tdFiles";
             this.dgv_tdFiles.Size = new System.Drawing.Size(275, 463);
             this.dgv_tdFiles.TabIndex = 19;
+            this.dgv_tdFiles.Visible = false;
             // 
             // label4
             // 
@@ -338,6 +345,7 @@
             this.bt_morpheusBUResultsAdd.TabIndex = 23;
             this.bt_morpheusBUResultsAdd.Text = "Add";
             this.bt_morpheusBUResultsAdd.UseVisualStyleBackColor = true;
+            this.bt_morpheusBUResultsAdd.Visible = false;
             this.bt_morpheusBUResultsAdd.Click += new System.EventHandler(this.bt_morpheusBUResultsAdd_Click);
             // 
             // bt_morpheusBUResultsClear
@@ -348,6 +356,7 @@
             this.bt_morpheusBUResultsClear.TabIndex = 22;
             this.bt_morpheusBUResultsClear.Text = "Clear";
             this.bt_morpheusBUResultsClear.UseVisualStyleBackColor = true;
+            this.bt_morpheusBUResultsClear.Visible = false;
             this.bt_morpheusBUResultsClear.Click += new System.EventHandler(this.bt_morpheusBUResultsClear_Click);
             // 
             // bt_tdResultsAdd
@@ -358,6 +367,7 @@
             this.bt_tdResultsAdd.TabIndex = 25;
             this.bt_tdResultsAdd.Text = "Add";
             this.bt_tdResultsAdd.UseVisualStyleBackColor = true;
+            this.bt_tdResultsAdd.Visible = false;
             this.bt_tdResultsAdd.Click += new System.EventHandler(this.bt_tdResultsAdd_Click);
             // 
             // bt_tdResultsClear
@@ -368,6 +378,7 @@
             this.bt_tdResultsClear.TabIndex = 24;
             this.bt_tdResultsClear.Text = "Clear";
             this.bt_tdResultsClear.UseVisualStyleBackColor = true;
+            this.bt_tdResultsClear.Visible = false;
             this.bt_tdResultsClear.Click += new System.EventHandler(this.bt_tdResultsClear_Click);
             // 
             // bt_clearResults
@@ -406,21 +417,14 @@
             this.groupBox3.TabStop = false;
             this.groupBox3.Text = "Text Filters";
             // 
-            // tb_identificationFilter
+            // label7
             // 
-            this.tb_identificationFilter.Location = new System.Drawing.Point(8, 19);
-            this.tb_identificationFilter.Name = "tb_identificationFilter";
-            this.tb_identificationFilter.Size = new System.Drawing.Size(100, 20);
-            this.tb_identificationFilter.TabIndex = 29;
-            this.tb_identificationFilter.TextChanged += new System.EventHandler(this.tb_identificationFilter_TextChanged_1);
-            // 
-            // tb_quantFilter
-            // 
-            this.tb_quantFilter.Location = new System.Drawing.Point(8, 46);
-            this.tb_quantFilter.Name = "tb_quantFilter";
-            this.tb_quantFilter.Size = new System.Drawing.Size(100, 20);
-            this.tb_quantFilter.TabIndex = 30;
-            this.tb_quantFilter.TextChanged += new System.EventHandler(this.tb_quantFilter_TextChanged);
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(114, 49);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(110, 13);
+            this.label7.TabIndex = 32;
+            this.label7.Text = "Quantification Results";
             // 
             // label6
             // 
@@ -431,18 +435,37 @@
             this.label6.TabIndex = 31;
             this.label6.Text = "Identification Results";
             // 
-            // label7
+            // tb_quantFilter
             // 
-            this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(114, 49);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(110, 13);
-            this.label7.TabIndex = 32;
-            this.label7.Text = "Quantification Results";
+            this.tb_quantFilter.Location = new System.Drawing.Point(8, 46);
+            this.tb_quantFilter.Name = "tb_quantFilter";
+            this.tb_quantFilter.Size = new System.Drawing.Size(100, 20);
+            this.tb_quantFilter.TabIndex = 30;
+            this.tb_quantFilter.TextChanged += new System.EventHandler(this.tb_quantFilter_TextChanged);
+            // 
+            // tb_identificationFilter
+            // 
+            this.tb_identificationFilter.Location = new System.Drawing.Point(8, 19);
+            this.tb_identificationFilter.Name = "tb_identificationFilter";
+            this.tb_identificationFilter.Size = new System.Drawing.Size(100, 20);
+            this.tb_identificationFilter.TabIndex = 29;
+            this.tb_identificationFilter.TextChanged += new System.EventHandler(this.tb_identificationFilter_TextChanged_1);
+            // 
+            // cb_advanced_user
+            // 
+            this.cb_advanced_user.AutoSize = true;
+            this.cb_advanced_user.Location = new System.Drawing.Point(179, 587);
+            this.cb_advanced_user.Name = "cb_advanced_user";
+            this.cb_advanced_user.Size = new System.Drawing.Size(100, 17);
+            this.cb_advanced_user.TabIndex = 30;
+            this.cb_advanced_user.Text = "Advanced User";
+            this.cb_advanced_user.UseVisualStyleBackColor = true;
+            this.cb_advanced_user.CheckedChanged += new System.EventHandler(this.cb_advanced_user_CheckedChanged);
             // 
             // LoadDeconvolutionResults
             // 
             this.ClientSize = new System.Drawing.Size(1362, 736);
+            this.Controls.Add(this.cb_advanced_user);
             this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.cb_run_when_load);
             this.Controls.Add(this.bt_clearResults);
@@ -522,5 +545,6 @@
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.TextBox tb_quantFilter;
         private System.Windows.Forms.TextBox tb_identificationFilter;
+        private System.Windows.Forms.CheckBox cb_advanced_user;
     }
 }

--- a/ProteoformSuiteGUI/LoadDeconvolutionResults.Designer.cs
+++ b/ProteoformSuiteGUI/LoadDeconvolutionResults.Designer.cs
@@ -150,6 +150,7 @@
             this.label3.Size = new System.Drawing.Size(293, 20);
             this.label3.TabIndex = 6;
             this.label3.Text = "Deconvolution Calibration Files (.txt, .tsv)";
+            this.label3.Visible = false;
             // 
             // btn_protIdResultsClear
             // 
@@ -326,6 +327,7 @@
             this.label4.Size = new System.Drawing.Size(183, 20);
             this.label4.TabIndex = 20;
             this.label4.Text = "Top-Down Results (.xlsx)";
+            this.label4.Visible = false;
             // 
             // label5
             // 
@@ -336,6 +338,7 @@
             this.label5.Size = new System.Drawing.Size(258, 20);
             this.label5.TabIndex = 21;
             this.label5.Text = "Morpheus Bottom-Up Results (.tsv)";
+            this.label5.Visible = false;
             // 
             // bt_morpheusBUResultsAdd
             // 
@@ -441,6 +444,7 @@
             this.tb_quantFilter.Name = "tb_quantFilter";
             this.tb_quantFilter.Size = new System.Drawing.Size(100, 20);
             this.tb_quantFilter.TabIndex = 30;
+            this.tb_quantFilter.Visible = false;
             this.tb_quantFilter.TextChanged += new System.EventHandler(this.tb_quantFilter_TextChanged);
             // 
             // tb_identificationFilter
@@ -537,7 +541,6 @@
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.DataGridView dgv_tdFiles;
         private System.Windows.Forms.DataGridView dgv_buFiles;
-        private System.Windows.Forms.CheckBox cb_td_file;
         private System.Windows.Forms.Button bt_clearResults;
         private System.Windows.Forms.CheckBox cb_run_when_load;
         private System.Windows.Forms.GroupBox groupBox3;
@@ -546,5 +549,6 @@
         private System.Windows.Forms.TextBox tb_quantFilter;
         private System.Windows.Forms.TextBox tb_identificationFilter;
         private System.Windows.Forms.CheckBox cb_advanced_user;
+        private System.Windows.Forms.CheckBox cb_td_file;
     }
 }

--- a/ProteoformSuiteGUI/LoadDeconvolutionResults.cs
+++ b/ProteoformSuiteGUI/LoadDeconvolutionResults.cs
@@ -410,6 +410,20 @@ namespace ProteoformSuite
         }
 
 
+        private void cb_advanced_user_CheckedChanged(object sender, EventArgs e)
+        {
+            cb_td_file.Visible = true;
+            dgv_calibrationFiles.Visible = true;
+            btn_protCalibResultsAdd.Visible = true;
+            btn_protCalibResultsClear.Visible = true;
+            dgv_tdFiles.Visible = true;
+            bt_tdResultsAdd.Visible = true;
+            bt_tdResultsClear.Visible = true;
+            dgv_buFiles.Visible = true;
+            bt_morpheusBUResultsAdd.Visible = true;
+            bt_morpheusBUResultsClear.Visible = true;
+        }
+
         // FILTERS
         private void tb_identificationFilter_TextChanged_1(object sender, EventArgs e)
         {
@@ -420,5 +434,6 @@ namespace ProteoformSuite
         {
             DisplayUtility.FillDataGridView(dgv_quantitationFiles, ExtensionMethods.filter(Lollipop.identification_files(), tb_identificationFilter.Text));
         }
+
     }
 }

--- a/ProteoformSuiteInternal/ComponentReader.cs
+++ b/ProteoformSuiteInternal/ComponentReader.cs
@@ -266,41 +266,5 @@ namespace ProteoformSuiteInternal
 
             return allCorrectionFactors.Average();                
         }
-
-        //Reading in Top-down excel
-        public static List<Psm> ReadTDFile(string filename, TDProgram td_program)
-        {
-            List<Psm> psm_list = new List<Psm>();
-            using (SpreadsheetDocument spreadsheetDocument = SpreadsheetDocument.Open(filename, false))
-            {
-                // Get Data in Sheet1 of Excel file
-                IEnumerable<Sheet> sheetcollection = spreadsheetDocument.WorkbookPart.Workbook.GetFirstChild<Sheets>().Elements<Sheet>(); // Get all sheets in spread sheet document 
-                WorksheetPart worksheet_1 = (WorksheetPart)spreadsheetDocument.WorkbookPart.GetPartById(sheetcollection.First().Id.Value); // Get sheet1 Part of Spread Sheet Document
-                SheetData sheet_1 = worksheet_1.Worksheet.Elements<SheetData>().First();
-                List<Row> rowcollection = worksheet_1.Worksheet.Descendants<Row>().ToList();
-                for (int i = 1; i < rowcollection.Count; i++)   //skip first row (headers)
-                {
-                    List<string> cellStrings = new List<string>();
-                    for (int k = 0; k < rowcollection[i].Descendants<Cell>().Count(); k++)
-                    {
-                        cellStrings.Add(GetCellValue(spreadsheetDocument, rowcollection[i].Descendants<Cell>().ElementAt(k)));
-                    }
-
-                    if (td_program == TDProgram.NRTDP)
-                    {
-                        Psm new_psm = new Psm(cellStrings[8] + cellStrings[4], filename, Convert.ToInt16(cellStrings[5]), Convert.ToInt16(cellStrings[6]),
-                            0, 0, Convert.ToDouble(cellStrings[14]), 0, cellStrings[2], Convert.ToDouble(cellStrings[12]), 0, 0, PsmType.TopDown);
-                        psm_list.Add(new_psm);
-                    }
-
-                    else if (td_program == TDProgram.ProSight)
-                    {
-                        Psm new_psm = new Psm(cellStrings[6] + cellStrings[8], cellStrings[14], 0, 0, 0, 0, Convert.ToDouble(cellStrings[20]), 0, cellStrings[4], Convert.ToDouble(cellStrings[9]), 0, Convert.ToDouble(cellStrings[11]), PsmType.TopDown);
-                        psm_list.Add(new_psm);
-                    }
-                }
-            }
-            return psm_list;
-        }
     }
 }

--- a/ProteoformSuiteInternal/ProteoformRelation.cs
+++ b/ProteoformSuiteInternal/ProteoformRelation.cs
@@ -175,10 +175,6 @@ namespace ProteoformSuiteInternal
         {
             get { try { return ((TheoreticalProteoform)connected_proteoforms[1]).psm_count_BU; } catch { return 0; }}
         }
-        public int psm_count_TD
-        {
-            get { try { return ((TheoreticalProteoform)connected_proteoforms[1]).psm_count_TD; } catch { return 0; } }
-        }
         public string of_interest
         {
             get { try { return ((TheoreticalProteoform)connected_proteoforms[1]).of_interest; } catch { return null; } }

--- a/ProteoformSuiteInternal/inputFile.cs
+++ b/ProteoformSuiteInternal/inputFile.cs
@@ -111,8 +111,7 @@ namespace ProteoformSuiteInternal
         Quantification,
         Calibration,
         BottomUp,
-        TopDown,
-        TopDownIDResults
+        TopDown
     }
 
     public enum Labeling


### PR DESCRIPTION
*Maximum fdr above the threshold displayed for EE and ET (setting the threshold with FDR instead of peak count did not work well for one neucode raw file when I tried it -- too many peaks with 0 FDR). 
*Cleaned out lots of topdown code that I don't need anymore/is outdated with my TD branch
*Non-identification/quantitation DGVs invisible on load page unless advanced checkbox checked