### PR TITLE
>10x speedup for unlabeled

### DIFF
--- a/ProteoformSuiteInternal/DeltaMassPeak.cs
+++ b/ProteoformSuiteInternal/DeltaMassPeak.cs
@@ -9,22 +9,9 @@ namespace ProteoformSuiteInternal
     //Please see ProteoformRelation class for notes on naming this one.
     public class DeltaMassPeak : ProteoformRelation
     {
-        private List<ProteoformRelation> _grouped_relations;
-        public List<ProteoformRelation> grouped_relations
-        {
-            get { return _grouped_relations; }
-            set
-            {
-                _grouped_relations = value;
-                this.peak_relation_group_count = value.Count;
-                this.peak_deltaM_average = value.Select(r => r.delta_mass).Average();
-                this.peak_accepted = typeof(TheoreticalProteoform).IsAssignableFrom(grouped_relations[0].connected_proteoforms[1].GetType()) ?       
-                     this.peak_relation_group_count >= Lollipop.min_peak_count_et : 
-                     this.peak_relation_group_count >= Lollipop.min_peak_count_ee;               
-            }
-        }
+        public List<ProteoformRelation> grouped_relations { get; set; }
         public double peak_deltaM_average { get; set; }
-        public int peak_relation_group_count { get; set; }
+        public int peak_relation_group_count { get { return grouped_relations.Count; } }
         public double decoy_relation_count { get; set; }
         public double peak_group_fdr { get; set; }
         public bool peak_accepted { get; set; } = false;
@@ -35,45 +22,39 @@ namespace ProteoformSuiteInternal
 
         public DeltaMassPeak(ProteoformRelation base_relation, List<ProteoformRelation> relations_to_group) : base(base_relation)
         {
-            this.base_relation = base_relation;
-
-            if (!Lollipop.opening_results) this.find_nearby_relations(relations_to_group);
-            else this.grouped_relations = relations_to_group;
-
-            Parallel.ForEach<ProteoformRelation>(this.grouped_relations, relation =>
+            this.peak = this;
+            lock (base_relation)
             {
-                relation.peak = this;
-                relation.accepted = this.peak_accepted;
-            });
+                this.base_relation = base_relation;
+                base_relation.peak = this;
+            }
 
+            grouped_relations = !Lollipop.opening_results ? this.find_nearby_relations(relations_to_group) : relations_to_group.ToList();
+            this.peak_accepted = typeof(TheoreticalProteoform).IsAssignableFrom(grouped_relations.First().connected_proteoforms[1].GetType()) ?
+                     this.peak_relation_group_count >= Lollipop.min_peak_count_et :
+                     this.peak_relation_group_count >= Lollipop.min_peak_count_ee;
             if (!Lollipop.opening_results && Lollipop.updated_theoretical) this.possiblePeakAssignments = nearestPTMs(this.peak_deltaM_average);
         }
 
         /*(this needs to be done at the actual time of forming peaks or else the average is wrong so the peak can be formed out
             of incorrect relations (average shouldn't include relations already grouped into peaks)*/
-        public List<ProteoformRelation> find_nearby_relations(List<ProteoformRelation> ungrouped_relations)
+        private List<ProteoformRelation> find_nearby_relations(List<ProteoformRelation> ungrouped_relations)
         {
             for (int i = 0; i < Lollipop.relation_group_centering_iterations; i++)
             {
-                double center_deltaM;
-                double peak_width_base;
-                if (typeof(TheoreticalProteoform).IsAssignableFrom(ungrouped_relations[0].connected_proteoforms[1].GetType())) peak_width_base = Lollipop.peak_width_base_et;
-                else peak_width_base = Lollipop.peak_width_base_ee;
-                if (i > 0)
-                
-                    center_deltaM = peak_deltaM_average;
-
-                else center_deltaM = this.delta_mass;
-                                
+                double center_deltaM = i > 0 ? peak_deltaM_average : this.delta_mass;
+                double peak_width_base = typeof(TheoreticalProteoform).IsAssignableFrom(ungrouped_relations.First().connected_proteoforms[1].GetType()) ?
+                    Lollipop.peak_width_base_et :
+                    Lollipop.peak_width_base_ee;
                 double lower_limit_of_peak_width = center_deltaM - peak_width_base / 2;
                 double upper_limit_of_peak_width = center_deltaM + peak_width_base / 2;
-                this.grouped_relations = ungrouped_relations.
-                    Where(relation => relation.delta_mass >= lower_limit_of_peak_width && relation.delta_mass <= upper_limit_of_peak_width).ToList();
+                grouped_relations = ungrouped_relations.Where(relation => relation.delta_mass >= lower_limit_of_peak_width && relation.delta_mass <= upper_limit_of_peak_width).ToList();
+                peak_deltaM_average = grouped_relations.Select(r => r.delta_mass).Average();
             }
 
             foreach (ProteoformRelation mass_difference in grouped_relations)
                 foreach (Proteoform p in mass_difference.connected_proteoforms)
-                    p.relationships.Add(mass_difference);
+                    lock (p) p.relationships.Add(mass_difference);
 
             return this.grouped_relations;
         }
@@ -115,7 +96,7 @@ namespace ProteoformSuiteInternal
             if (this.relation_type != ProteoformComparison.et)
                 return false; //Not currently intended for ee relations
 
-            foreach (ProteoformRelation r in this._grouped_relations)
+            foreach (ProteoformRelation r in this.grouped_relations)
             {
                 Proteoform p = r.connected_proteoforms[0];
                 if (p is ExperimentalProteoform && ((ExperimentalProteoform)p).mass_shifted == false && Lollipop.proteoform_community.experimental_proteoforms.Contains(p))

--- a/ProteoformSuiteInternal/ProteoformRelation.cs
+++ b/ProteoformSuiteInternal/ProteoformRelation.cs
@@ -72,14 +72,14 @@ namespace ProteoformSuiteInternal
             if (!Lollipop.opening_results) this.nearby_relations = relation.nearby_relations;
         }
 
-        public List<ProteoformRelation> set_nearby_group(List<ProteoformRelation> all_ordered_relations)
+        public List<ProteoformRelation> set_nearby_group(List<ProteoformRelation> all_ordered_relations, List<int> ordered_relation_ids)
         {
             double peak_width_base = typeof(TheoreticalProteoform).IsAssignableFrom(all_ordered_relations[0].connected_proteoforms[1].GetType()) ? 
                 Lollipop.peak_width_base_et :
                 Lollipop.peak_width_base_ee;
             double lower_limit_of_peak_width = this.delta_mass - peak_width_base / 2;
             double upper_limit_of_peak_width = this.delta_mass + peak_width_base / 2;
-            int idx = all_ordered_relations.IndexOf(this);
+            int idx = ordered_relation_ids.IndexOf(this.instanceId);
             List<ProteoformRelation> within_range = new List<ProteoformRelation> { this };
             int curr_idx = idx - 1;
             while (curr_idx >= 0 && lower_limit_of_peak_width <= all_ordered_relations[curr_idx].delta_mass)
@@ -101,6 +101,20 @@ namespace ProteoformSuiteInternal
         {
             new DeltaMassPeak(this, Lollipop.proteoform_community.remaining_relations_outside_no_mans);
             if (Lollipop.decoy_databases > 0) this.peak.calculate_fdr(Lollipop.ed_relations);
+        }
+
+        public override bool Equals(object obj)
+        {
+            ProteoformRelation r2 = obj as ProteoformRelation; 
+            return r2 != null && 
+                (this.instanceId == r2.instanceId ||
+                this.connected_proteoforms[0] == r2.connected_proteoforms[1] && this.connected_proteoforms[1] == r2.connected_proteoforms[0] ||
+                this.connected_proteoforms[0] == r2.connected_proteoforms[0] && this.connected_proteoforms[1] == r2.connected_proteoforms[1]);
+        }
+
+        public override int GetHashCode()
+        {
+            return connected_proteoforms[0].GetHashCode() ^ connected_proteoforms[1].GetHashCode();
         }
 
         // FOR DATAGRIDVIEW DISPLAY

--- a/ProteoformSuiteInternal/ProteoformRelation.cs
+++ b/ProteoformSuiteInternal/ProteoformRelation.cs
@@ -72,15 +72,28 @@ namespace ProteoformSuiteInternal
             if (!Lollipop.opening_results) this.nearby_relations = relation.nearby_relations;
         }
 
-        public List<ProteoformRelation> set_nearby_group(List<ProteoformRelation> all_relations)
+        public List<ProteoformRelation> set_nearby_group(List<ProteoformRelation> all_ordered_relations)
         {
-            double peak_width_base = typeof(TheoreticalProteoform).IsAssignableFrom(all_relations[0].connected_proteoforms[1].GetType()) ? 
+            double peak_width_base = typeof(TheoreticalProteoform).IsAssignableFrom(all_ordered_relations[0].connected_proteoforms[1].GetType()) ? 
                 Lollipop.peak_width_base_et :
                 Lollipop.peak_width_base_ee;
             double lower_limit_of_peak_width = this.delta_mass - peak_width_base / 2;
             double upper_limit_of_peak_width = this.delta_mass + peak_width_base / 2;
-            lock (this) nearby_relations = all_relations.Where(relation =>
-                lower_limit_of_peak_width <= relation.delta_mass && relation.delta_mass <= upper_limit_of_peak_width).ToList();
+            int idx = all_ordered_relations.IndexOf(this);
+            List<ProteoformRelation> within_range = new List<ProteoformRelation> { this };
+            int curr_idx = idx - 1;
+            while (curr_idx >= 0 && lower_limit_of_peak_width <= all_ordered_relations[curr_idx].delta_mass)
+            {
+                within_range.Add(all_ordered_relations[curr_idx]);
+                curr_idx--;
+            }
+            curr_idx = idx + 1;
+            while (curr_idx < all_ordered_relations.Count && all_ordered_relations[curr_idx].delta_mass <= upper_limit_of_peak_width)
+            {
+                within_range.Add(all_ordered_relations[curr_idx]);
+                curr_idx++;
+            }
+            lock (this) nearby_relations = within_range;
             return this.nearby_relations;
         }
 

--- a/Test/TestCytoscapeScript.cs
+++ b/Test/TestCytoscapeScript.cs
@@ -147,6 +147,7 @@ namespace Test
         public void cytoscape_edges_and_nodes_match()
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
+            Lollipop.proteoform_community = community;
             string edges = CytoscapeScript.get_cytoscape_edges_tsv(community.families, 2);
             string[] lines = edges.Split(new char[] { '\n' });
             HashSet<string> shared_pf_names_edges = new HashSet<string>();
@@ -177,6 +178,7 @@ namespace Test
         public void cytoscape_script_from_theoreticals()
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
+            Lollipop.proteoform_community = community;
             CytoscapeScript.write_cytoscape_script(community.families.SelectMany(f => f.theoretical_proteoforms).ToArray(), community.families, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2);
             string[] edge_lines = File.ReadAllLines(Path.Combine(TestContext.CurrentContext.TestDirectory, CytoscapeScript.edge_file_prefix + "test" + CytoscapeScript.edge_file_extension));
             HashSet<string> shared_pf_names_edges = new HashSet<string>();
@@ -206,6 +208,7 @@ namespace Test
         public void cytoscape_script_from_goterm()
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
+            Lollipop.proteoform_community = community;
             CytoscapeScript.write_cytoscape_script(new GoTerm[] { TestProteoformFamilies.p1_goterm }, community.families, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2);
             string[] edge_lines = File.ReadAllLines(Path.Combine(TestContext.CurrentContext.TestDirectory, CytoscapeScript.edge_file_prefix + "test" + CytoscapeScript.edge_file_extension));
             HashSet<string> shared_pf_names_edges = new HashSet<string>();
@@ -235,6 +238,7 @@ namespace Test
         public void cytoscape_script_from_quantValues()
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
+            Lollipop.proteoform_community = community;
             CytoscapeScript.write_cytoscape_script(community.families.SelectMany(f => f.experimental_proteoforms.Select(ex => ex.quant)).ToArray(), community.families, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2);
             string[] edge_lines = File.ReadAllLines(Path.Combine(TestContext.CurrentContext.TestDirectory, CytoscapeScript.edge_file_prefix + "test" + CytoscapeScript.edge_file_extension));
             HashSet<string> shared_pf_names_edges = new HashSet<string>();
@@ -264,6 +268,7 @@ namespace Test
         public void cytoscape_script_from_subset_of_families()
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
+            Lollipop.proteoform_community = community;
             CytoscapeScript.write_cytoscape_script(new List<ProteoformFamily> { community.families[0] }, community.families, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2);
             string[] edge_lines = File.ReadAllLines(Path.Combine(TestContext.CurrentContext.TestDirectory, CytoscapeScript.edge_file_prefix + "test" + CytoscapeScript.edge_file_extension));
             HashSet<string> shared_pf_names_edges = new HashSet<string>();

--- a/Test/TestDeltaMassPeak.cs
+++ b/Test/TestDeltaMassPeak.cs
@@ -59,7 +59,7 @@ namespace Test
 
             ProteoformRelation base_relation = new ProteoformRelation(pf3, pf4, relation_type2, delta_mass2);
 
-            base_relation.nearby_relations = base_relation.set_nearby_group(theList);
+            base_relation.nearby_relations = base_relation.set_nearby_group(theList, theList.Select(r => r.instanceId).ToList());
             Console.WriteLine("Creating deltaMassPeak");
             DeltaMassPeak deltaMassPeak = new DeltaMassPeak(base_relation, theList);
             Console.WriteLine("Created deltaMassPeak");
@@ -131,7 +131,7 @@ namespace Test
             pr2.relation_type = comparison34;
 
             List<ProteoformRelation> prs2 = new List<ProteoformRelation> { pr2, pr3, pr4 };
-            foreach (ProteoformRelation pr in prs2) pr.set_nearby_group(prs2);
+            foreach (ProteoformRelation pr in prs2) pr.set_nearby_group(prs2, prs2.Select(r => r.instanceId).ToList());
             Assert.AreEqual(3, pr2.nearby_relations_count);
             Assert.AreEqual(3, pr3.nearby_relations_count);
             Assert.AreEqual(3, pr4.nearby_relations_count);
@@ -163,7 +163,7 @@ namespace Test
             ProteoformRelation pr2 = new ProteoformRelation(pf3, pf4, wrong_comparison, 0);
             ProteoformRelation pr3 = new ProteoformRelation(pf3, pf4, wrong_comparison, 0);
             List<ProteoformRelation> prs = new List<ProteoformRelation> { pr2, pr3 };
-            foreach (ProteoformRelation pr in prs) pr.set_nearby_group(prs);
+            foreach (ProteoformRelation pr in prs) pr.set_nearby_group(prs, prs.Select(r => r.instanceId).ToList());
             test_community.accept_deltaMass_peaks(prs, new List<ProteoformRelation>());
             Assert.False(test_community.delta_mass_peaks[0].shift_experimental_masses(1, true));
         }
@@ -218,7 +218,7 @@ namespace Test
             ProteoformRelation pr3 = new ProteoformRelation(pf3, pf7, comparison36, 1);
             ProteoformRelation pr4 = new ProteoformRelation(pf4, pf8, comparison47, 1);
             List<ProteoformRelation> prs = new List<ProteoformRelation> { pr1, pr2, pr3, pr4 };
-            foreach (ProteoformRelation pr in prs) pr.set_nearby_group(prs);
+            foreach (ProteoformRelation pr in prs) pr.set_nearby_group(prs, prs.Select(r => r.instanceId).ToList());
             test_community.accept_deltaMass_peaks(prs, new List<ProteoformRelation>());
             Assert.AreEqual(2, test_community.delta_mass_peaks.Count);
 
@@ -283,7 +283,7 @@ namespace Test
             ProteoformRelation pr3 = new ProteoformRelation(pf3, pf7, comparison36, 1);
             ProteoformRelation pr4 = new ProteoformRelation(pf4, pf8, comparison47, 1);
             List<ProteoformRelation> prs = new List<ProteoformRelation> { pr1, pr2, pr3, pr4 };
-            foreach (ProteoformRelation pr in prs) pr.set_nearby_group(prs);
+            foreach (ProteoformRelation pr in prs) pr.set_nearby_group(prs, prs.Select(r => r.instanceId).ToList());
             test_community.accept_deltaMass_peaks(prs, new List<ProteoformRelation>());
             Assert.AreEqual(2, test_community.delta_mass_peaks.Count);
 

--- a/Test/TestDeltaMassPeak.cs
+++ b/Test/TestDeltaMassPeak.cs
@@ -93,6 +93,8 @@ namespace Test
         public void TestAcceptDeltaMassPeaks()
         {
             ProteoformCommunity test_community = new ProteoformCommunity();
+            Lollipop.proteoform_community = test_community;
+
             Lollipop.uniprotModificationTable = new Dictionary<string, IList<Modification>> {
                 { "unmodified", new List<Modification>() {
                     new ModificationWithMass("unmodified", new Tuple<string, string>("", ""), null, ModificationSites.K, 0, new Dictionary<string, IList<string>>(), -1, new List<double>(), new List<double>(), "") }
@@ -154,6 +156,7 @@ namespace Test
         public void wrong_relation_shifting()
         {
             ProteoformCommunity test_community = new ProteoformCommunity();
+            Lollipop.proteoform_community = test_community;
             ExperimentalProteoform pf3 = new ExperimentalProteoform("E1");
             ExperimentalProteoform pf4 = new ExperimentalProteoform("E2");
             ProteoformComparison wrong_comparison = ProteoformComparison.ee;
@@ -183,6 +186,7 @@ namespace Test
         public void shift_et_peak_neucode()
         {
             ProteoformCommunity test_community = new ProteoformCommunity();
+            Lollipop.proteoform_community = test_community;
 
             //Make a few experimental proteoforms
             List<Component> n1 = TestExperimentalProteoform.generate_neucode_components(100);
@@ -247,6 +251,7 @@ namespace Test
         public void shift_et_peak_unlabeled()
         {
             ProteoformCommunity test_community = new ProteoformCommunity();
+            Lollipop.proteoform_community = test_community;
 
             //Make a few experimental proteoforms
             List<Component> n1 = TestExperimentalProteoform.generate_neucode_components(100);

--- a/Test/TestGoTermNumber.cs
+++ b/Test/TestGoTermNumber.cs
@@ -97,8 +97,13 @@ namespace Test
             t.proteinList = new List<ProteinWithGoTerms> { p1 };
             u.proteinList = new List<ProteinWithGoTerms> { p2 };
             v.proteinList = new List<ProteinWithGoTerms> { p3 };
-            ProteoformFamily f = new ProteoformFamily(new List<Proteoform> { t, v, e1 }, 0); // two theoreticals with the same GoTerms... expecting one GoTerm number but two theoretical proteins
-            ProteoformFamily h = new ProteoformFamily(new List<Proteoform> { u, e2 }, 0);
+            make_relation(e1, t);
+            make_relation(e1, v);
+            make_relation(e2, u);
+            ProteoformFamily f = new ProteoformFamily(e1); // two theoreticals with the same GoTerms... expecting one GoTerm number but two theoretical proteins
+            ProteoformFamily h = new ProteoformFamily(e2);
+            f.construct_family();
+            h.construct_family();
             List<ProteoformFamily> families = new List<ProteoformFamily> { f, h };
             t.family = f;
             v.family = f;
@@ -149,8 +154,13 @@ namespace Test
             t.proteinList = new List<ProteinWithGoTerms> { p1 };
             u.proteinList = new List<ProteinWithGoTerms> { p2 };
             v.proteinList = new List<ProteinWithGoTerms> { p3 };
-            ProteoformFamily f = new ProteoformFamily(new List<Proteoform> { t, v, e1 }, 0); // two theoreticals with the same GoTerms... expecting one GoTerm number but two theoretical proteins
-            ProteoformFamily h = new ProteoformFamily(new List<Proteoform> { u, e2 }, 0);
+            make_relation(e1, t);
+            make_relation(e1, v);
+            make_relation(e2, u);
+            ProteoformFamily f = new ProteoformFamily(e1); // two theoreticals with the same GoTerms... expecting one GoTerm number but two theoretical proteins
+            ProteoformFamily h = new ProteoformFamily(e2);
+            f.construct_family();
+            h.construct_family();
             List<ProteoformFamily> families = new List<ProteoformFamily> { f, h };
             t.family = f;
             v.family = f;
@@ -169,6 +179,16 @@ namespace Test
             List<ProteoformFamily> fams = Lollipop.getInterestingFamilies(Lollipop.goTermNumbers, families);
             Assert.AreEqual(1, fams.Count);
             Assert.AreEqual(2, fams[0].theoretical_proteoforms.Count);
+        }
+
+        public void make_relation(Proteoform p1, Proteoform p2)
+        {
+            ProteoformRelation pp = new ProteoformRelation(p1, p2, ProteoformComparison.ee, 0);
+            DeltaMassPeak ppp = new DeltaMassPeak(pp, new List<ProteoformRelation> { pp });
+            pp.peak = ppp;
+            ppp.peak_accepted = true;
+            p1.relationships.Add(pp);
+            p2.relationships.Add(pp);
         }
 
         [Test]
@@ -202,8 +222,13 @@ namespace Test
             t.proteinList = new List<ProteinWithGoTerms> { p1 };
             u.proteinList = new List<ProteinWithGoTerms> { p2 };
             v.proteinList = new List<ProteinWithGoTerms> { p3 };
-            ProteoformFamily f = new ProteoformFamily(new List<Proteoform> { t, v, e1 }, 0); // two theoreticals with the same GoTerms... expecting one GoTerm number but two theoretical proteins
-            ProteoformFamily h = new ProteoformFamily(new List<Proteoform> { u, e2 }, 0);
+            make_relation(e1, t);
+            make_relation(e1, v);
+            make_relation(e2, u);
+            ProteoformFamily f = new ProteoformFamily(e1); // two theoreticals with the same GoTerms... expecting one GoTerm number but two theoretical proteins
+            ProteoformFamily h = new ProteoformFamily(e2);
+            f.construct_family();
+            h.construct_family();
             List<ProteoformFamily> families = new List<ProteoformFamily> { f, h };
             t.family = f;
             v.family = f;

--- a/Test/TestProteoformFamilies.cs
+++ b/Test/TestProteoformFamilies.cs
@@ -46,6 +46,8 @@ namespace Test
         {
             //Four experimental proteoforms, three relations (linear), all accepted; should give 1 bundled family
             ProteoformCommunity test_community = new ProteoformCommunity();
+            Lollipop.proteoform_community = test_community;
+
             Lollipop.uniprotModificationTable = new Dictionary<string, IList<Modification>> { { "unmodified", new List<Modification> { new Modification("unmodified") } } };
 
             Lollipop.min_peak_count_ee = 2;
@@ -85,6 +87,8 @@ namespace Test
         {
             //Five experimental proteoforms, four relations (linear), second on not accepted into a peak, one peak; should give 2 families
             ProteoformCommunity test_community = new ProteoformCommunity();
+            Lollipop.proteoform_community = test_community;
+
             Lollipop.uniprotModificationTable = new Dictionary<string, IList<Modification>> { { "unmodified", new List<Modification> { new Modification("unmodified") } } };
 
             Lollipop.ee_max_mass_difference = 20;
@@ -176,6 +180,7 @@ namespace Test
         {
             //Five experimental proteoforms, four relations (linear), second on not accepted into a peak, one peak; should give 2 families
             ProteoformCommunity community = new ProteoformCommunity();
+            Lollipop.proteoform_community = community;
             Lollipop.uniprotModificationTable = new Dictionary<string, IList<Modification>> { { "unmodified", new List<Modification> { new Modification("unmodified") } } };
 
             Lollipop.ee_max_mass_difference = 20;
@@ -259,6 +264,7 @@ namespace Test
         public void test_construct_one_proteform_family_from_ET_with_two_theoretical_pf_groups_with_same_accession()
         {
             ProteoformCommunity community = construct_two_families_with_potentially_colliding_theoreticals();
+            Lollipop.proteoform_community = community;
 
             Assert.AreEqual(2, community.families.Count);
             Assert.AreEqual(8, community.families.SelectMany(f => f.proteoforms).Count());

--- a/Test/TestProteoformFamilies.cs
+++ b/Test/TestProteoformFamilies.cs
@@ -110,7 +110,7 @@ namespace Test
             ProteoformRelation pr4 = new ProteoformRelation(pf5, pf6, comparison56, 0);
             ProteoformRelation pr5 = new ProteoformRelation(pf6, pf7, comparison67, 0);
 
-            List<ProteoformRelation> prs2 = new List<ProteoformRelation> { pr2, pr3, pr4, pr5 };
+            List<ProteoformRelation> prs2 = new List<ProteoformRelation> { pr2, pr3, pr4, pr5 }.OrderBy(r => r.delta_mass).ToList();
             foreach (ProteoformRelation pr in prs2) pr.set_nearby_group(prs2);
             Assert.AreEqual(3, pr2.nearby_relations_count);
             Assert.AreEqual(1, pr3.nearby_relations_count);
@@ -235,8 +235,8 @@ namespace Test
             ProteoformRelation pr7 = new ProteoformRelation(pf7, pf8, comparison78, 0);
 
             List<ProteoformRelation> prs = new List<ProteoformRelation> { pr1, pr2, pr3, pr4, pr5, pr6, pr7 };
-            List<ProteoformRelation> prs_et = prs.Where(r => r.relation_type == ProteoformComparison.et).ToList();
-            List<ProteoformRelation> prs_ee = prs.Where(r => r.relation_type == ProteoformComparison.ee).ToList();
+            List<ProteoformRelation> prs_et = prs.Where(r => r.relation_type == ProteoformComparison.et).OrderBy(r => r.delta_mass).ToList();
+            List<ProteoformRelation> prs_ee = prs.Where(r => r.relation_type == ProteoformComparison.ee).OrderBy(r => r.delta_mass).ToList();
             foreach (ProteoformRelation pr in prs_et) pr.set_nearby_group(prs_et);
             foreach (ProteoformRelation pr in prs_ee) pr.set_nearby_group(prs_ee);
             Assert.AreEqual(2, pr1.nearby_relations_count); // 2 ET relations at 0 delta mass

--- a/Test/TestProteoformFamilies.cs
+++ b/Test/TestProteoformFamilies.cs
@@ -26,7 +26,7 @@ namespace Test
             ProteoformComparison comparison = ProteoformComparison.et;
             ProteoformRelation pr1 = new ProteoformRelation(pf1, pf2, comparison, 0);
             List<ProteoformRelation> prs = new List<ProteoformRelation> { pr1 };
-            foreach (ProteoformRelation pr in prs) pr.set_nearby_group(prs);
+            foreach (ProteoformRelation pr in prs) pr.set_nearby_group(prs, prs.Select(r => r.instanceId).ToList());
             DeltaMassPeak peak = new DeltaMassPeak(prs[0], prs);
             test_community.delta_mass_peaks = new List<DeltaMassPeak> { peak };
             test_community.experimental_proteoforms = new ExperimentalProteoform[] { pf1 };
@@ -55,19 +55,20 @@ namespace Test
             ExperimentalProteoform pf4 = new ExperimentalProteoform("E2");
             ExperimentalProteoform pf5 = new ExperimentalProteoform("E3");
             ExperimentalProteoform pf6 = new ExperimentalProteoform("E4");
+            test_community.experimental_proteoforms = new ExperimentalProteoform[] { pf3, pf4, pf5, pf6 };
 
             ProteoformComparison comparison34 = ProteoformComparison.ee;
             ProteoformComparison comparison45 = ProteoformComparison.ee;
             ProteoformComparison comparison56 = ProteoformComparison.ee;
-            ProteoformRelation pr2 = new ProteoformRelation(pf3, pf4, comparison34, 0);
-            ProteoformRelation pr3 = new ProteoformRelation(pf4, pf5, comparison45, 0);
-            ProteoformRelation pr4 = new ProteoformRelation(pf5, pf6, comparison56, 0);
+            make_relation(pf3, pf4, comparison34, 0);
+            make_relation(pf4, pf5, comparison45, 0);
+            make_relation(pf5, pf6, comparison56, 0);
 
-            List<ProteoformRelation> prs2 = new List<ProteoformRelation> { pr2, pr3, pr4 };
-            foreach (ProteoformRelation pr in prs2) pr.set_nearby_group(prs2);
-            Assert.AreEqual(3, pr2.nearby_relations_count);
-            Assert.AreEqual(3, pr3.nearby_relations_count);
-            Assert.AreEqual(3, pr4.nearby_relations_count);
+            List<ProteoformRelation> prs2 = new HashSet<ProteoformRelation>(test_community.experimental_proteoforms.SelectMany(p => p.relationships).Concat(test_community.theoretical_proteoforms.SelectMany(p => p.relationships))).OrderBy(r => r.delta_mass).ToList();
+            foreach (ProteoformRelation pr in prs2) pr.set_nearby_group(prs2, prs2.Select(r => r.instanceId).ToList());
+            Assert.AreEqual(3, pf3.relationships.First().nearby_relations_count);
+            Assert.AreEqual(3, pf5.relationships.First().nearby_relations_count);
+            Assert.AreEqual(3, pf6.relationships.First().nearby_relations_count);
 
             test_community.accept_deltaMass_peaks(prs2, new List<ProteoformRelation>());
             Assert.AreEqual(1, test_community.delta_mass_peaks.Count);
@@ -111,7 +112,7 @@ namespace Test
             ProteoformRelation pr5 = new ProteoformRelation(pf6, pf7, comparison67, 0);
 
             List<ProteoformRelation> prs2 = new List<ProteoformRelation> { pr2, pr3, pr4, pr5 }.OrderBy(r => r.delta_mass).ToList();
-            foreach (ProteoformRelation pr in prs2) pr.set_nearby_group(prs2);
+            foreach (ProteoformRelation pr in prs2) pr.set_nearby_group(prs2, prs2.Select(r => r.instanceId).ToList());
             Assert.AreEqual(3, pr2.nearby_relations_count);
             Assert.AreEqual(1, pr3.nearby_relations_count);
             Assert.AreEqual(3, pr4.nearby_relations_count);
@@ -125,14 +126,14 @@ namespace Test
             test_community.experimental_proteoforms = new ExperimentalProteoform[] { pf3, pf4, pf5, pf6, pf7 };
             test_community.construct_families();
             Assert.AreEqual(2, test_community.families.Count);
-            Assert.AreEqual("", test_community.families[0].accession_list);
-            Assert.AreEqual(2, test_community.families[0].proteoforms.Count);
-            Assert.AreEqual(2, test_community.families[0].experimental_count);
-            Assert.AreEqual(0, test_community.families[0].theoretical_count);
-            Assert.AreEqual("", test_community.families[1].accession_list);
-            Assert.AreEqual(3, test_community.families[1].proteoforms.Count);
-            Assert.AreEqual(3, test_community.families[1].experimental_count);
-            Assert.AreEqual(0, test_community.families[1].theoretical_count);
+            Assert.AreEqual("", test_community.families.FirstOrDefault(f => f.proteoforms.Contains(pf3)).accession_list);
+            Assert.AreEqual(2, test_community.families.FirstOrDefault(f => f.proteoforms.Contains(pf3)).proteoforms.Count);
+            Assert.AreEqual(2, test_community.families.FirstOrDefault(f => f.proteoforms.Contains(pf3)).experimental_count);
+            Assert.AreEqual(0, test_community.families.FirstOrDefault(f => f.proteoforms.Contains(pf3)).theoretical_count);
+            Assert.AreEqual("", test_community.families.FirstOrDefault(f => f.proteoforms.Contains(pf5)).accession_list);
+            Assert.AreEqual(3, test_community.families.FirstOrDefault(f => f.proteoforms.Contains(pf5)).proteoforms.Count);
+            Assert.AreEqual(3, test_community.families.FirstOrDefault(f => f.proteoforms.Contains(pf5)).experimental_count);
+            Assert.AreEqual(0, test_community.families.FirstOrDefault(f => f.proteoforms.Contains(pf5)).theoretical_count);
         }
 
         [Test]
@@ -155,7 +156,7 @@ namespace Test
             ProteoformComparison comparison = ProteoformComparison.et;
             ProteoformRelation pr1 = new ProteoformRelation(pf1, pf2, comparison, 0);
             List<ProteoformRelation> prs = new List<ProteoformRelation> { pr1 };
-            foreach (ProteoformRelation pr in prs) pr.set_nearby_group(prs);
+            foreach (ProteoformRelation pr in prs) pr.set_nearby_group(prs, prs.Select(r => r.instanceId).ToList());
             DeltaMassPeak peak = new DeltaMassPeak(prs[0], prs);
             test_community.delta_mass_peaks = new List<DeltaMassPeak> { peak };
             test_community.experimental_proteoforms = new ExperimentalProteoform[] { pf1 };
@@ -168,6 +169,13 @@ namespace Test
             Assert.AreEqual("E1", test_community.families.First().experimentals_list);
             Assert.AreEqual(p1.Name, test_community.families.First().name_list);
             Assert.AreEqual(pf2.accession, test_community.families.First().accession_list);
+        }
+
+        public static void make_relation(Proteoform p1, Proteoform p2, ProteoformComparison c, double delta_mass)
+        {
+            ProteoformRelation pp = new ProteoformRelation(p1, p2, c, delta_mass);
+            p1.relationships.Add(pp);
+            p2.relationships.Add(pp);
         }
 
         public static string p1_accession = "T1";
@@ -205,12 +213,12 @@ namespace Test
             community.theoretical_proteoforms = new TheoreticalProteoform[] { pf1, pf2 };
 
             //ExperimentalProteoforms
-            ExperimentalProteoform pf3 = new ExperimentalProteoform("E1");
-            ExperimentalProteoform pf4 = new ExperimentalProteoform("E2");
-            ExperimentalProteoform pf5 = new ExperimentalProteoform("E3");
-            ExperimentalProteoform pf6 = new ExperimentalProteoform("E4");
-            ExperimentalProteoform pf7 = new ExperimentalProteoform("E5");
-            ExperimentalProteoform pf8 = new ExperimentalProteoform("E6");
+            ExperimentalProteoform pf3 = new ExperimentalProteoform("E1", 0, 0, true);
+            ExperimentalProteoform pf4 = new ExperimentalProteoform("E2", 0, 0, true);
+            ExperimentalProteoform pf5 = new ExperimentalProteoform("E3", 0, 0, true);
+            ExperimentalProteoform pf6 = new ExperimentalProteoform("E4", 0, 0, true);
+            ExperimentalProteoform pf7 = new ExperimentalProteoform("E5", 0, 0, true);
+            ExperimentalProteoform pf8 = new ExperimentalProteoform("E6", 0, 0, true);
             community.experimental_proteoforms = new ExperimentalProteoform[] { pf3, pf4, pf5, pf6, pf7, pf8 };
             pf3.agg_mass = 1234.56;
             pf4.agg_mass = 1234.56;
@@ -226,26 +234,28 @@ namespace Test
             ProteoformComparison comparison56 = ProteoformComparison.ee;
             ProteoformComparison comparison67 = ProteoformComparison.ee;
             ProteoformComparison comparison78 = ProteoformComparison.ee;
-            ProteoformRelation pr1 = new ProteoformRelation(pf3, pf1, comparison13, 0);
-            ProteoformRelation pr2 = new ProteoformRelation(pf3, pf2, comparison23, 0);
-            ProteoformRelation pr3 = new ProteoformRelation(pf3, pf4, comparison34, 0);
-            ProteoformRelation pr4 = new ProteoformRelation(pf4, pf5, comparison45, 0); 
-            ProteoformRelation pr5 = new ProteoformRelation(pf5, pf6, comparison56, 19); //not accepted
-            ProteoformRelation pr6 = new ProteoformRelation(pf6, pf7, comparison67, 0);
-            ProteoformRelation pr7 = new ProteoformRelation(pf7, pf8, comparison78, 0);
+            make_relation(pf3, pf1, comparison13, 0);
+            make_relation(pf3, pf2, comparison23, 0);
+            make_relation(pf3, pf4, comparison34, 0);
+            make_relation(pf4, pf5, comparison45, 0);
+            make_relation(pf5, pf6, comparison56, 19); //not accepted
+            make_relation(pf6, pf7, comparison67, 0);
+            make_relation(pf7, pf8, comparison78, 0);
 
-            List<ProteoformRelation> prs = new List<ProteoformRelation> { pr1, pr2, pr3, pr4, pr5, pr6, pr7 };
+
+
+            List<ProteoformRelation> prs = new HashSet<ProteoformRelation>(community.experimental_proteoforms.SelectMany(p => p.relationships).Concat(community.theoretical_proteoforms.SelectMany(p => p.relationships))).ToList();
             List<ProteoformRelation> prs_et = prs.Where(r => r.relation_type == ProteoformComparison.et).OrderBy(r => r.delta_mass).ToList();
             List<ProteoformRelation> prs_ee = prs.Where(r => r.relation_type == ProteoformComparison.ee).OrderBy(r => r.delta_mass).ToList();
-            foreach (ProteoformRelation pr in prs_et) pr.set_nearby_group(prs_et);
-            foreach (ProteoformRelation pr in prs_ee) pr.set_nearby_group(prs_ee);
-            Assert.AreEqual(2, pr1.nearby_relations_count); // 2 ET relations at 0 delta mass
-            Assert.AreEqual(2, pr2.nearby_relations_count);
-            Assert.AreEqual(4, pr3.nearby_relations_count); // 4 EE relations at 0 delta mass
-            Assert.AreEqual(4, pr4.nearby_relations_count);
-            Assert.AreEqual(1, pr5.nearby_relations_count); // 1 EE relation at 19 delta mass
-            Assert.AreEqual(4, pr6.nearby_relations_count);
-            Assert.AreEqual(4, pr7.nearby_relations_count);
+            foreach (ProteoformRelation pr in prs_et) pr.set_nearby_group(prs_et, prs_et.Select(r => r.instanceId).ToList());
+            foreach (ProteoformRelation pr in prs_ee) pr.set_nearby_group(prs_ee, prs_ee.Select(r => r.instanceId).ToList());
+            Assert.AreEqual(2, pf1.relationships.First().nearby_relations_count); // 2 ET relations at 0 delta mass
+            Assert.AreEqual(2, pf2.relationships.First().nearby_relations_count);
+            Assert.AreEqual(4, pf4.relationships.First().nearby_relations_count); // 4 EE relations at 0 delta mass
+            Assert.AreEqual(4, pf5.relationships.First().nearby_relations_count);
+            Assert.AreEqual(1, pf6.relationships.First().nearby_relations_count); // 1 EE relation at 19 delta mass
+            Assert.AreEqual(4, pf7.relationships.First().nearby_relations_count);
+            Assert.AreEqual(4, pf8.relationships.First().nearby_relations_count);
 
             community.accept_deltaMass_peaks(prs_et, new List<ProteoformRelation>());
             community.accept_deltaMass_peaks(prs_ee, new List<ProteoformRelation>());
@@ -268,10 +278,10 @@ namespace Test
 
             Assert.AreEqual(2, community.families.Count);
             Assert.AreEqual(8, community.families.SelectMany(f => f.proteoforms).Count());
-            Assert.AreEqual(5, community.families[0].proteoforms.Count);
-            Assert.AreEqual(3, community.families[1].proteoforms.Count);
-            Assert.AreEqual(3, community.families.First().experimental_count);
-            Assert.AreEqual(2, community.families.First().theoretical_count);
+            Assert.AreEqual(5, community.families.FirstOrDefault(f => f.proteoforms.Select(p => p.accession).Contains("E1")).proteoforms.Count);
+            Assert.AreEqual(3, community.families.FirstOrDefault(f => f.proteoforms.Select(p => p.accession).Contains("E6")).proteoforms.Count);
+            Assert.AreEqual(3, community.families.FirstOrDefault(f => f.proteoforms.Select(p => p.accession).Contains("E1")).experimental_count);
+            Assert.AreEqual(2, community.families.FirstOrDefault(f => f.proteoforms.Select(p => p.accession).Contains("E1")).theoretical_count);
             Assert.True(String.Join("", community.families.Select(f => f.experimentals_list)).Contains("E1"));
             Assert.True(String.Join("", community.families.Select(f => f.name_list)).Contains(p1_name));
             Assert.True(String.Join("", community.families.Select(f => f.accession_list)).Contains(pf1_accession));

--- a/Test/TestQuantification.cs
+++ b/Test/TestQuantification.cs
@@ -761,6 +761,16 @@ namespace Test
             satisfactoryProteoformsCount++;
         }
 
+        public void make_relation(Proteoform p1, Proteoform p2)
+        {
+            ProteoformRelation pp = new ProteoformRelation(p1, p2, ProteoformComparison.ee, 0);
+            DeltaMassPeak ppp = new DeltaMassPeak(pp, new List<ProteoformRelation> { pp });
+            pp.peak = ppp;
+            ppp.peak_accepted = true;
+            p1.relationships.Add(pp);
+            p2.relationships.Add(pp);
+        }
+
         [Test]
         public void test_get_observed_proteins()
         {
@@ -776,7 +786,20 @@ namespace Test
             TheoreticalProteoform u = new TheoreticalProteoform("T2_T1_asdf_asdf", "", p2, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
             TheoreticalProteoform v = new TheoreticalProteoform("T3_T1_asdf_Asdf_Asdf", "", p3, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
             ExperimentalProteoform e = new ExperimentalProteoform("E1");
-            ProteoformFamily f = new ProteoformFamily(new List<Proteoform> { e, t, u }, 0);
+            ProteoformRelation et = new ProteoformRelation(e, t, ProteoformComparison.et, 0);
+            DeltaMassPeak etp = new DeltaMassPeak(et, new List<ProteoformRelation> { et });
+            et.peak = etp;
+            etp.peak_accepted = true;
+            e.relationships.Add(et);
+            t.relationships.Add(et);
+            ProteoformRelation eu = new ProteoformRelation(e, u, ProteoformComparison.et, 0);
+            DeltaMassPeak eup = new DeltaMassPeak(eu, new List<ProteoformRelation> { eu });
+            eu.peak = eup;
+            eup.peak_accepted = true;
+            e.relationships.Add(eu);
+            u.relationships.Add(eu);
+            ProteoformFamily f = new ProteoformFamily(e);
+            f.construct_family();
             e.family = f;
             t.family = f;
             u.family = f;
@@ -805,7 +828,14 @@ namespace Test
             ExperimentalProteoform fx = new ExperimentalProteoform("E1");
             ExperimentalProteoform gx = new ExperimentalProteoform("E1");
             ExperimentalProteoform hx = new ExperimentalProteoform("E1");
-            ProteoformFamily f = new ProteoformFamily(new List<Proteoform> { ex, fx, gx, hx, t, u }, 0);
+            make_relation(ex, t);
+            make_relation(ex, u);
+            //make_relation(ex, v);
+            make_relation(ex, fx);
+            make_relation(ex, gx);
+            make_relation(ex, hx);
+            ProteoformFamily f = new ProteoformFamily(ex);
+            f.construct_family();
             ex.family = f;
             fx.family = f;
             gx.family = f;
@@ -899,9 +929,16 @@ namespace Test
             fx.quant.FDR = 0.4m;
             fx.quant.intensitySum = 2;
             List<ExperimentalProteoform> exps = new List<ExperimentalProteoform> { ex, fx, gx, hx };
-            ProteoformFamily e = new ProteoformFamily(new List<Proteoform> { ex }, 0);
-            ProteoformFamily f = new ProteoformFamily(new List<Proteoform> { fx, gx, v }, 0);
-            ProteoformFamily h = new ProteoformFamily(new List<Proteoform> { hx, t, u }, 0);
+            make_relation(gx, v);
+            make_relation(fx, v);
+            make_relation(hx, t);
+            make_relation(hx, u);        
+            ProteoformFamily e = new ProteoformFamily(ex);
+            ProteoformFamily f = new ProteoformFamily(v);
+            ProteoformFamily h = new ProteoformFamily(hx);
+            e.construct_family();
+            f.construct_family();
+            h.construct_family();
             List<ProteoformFamily> families = new List<ProteoformFamily> { e, f, h };
             ex.family = e;
             fx.family = f;


### PR DESCRIPTION
* Parallelized count_nearby_relations
* Used ordered lists to narrow search for nearby relations in most cases
* Threaded accepting delta mass peaks that are >= 10 Da apart
* Threaded family construction
* 1 identification file takes around 45 sec, instead of >10 min
* 8 identification files take ~2 min, instead of way too much time (I gave up on the run at 20 mins)
* Results of analysis are unchanged