### PR TITLE
Fixed bug where ProteoformFamily.theoretical_proteoforms did not contain all theoreticals in the family

### DIFF
--- a/ProteoformSuiteGUI/LoadDeconvolutionResults.cs
+++ b/ProteoformSuiteGUI/LoadDeconvolutionResults.cs
@@ -266,13 +266,12 @@ namespace ProteoformSuite
         {
             if (Lollipop.input_files.Count == 0)
             {
-                MessageBox.Show("Please load in deconvolution result files in order to use load and run.");
+                MessageBox.Show("Please load in deconvolution result files in order to use load and run.", "Full Run");
                 return;
             }
-            MessageBox.Show("Will start the run now.\n\nWill show as non-responsive.");
             bool successful_run = ((ProteoformSweet)MdiParent).full_run();
-            if (successful_run) MessageBox.Show("Successfully ran method. Feel free to explore using the Results menu.");
-            else { MessageBox.Show("Method did not successfully run."); }
+            if (successful_run) MessageBox.Show("Successfully ran method. Feel free to explore using the Results menu.", "Full Run");
+            else MessageBox.Show("Method did not successfully run.", "Full Run"); 
         }
 
 

--- a/ProteoformSuiteGUI/NeuCodePairs.cs
+++ b/ProteoformSuiteGUI/NeuCodePairs.cs
@@ -15,7 +15,8 @@ namespace ProteoformSuite
 {
     public partial class NeuCodePairs : Form
     {
-        bool initial_load = true; 
+        bool initial_load = true;
+        public bool preloaded = false; 
 
         public NeuCodePairs()
         {
@@ -30,12 +31,13 @@ namespace ProteoformSuite
 
         public void display_neucode_pairs()
         {
-            if (Lollipop.raw_neucode_pairs.Count > 0)
+            if (Lollipop.raw_neucode_pairs.Count > 0 && !preloaded)
             {
                 GraphNeuCodePairs();
                 FillNeuCodePairsDGV();
-                initial_load = false;
             }
+            preloaded = false;
+            initial_load = false;
         }
 
         public void FillNeuCodePairsDGV()

--- a/ProteoformSuiteGUI/ProteoformFamilies.Designer.cs
+++ b/ProteoformSuiteGUI/ProteoformFamilies.Designer.cs
@@ -66,6 +66,11 @@
             this.label8 = new System.Windows.Forms.Label();
             this.label7 = new System.Windows.Forms.Label();
             this.Families_update = new System.Windows.Forms.Button();
+            this.groupBox5 = new System.Windows.Forms.GroupBox();
+            this.cb_moreOpacity = new System.Windows.Forms.CheckBox();
+            this.cb_boldLabel = new System.Windows.Forms.CheckBox();
+            this.cb_redBorder = new System.Windows.Forms.CheckBox();
+            this.cb_buildAsQuantitative = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -83,6 +88,7 @@
             this.splitContainer3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dgv_proteoform_family_members)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nud_decimalRoundingLabels)).BeginInit();
+            this.groupBox5.SuspendLayout();
             this.SuspendLayout();
             // 
             // splitContainer1
@@ -312,6 +318,8 @@
             // 
             // splitContainer3.Panel2
             // 
+            this.splitContainer3.Panel2.Controls.Add(this.cb_buildAsQuantitative);
+            this.splitContainer3.Panel2.Controls.Add(this.groupBox5);
             this.splitContainer3.Panel2.Controls.Add(this.btn_merge);
             this.splitContainer3.Panel2.Controls.Add(this.tb_singleton_count);
             this.splitContainer3.Panel2.Controls.Add(this.lb_singletons);
@@ -348,7 +356,7 @@
             // btn_merge
             // 
             this.btn_merge.Enabled = false;
-            this.btn_merge.Location = new System.Drawing.Point(97, 201);
+            this.btn_merge.Location = new System.Drawing.Point(73, 188);
             this.btn_merge.Name = "btn_merge";
             this.btn_merge.Size = new System.Drawing.Size(195, 23);
             this.btn_merge.TabIndex = 45;
@@ -413,7 +421,7 @@
             // 
             // btn_buildSelectedFamilies
             // 
-            this.btn_buildSelectedFamilies.Location = new System.Drawing.Point(97, 139);
+            this.btn_buildSelectedFamilies.Location = new System.Drawing.Point(73, 139);
             this.btn_buildSelectedFamilies.Name = "btn_buildSelectedFamilies";
             this.btn_buildSelectedFamilies.Size = new System.Drawing.Size(195, 23);
             this.btn_buildSelectedFamilies.TabIndex = 7;
@@ -423,7 +431,7 @@
             // 
             // btn_buildAllFamilies
             // 
-            this.btn_buildAllFamilies.Location = new System.Drawing.Point(112, 110);
+            this.btn_buildAllFamilies.Location = new System.Drawing.Point(99, 110);
             this.btn_buildAllFamilies.Name = "btn_buildAllFamilies";
             this.btn_buildAllFamilies.Size = new System.Drawing.Size(169, 23);
             this.btn_buildAllFamilies.TabIndex = 6;
@@ -513,6 +521,66 @@
             this.Families_update.UseVisualStyleBackColor = true;
             this.Families_update.Click += new System.EventHandler(this.Families_update_Click);
             // 
+            // groupBox5
+            // 
+            this.groupBox5.Controls.Add(this.cb_moreOpacity);
+            this.groupBox5.Controls.Add(this.cb_boldLabel);
+            this.groupBox5.Controls.Add(this.cb_redBorder);
+            this.groupBox5.Location = new System.Drawing.Point(280, 139);
+            this.groupBox5.Name = "groupBox5";
+            this.groupBox5.Size = new System.Drawing.Size(200, 120);
+            this.groupBox5.TabIndex = 57;
+            this.groupBox5.TabStop = false;
+            this.groupBox5.Text = "Highlights for Significant Differences";
+            // 
+            // cb_moreOpacity
+            // 
+            this.cb_moreOpacity.AutoSize = true;
+            this.cb_moreOpacity.Enabled = false;
+            this.cb_moreOpacity.Location = new System.Drawing.Point(21, 76);
+            this.cb_moreOpacity.Name = "cb_moreOpacity";
+            this.cb_moreOpacity.Size = new System.Drawing.Size(96, 17);
+            this.cb_moreOpacity.TabIndex = 58;
+            this.cb_moreOpacity.Text = "Higher Opacity";
+            this.cb_moreOpacity.UseVisualStyleBackColor = true;
+            // 
+            // cb_boldLabel
+            // 
+            this.cb_boldLabel.AutoSize = true;
+            this.cb_boldLabel.Checked = true;
+            this.cb_boldLabel.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cb_boldLabel.Enabled = false;
+            this.cb_boldLabel.Location = new System.Drawing.Point(21, 53);
+            this.cb_boldLabel.Name = "cb_boldLabel";
+            this.cb_boldLabel.Size = new System.Drawing.Size(76, 17);
+            this.cb_boldLabel.TabIndex = 57;
+            this.cb_boldLabel.Text = "Bold Label";
+            this.cb_boldLabel.UseVisualStyleBackColor = true;
+            // 
+            // cb_redBorder
+            // 
+            this.cb_redBorder.AutoSize = true;
+            this.cb_redBorder.Checked = true;
+            this.cb_redBorder.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cb_redBorder.Enabled = false;
+            this.cb_redBorder.Location = new System.Drawing.Point(21, 30);
+            this.cb_redBorder.Name = "cb_redBorder";
+            this.cb_redBorder.Size = new System.Drawing.Size(109, 17);
+            this.cb_redBorder.TabIndex = 56;
+            this.cb_redBorder.Text = "Red Node Border";
+            this.cb_redBorder.UseVisualStyleBackColor = true;
+            // 
+            // cb_buildAsQuantitative
+            // 
+            this.cb_buildAsQuantitative.AutoSize = true;
+            this.cb_buildAsQuantitative.Location = new System.Drawing.Point(301, 110);
+            this.cb_buildAsQuantitative.Name = "cb_buildAsQuantitative";
+            this.cb_buildAsQuantitative.Size = new System.Drawing.Size(163, 17);
+            this.cb_buildAsQuantitative.TabIndex = 58;
+            this.cb_buildAsQuantitative.Text = "Build as Quantitative Families";
+            this.cb_buildAsQuantitative.UseVisualStyleBackColor = true;
+            this.cb_buildAsQuantitative.CheckedChanged += new System.EventHandler(this.cb_buildAsQuantitative_CheckedChanged);
+            // 
             // ProteoformFamilies
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -541,6 +609,8 @@
             this.splitContainer3.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dgv_proteoform_family_members)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nud_decimalRoundingLabels)).EndInit();
+            this.groupBox5.ResumeLayout(false);
+            this.groupBox5.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -585,5 +655,10 @@
         private System.Windows.Forms.ComboBox cmbx_colorScheme;
         private System.Windows.Forms.Label label9;
         private System.Windows.Forms.ComboBox cmbx_edgeLabel;
+        private System.Windows.Forms.CheckBox cb_buildAsQuantitative;
+        private System.Windows.Forms.GroupBox groupBox5;
+        private System.Windows.Forms.CheckBox cb_moreOpacity;
+        private System.Windows.Forms.CheckBox cb_boldLabel;
+        private System.Windows.Forms.CheckBox cb_redBorder;
     }
 }

--- a/ProteoformSuiteGUI/ProteoformFamilies.cs
+++ b/ProteoformSuiteGUI/ProteoformFamilies.cs
@@ -28,6 +28,8 @@ namespace ProteoformSuite
         {
             this.tb_familyBuildFolder.Text = Lollipop.family_build_folder_path;
             this.nud_decimalRoundingLabels.Value = Convert.ToDecimal(Lollipop.deltaM_edge_display_rounding);
+            this.cb_buildAsQuantitative.Enabled = Lollipop.qVals.Count > 0;
+            this.cb_buildAsQuantitative.Checked = false;
         }
 
         private void initialize_settings()
@@ -223,7 +225,7 @@ namespace ProteoformSuite
         {
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
-            string message = CytoscapeScript.write_cytoscape_script(Lollipop.proteoform_community.families, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, false, false, false, false, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding);
+            string message = CytoscapeScript.write_cytoscape_script(Lollipop.proteoform_community.families, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, cb_buildAsQuantitative.Checked, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding);
             MessageBox.Show(message, "Cytoscape Build");
         }
 
@@ -232,7 +234,7 @@ namespace ProteoformSuite
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
             object[] selected = DisplayUtility.get_selected_objects(dgv_main);
-            string message = CytoscapeScript.write_cytoscape_script(selected, table_types[cmbx_tableSelector.SelectedIndex], Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, false, false, false, false, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding);
+            string message = CytoscapeScript.write_cytoscape_script(selected, table_types[cmbx_tableSelector.SelectedIndex], Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, cb_buildAsQuantitative.Checked, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding);
             MessageBox.Show(message, "Cytoscape Build");
         }
 
@@ -250,6 +252,13 @@ namespace ProteoformSuite
         private void btn_merge_Click(object sender, EventArgs e)
         {
             
+        }
+
+        private void cb_buildAsQuantitative_CheckedChanged(object sender, EventArgs e)
+        {
+            cb_redBorder.Enabled = cb_buildAsQuantitative.Checked;
+            cb_boldLabel.Enabled = cb_buildAsQuantitative.Checked;
+            cb_moreOpacity.Enabled = false; //not fully implemented
         }
     }
 }

--- a/ProteoformSuiteInternal/CytoscapeScript.cs
+++ b/ProteoformSuiteInternal/CytoscapeScript.cs
@@ -144,23 +144,11 @@ namespace ProteoformSuiteInternal
                     get_proteoform_shared_name(r.connected_proteoforms[0], double_rounding),
                     r.lysine_count.ToString(),
                     get_proteoform_shared_name(r.connected_proteoforms[1], double_rounding),
-                    Math.Round(r.peak_center_deltaM, double_rounding).ToString()
+                    Math.Round(r.peak_center_deltaM, double_rounding).ToString("0." + String.Join("", Enumerable.Range(0, double_rounding).Select(i => "0")))
                 });
                 edge_rows += Environment.NewLine;
             }
             return tsv_header + Environment.NewLine + edge_rows;
-        }
-
-        private static string get_proteoform_shared_name(Proteoform p, int double_rounding)
-        {
-            string result;
-            if (typeof(ExperimentalProteoform).IsAssignableFrom(p.GetType()))
-                result = Math.Round(((ExperimentalProteoform)p).agg_mass, double_rounding) + "_Da_" + p.accession;
-            else if (typeof(TheoreticalProteoform).IsAssignableFrom(p.GetType()))
-                result = ((TheoreticalProteoform)p).name.Split(new char[] { '_' }).FirstOrDefault() + " " + ((TheoreticalProteoform)p).ptm_list_string();
-            else
-                result = p.accession;
-            return result;
         }
 
         public static string get_cytoscape_nodes_tsv(List<ProteoformFamily> families, bool quantitative, string color_scheme, int double_rounding)
@@ -186,6 +174,24 @@ namespace ProteoformSuiteInternal
             }
 
             return tsv_header + Environment.NewLine + node_rows;
+        }
+
+        public static string get_proteoform_shared_name(Proteoform p, int double_rounding)
+        {
+            if (typeof(ExperimentalProteoform).IsAssignableFrom(p.GetType()))
+            {
+                return Math.Round(((ExperimentalProteoform)p).agg_mass, double_rounding) + "_Da_" + p.accession;
+            }
+
+            else if (typeof(TheoreticalProteoform).IsAssignableFrom(p.GetType()))
+            {
+                return p.accession.Split(new char[] { '_' }).FirstOrDefault() + " " + ((TheoreticalProteoform)p).ptm_list_string();
+            }
+
+            else
+            {
+                return p.accession;
+            }
         }
 
         private static string get_piechart_string(string color_scheme)

--- a/ProteoformSuiteInternal/Lollipop.cs
+++ b/ProteoformSuiteInternal/Lollipop.cs
@@ -105,7 +105,10 @@ namespace ProteoformSuiteInternal
                     else if (extension == ".txt")
                         file = new InputFile(complete_path, Purpose.PtmList);
                     else
+                    {
                         file = new InputFile(complete_path, Purpose.ProteinDatabase);
+                        file.ContaminantDB = file.filename.Contains("cRAP");
+                    }
                     destination.Add(file);
                 }
             }
@@ -561,8 +564,8 @@ namespace ProteoformSuiteInternal
             //}
 
             //PARALLEL PROBLEM
-            process_entries();
-            process_decoys();
+            process_entries(expanded_proteins);
+            process_decoys(expanded_proteins);
 
             if (combine_theoretical_proteoforms_byMass)
             {
@@ -625,7 +628,7 @@ namespace ProteoformSuiteInternal
             return expanded_prots.ToArray();
         }
 
-        private static ProteinSequenceGroup[] group_proteins_by_sequence(IEnumerable<Protein> proteins)
+        private static ProteinSequenceGroup[] group_proteins_by_sequence(Protein[] proteins)
         {
             Dictionary<string, List<Protein>> sequence_groupings = new Dictionary<string, List<Protein>>();
             foreach (Protein p in proteins)
@@ -648,7 +651,7 @@ namespace ProteoformSuiteInternal
             return mass_groupings.Select(kv => new TheoreticalProteoformGroup(kv.Value, contaminants, theoretical_proteins)).ToArray();
         }
 
-        private static void process_entries()
+        private static void process_entries(IEnumerable<Protein> expanded_proteins)
         {
             List<TheoreticalProteoform> theoretical_proteoforms = new List<TheoreticalProteoform>();
             //foreach (Protein p in expanded_proteins)
@@ -662,7 +665,7 @@ namespace ProteoformSuiteInternal
             Lollipop.proteoform_community.theoretical_proteoforms = theoretical_proteoforms.ToArray();
         }
 
-        private static void process_decoys()
+        private static void process_decoys(Protein[] expanded_proteins)
         {
             for (int decoyNumber = 0; decoyNumber < Lollipop.decoy_databases; decoyNumber++)
             {

--- a/ProteoformSuiteInternal/Modification.cs
+++ b/ProteoformSuiteInternal/Modification.cs
@@ -47,7 +47,7 @@ namespace ProteoformSuiteInternal
     public class Ptm
     {
         public int position = -1;
-        public ModificationWithMass modification = new ModificationWithMass("unmodified", null, null, ModificationSites.Any, 0, null, -1, null, null, null);
+        public ModificationWithMass modification = new ModificationWithMass("Unmodified", new Tuple<string, string>("N/A", "Unmodified"), null, ModificationSites.Any, 0, null, -1, null, null, null);
         public Ptm() // initializes an "un-Modification"
         { }
         public Ptm(int position, ModificationWithMass modification)
@@ -95,7 +95,7 @@ namespace ProteoformSuiteInternal
         public List<PtmSet> get_combinations(int num_ptms_needed)
         {
             List<PtmSet> combinations = all_unique_positional_combinations(num_ptms_needed);
-            List<PtmSet> unique_mass_combinations = new List<PtmSet>();
+            List<PtmSet> unique_mass_combinations = new List<PtmSet> { new PtmSet(new List<Ptm>()) }; //initialize with an "unmodified" ptmset
 
             //I tried speeding this up by removing all similar masses instead; it doesn't speed it up... AC170223
             foreach (PtmSet combination in combinations)
@@ -106,7 +106,6 @@ namespace ProteoformSuiteInternal
                     unique_mass_combinations.Add(combination);
             }
 
-            unique_mass_combinations.Add(new PtmSet(new List<Ptm>()));
             return unique_mass_combinations;
         }
 

--- a/ProteoformSuiteInternal/Proteoform.cs
+++ b/ProteoformSuiteInternal/Proteoform.cs
@@ -666,7 +666,7 @@ namespace ProteoformSuiteInternal
         public List<string> accessionList { get; set; } // this is the list of accession numbers for all proteoforms that share the same modified mass. the list gets alphabetical order
 
         public TheoreticalProteoformGroup(List<TheoreticalProteoform> theoreticals, bool contaminants, Dictionary<InputFile, Protein[]> theoretical_proteins)
-            : base(theoreticals[0].accession + "_T" + theoreticals.Count(), String.Join(";", theoreticals.Select(t => t.description)), String.Join(";", theoreticals.Select(t => t.description)), String.Join(";", theoreticals.Select(t => t.fragment)), theoreticals[0].begin, theoreticals[0].end, theoreticals[0].unmodified_mass, theoreticals[0].lysine_count, theoreticals[0].goTerms, theoreticals[0].ptm_set, theoreticals[0].modified_mass, theoreticals[0].is_target)
+            : base(theoreticals[0].accession + "_T" + theoreticals.Count(), String.Join(";", theoreticals.Select(t => t.description)), String.Join(";", theoreticals.Select(t => t.name)), String.Join(";", theoreticals.Select(t => t.fragment)), theoreticals[0].begin, theoreticals[0].end, theoreticals[0].unmodified_mass, theoreticals[0].lysine_count, theoreticals[0].goTerms, theoreticals[0].ptm_set, theoreticals[0].modified_mass, theoreticals[0].is_target)
         {
             this.accessionList = theoreticals.Select(p => p.accession).ToList();
             this.proteinList = theoreticals.SelectMany(p => p.proteinList).ToList();
@@ -677,7 +677,7 @@ namespace ProteoformSuiteInternal
                 if (!contaminant) return;
                 this.accession = matching_contaminants[0].Accession + "_T" + accessionList.Count();
                 this.description = String.Join(";", matching_contaminants.Select(t => t.FullDescription));
-                this.name = String.Join(";", matching_contaminants.Select(t => t.FullDescription));
+                this.name = String.Join(";", matching_contaminants.Select(t => t.Name));
                 TheoreticalProteoform first_contaminant = theoreticals.FirstOrDefault(t => t.contaminant);
                 this.begin = first_contaminant.begin;
                 this.end = first_contaminant.end;

--- a/ProteoformSuiteInternal/ProteoformFamily.cs
+++ b/ProteoformSuiteInternal/ProteoformFamily.cs
@@ -49,15 +49,15 @@ namespace ProteoformSuiteInternal
                 _proteoforms = value;
                 HashSet<int> lysine_counts = new HashSet<int>(value.Select(p => p.lysine_count));
                 if (lysine_counts.Count == 1) this.lysine_count = lysine_counts.FirstOrDefault();
-                this.experimental_proteoforms = value.Where(p => p is ExperimentalProteoform).Select(p => (ExperimentalProteoform)p).ToList();
-                this.theoretical_proteoforms = value.Where(p => p is TheoreticalProteoform).Select(p => (TheoreticalProteoform)p).ToList();
+                this.experimental_proteoforms = value.OfType<ExperimentalProteoform>().ToList();
+                this.theoretical_proteoforms = value.OfType<TheoreticalProteoform>().ToList();
                 this.relations = new HashSet<ProteoformRelation>(value.SelectMany(p => p.relationships.Where(r => r.peak.peak_accepted)), new RelationComparer());
             }
         }
 
         public ProteoformFamily(IEnumerable<Proteoform> proteoforms, int family_id)
         {
-            this.proteoforms = new HashSet<Proteoform>(proteoforms, new ProteoformComparer());
+            this.proteoforms = new HashSet<Proteoform>(proteoforms); //, new ProteoformComparer());
             this.family_id = family_id;
         }
     }
@@ -73,18 +73,6 @@ namespace ProteoformSuiteInternal
         public int GetHashCode(ProteoformRelation r)
         {
             return r.nearby_relations_count;
-        }
-    }
-
-    public class ProteoformComparer: IEqualityComparer<Proteoform>
-    {
-        public bool Equals(Proteoform p1, Proteoform p2)
-        {
-            return p1.accession == p2.accession;
-        }
-        public int GetHashCode(Proteoform p)
-        {
-            return p.accession.ToCharArray().Sum(c => Convert.ToInt32(c));
         }
     }
 }

--- a/Test/TestCytoscapeScript.cs
+++ b/Test/TestCytoscapeScript.cs
@@ -19,14 +19,14 @@ namespace Test
         {
             ModificationMotif motif;
             ModificationMotif.TryGetMotif("K", out motif);
-            ModificationWithMass m = new ModificationWithMass("oxidation", new Tuple<string, string>("", ""), motif, ModificationSites.K, 1, new Dictionary<string, IList<string>>(), -1, new List<double>(), new List<double>(), "");
+            string mod_title = "oxidation";
+            ModificationWithMass m = new ModificationWithMass(mod_title, new Tuple<string, string>("", mod_title), motif, ModificationSites.K, 1, new Dictionary<string, IList<string>>(), -1, new List<double>(), new List<double>(), "");
 
-            ProteoformFamily f = new ProteoformFamily(new List<Proteoform> {
-                    new TheoreticalProteoform("T1","","T1","",0,0,100,20,new List<GoTerm>(), new PtmSet(new List<Ptm> { new Ptm(0, m) }),100,true)
-                }, 1);
+            Proteoform p = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new List<GoTerm>(), new PtmSet(new List<Ptm> { new Ptm(0, m) }), 100, true);
+            ProteoformFamily f = new ProteoformFamily(new List<Proteoform> {p}, 1);
             string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2);
             Assert.True(node_table.Contains(CytoscapeScript.modified_theoretical_label));
-            Assert.True(node_table.Contains(f.theoretical_proteoforms[0].ptm_list_string()));
+            Assert.AreNotEqual(f.theoretical_proteoforms[0].accession, CytoscapeScript.get_proteoform_shared_name(p, 2));
         }
 
         [Test]
@@ -36,23 +36,21 @@ namespace Test
             ModificationMotif.TryGetMotif("K", out motif);
             ModificationWithMass m = new ModificationWithMass("oxidation", new Tuple<string, string>("", ""), motif, ModificationSites.K, 1, new Dictionary<string, IList<string>>(), -1, new List<double>(), new List<double>(), "");
 
-            ProteoformFamily f = new ProteoformFamily(new List<Proteoform> {
-                    new TheoreticalProteoform("T1","","T1","",0,0,100,20,new List<GoTerm>(), new PtmSet(new List<Ptm> { new Ptm(0, m), new Ptm(0, m) }),100,true)
-                }, 1);
+            Proteoform p = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new List<GoTerm>(), new PtmSet(new List<Ptm> { new Ptm(0, m), new Ptm(0, m) }), 100, true);
+            ProteoformFamily f = new ProteoformFamily(new List<Proteoform> {p}, 1);
             string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2);
             Assert.True(node_table.Contains(CytoscapeScript.modified_theoretical_label));
-            Assert.True(node_table.Contains(f.theoretical_proteoforms[0].ptm_list_string()));
+            Assert.AreNotEqual(f.theoretical_proteoforms[0].accession, CytoscapeScript.get_proteoform_shared_name(p, 2));
         }
 
         [Test]
         public void nodes_table_gives_meaningful_unmodified_theoreticals()
         {
-            ProteoformFamily f = new ProteoformFamily(new List<Proteoform> {
-                    new TheoreticalProteoform("T1","","T1","",0,0,100,20,new List<GoTerm>(), new PtmSet(new List<Ptm> { new Ptm() }),100,true) //unmodified has one PTM labeled unmodified
-                }, 1);
+            Proteoform p = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new List<GoTerm>(), new PtmSet(new List<Ptm> { new Ptm() }), 100, true); //unmodified has one PTM labeled unmodified
+            ProteoformFamily f = new ProteoformFamily(new List<Proteoform> { p }, 1);
             string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2);
             Assert.True(node_table.Contains(CytoscapeScript.unmodified_theoretical_label));
-            Assert.True(node_table.Contains(f.theoretical_proteoforms[0].ptm_list_string()));
+            Assert.AreNotEqual(f.theoretical_proteoforms[0].accession, CytoscapeScript.get_proteoform_shared_name(p, 2));
         }
 
         [Test]
@@ -60,14 +58,14 @@ namespace Test
         {
             ModificationMotif motif;
             ModificationMotif.TryGetMotif("K", out motif);
-            ModificationWithMass m = new ModificationWithMass("Unmodified", new Tuple<string, string>("", ""), motif, ModificationSites.K, 0, new Dictionary<string, IList<string>>(), -1, new List<double>(), new List<double>(), "");
+            string mod_title = "unmodified".ToUpper();
+            ModificationWithMass m = new ModificationWithMass(mod_title, new Tuple<string, string>("N/A", mod_title), motif, ModificationSites.K, 0, new Dictionary<string, IList<string>>(), -1, new List<double>(), new List<double>(), "");
 
-            ProteoformFamily f = new ProteoformFamily(new List<Proteoform> {
-                    new TheoreticalProteoform("T1","","T1","",0,0,100,20,new List<GoTerm>(), new PtmSet(new List<Ptm> { new Ptm() }),100,true) //unmodified has one PTM labeled unmodified
-                }, 1);
+            Proteoform p = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new List<GoTerm>(), new PtmSet(new List<Ptm> { new Ptm() }), 100, true); //unmodified has one PTM labeled unmodified
+            ProteoformFamily f = new ProteoformFamily(new List<Proteoform> { p }, 1);
             string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2);
             Assert.True(node_table.Contains(CytoscapeScript.unmodified_theoretical_label));
-            Assert.True(node_table.Contains(f.theoretical_proteoforms[0].ptm_list_string()));
+            Assert.AreNotEqual(f.theoretical_proteoforms[0].accession, CytoscapeScript.get_proteoform_shared_name(p, 2));
         }
 
         [Test]
@@ -87,7 +85,7 @@ namespace Test
         public void test_write_families_no_experimentals_which_shouldnt_happen()
         {
             List<ProteoformFamily> f = new List<ProteoformFamily> { new ProteoformFamily(new List<Proteoform> {
-                    new TheoreticalProteoform("T1","","T1","",0,0,100,20,new List<GoTerm>(), new PtmSet(new List<Ptm> { new Ptm() }),100,true)
+                    new TheoreticalProteoform("T1","","T1_1","",0,0,100,20,new List<GoTerm>(), new PtmSet(new List<Ptm> { new Ptm() }),100,true)
                 }, 1) };
             string message = CytoscapeScript.write_cytoscape_script(f, f, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2);
             Assert.True(message.Contains("Error"));
@@ -96,7 +94,7 @@ namespace Test
         [Test]
         public void test_write_families_regular_display()
         {
-            TheoreticalProteoform t = new TheoreticalProteoform("T1", "", "T1", "", 0, 0, 100, 20, new List<GoTerm>(), new PtmSet(new List<Ptm> { new Ptm() }), 100, true);
+            TheoreticalProteoform t = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new List<GoTerm>(), new PtmSet(new List<Ptm> { new Ptm() }), 100, true);
             ExperimentalProteoform e = new ExperimentalProteoform("E1");
             e.agg_intensity = 999.99;
             e.quant.lightIntensitySum = 444.44m;

--- a/Test/TestExperimentalProteoform.cs
+++ b/Test/TestExperimentalProteoform.cs
@@ -257,16 +257,6 @@ namespace Test
         }
 
         [Test]
-        public void proteoform_equals()
-        {
-            Proteoform a = new Proteoform("a");
-            Proteoform b = new Proteoform("b");
-            Assert.False(new ProteoformComparer().Equals(a, b));
-            b.accession = a.accession;
-            Assert.True(new ProteoformComparer().Equals(a, b));
-        }
-
-        [Test]
         public void test_aggregate_copy()
         {
             double max_monoisotopic_mass = starter_mass + missed_monoisotopics * Lollipop.MONOISOTOPIC_UNIT_MASS;


### PR DESCRIPTION
Currently, not all proteoforms have unique accessions. Now, in constructing families, I'm using a simple hash-code comparison of Proteoform objects instead of using accessions. Also, I sped up full run of yeast quant dataset by ~30 sec of 10 min by running raw_experimental_components and theoretical_database at the same time.