### PR TITLE
Gene-centric proteoform families

### DIFF
--- a/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
@@ -49,17 +49,18 @@ namespace ProteoformSuiteGUI
             Lollipop.make_ee_relationships();
             ((ProteoformSweet)MdiParent).proteoformFamilies.ClearListsAndTables();
 
+            Parallel.Invoke
+            (
+                () => this.FillTablesAndCharts(),
+                () => { if (Lollipop.neucode_labeled) Lollipop.proteoform_community.construct_families(); }
+            );
+
             if (Lollipop.neucode_labeled)
             {
-                Parallel.Invoke
-                (
-                    () => this.FillTablesAndCharts(),
-                    () => Lollipop.proteoform_community.construct_families()
-                );
                 ((ProteoformSweet)this.MdiParent).proteoformFamilies.fill_proteoform_families("");
                 ((ProteoformSweet)this.MdiParent).proteoformFamilies.update_figures_of_merit();
             }
-            else { this.FillTablesAndCharts(); }
+
             this.Cursor = Cursors.Default;
             compared_ee = true;
         }

--- a/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
@@ -46,7 +46,7 @@ namespace ProteoformSuiteGUI
         public void run_the_gamut()
         {
             this.Cursor = Cursors.WaitCursor;
-            Lollipop.make_ee_relationships();
+            Lollipop.make_ee_relationships(Lollipop.proteoform_community);
             ((ProteoformSweet)MdiParent).proteoformFamilies.ClearListsAndTables();
 
             Parallel.Invoke

--- a/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
@@ -46,7 +46,7 @@ namespace ProteoformSuiteGUI
         public void run_the_gamut()
         {
             this.Cursor = Cursors.WaitCursor;
-            Lollipop.make_et_relationships();
+            Lollipop.make_et_relationships(Lollipop.proteoform_community);
             ((ProteoformSweet)MdiParent).proteoformFamilies.ClearListsAndTables();
             this.FillTablesAndCharts();
             this.Cursor = Cursors.Default;

--- a/ProteoformSuiteGUI/ProteoformFamilies.Designer.cs
+++ b/ProteoformSuiteGUI/ProteoformFamilies.Designer.cs
@@ -32,6 +32,8 @@
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.dgv_main = new System.Windows.Forms.DataGridView();
+            this.label10 = new System.Windows.Forms.Label();
+            this.cmbx_geneLabel = new System.Windows.Forms.ComboBox();
             this.label9 = new System.Windows.Forms.Label();
             this.cmbx_edgeLabel = new System.Windows.Forms.ComboBox();
             this.label6 = new System.Windows.Forms.Label();
@@ -50,6 +52,13 @@
             this.pictureBox_familyDisplay = new System.Windows.Forms.PictureBox();
             this.splitContainer3 = new System.Windows.Forms.SplitContainer();
             this.dgv_proteoform_family_members = new System.Windows.Forms.DataGridView();
+            this.cb_geneCentric = new System.Windows.Forms.CheckBox();
+            this.btn_inclusion_list_all_families = new System.Windows.Forms.Button();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.cb_orphans = new System.Windows.Forms.CheckBox();
+            this.cb_unidentified_families = new System.Windows.Forms.CheckBox();
+            this.cb_identified_families = new System.Windows.Forms.CheckBox();
+            this.btn_inclusion_list_selected_families = new System.Windows.Forms.Button();
             this.cb_buildAsQuantitative = new System.Windows.Forms.CheckBox();
             this.groupBox5 = new System.Windows.Forms.GroupBox();
             this.cb_moreOpacity = new System.Windows.Forms.CheckBox();
@@ -72,12 +81,6 @@
             this.label8 = new System.Windows.Forms.Label();
             this.label7 = new System.Windows.Forms.Label();
             this.Families_update = new System.Windows.Forms.Button();
-            this.btn_inclusion_list_selected_families = new System.Windows.Forms.Button();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.cb_orphans = new System.Windows.Forms.CheckBox();
-            this.cb_unidentified_families = new System.Windows.Forms.CheckBox();
-            this.cb_identified_families = new System.Windows.Forms.CheckBox();
-            this.btn_inclusion_list_all_families = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -94,9 +97,9 @@
             this.splitContainer3.Panel2.SuspendLayout();
             this.splitContainer3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dgv_proteoform_family_members)).BeginInit();
+            this.groupBox1.SuspendLayout();
             this.groupBox5.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nud_decimalRoundingLabels)).BeginInit();
-            this.groupBox1.SuspendLayout();
             this.SuspendLayout();
             // 
             // splitContainer1
@@ -132,6 +135,8 @@
             // 
             // splitContainer2.Panel2
             // 
+            this.splitContainer2.Panel2.Controls.Add(this.label10);
+            this.splitContainer2.Panel2.Controls.Add(this.cmbx_geneLabel);
             this.splitContainer2.Panel2.Controls.Add(this.label9);
             this.splitContainer2.Panel2.Controls.Add(this.cmbx_edgeLabel);
             this.splitContainer2.Panel2.Controls.Add(this.label6);
@@ -164,6 +169,27 @@
             this.dgv_main.Size = new System.Drawing.Size(681, 435);
             this.dgv_main.TabIndex = 2;
             this.dgv_main.CellMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.dgv_proteoform_families_CellMouseClick);
+            // 
+            // label10
+            // 
+            this.label10.AutoSize = true;
+            this.label10.BackColor = System.Drawing.SystemColors.Control;
+            this.label10.Location = new System.Drawing.Point(134, 247);
+            this.label10.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(105, 13);
+            this.label10.TabIndex = 50;
+            this.label10.Text = "Prefered Gene Label";
+            // 
+            // cmbx_geneLabel
+            // 
+            this.cmbx_geneLabel.Enabled = false;
+            this.cmbx_geneLabel.FormattingEnabled = true;
+            this.cmbx_geneLabel.Location = new System.Drawing.Point(6, 244);
+            this.cmbx_geneLabel.Name = "cmbx_geneLabel";
+            this.cmbx_geneLabel.Size = new System.Drawing.Size(121, 21);
+            this.cmbx_geneLabel.TabIndex = 49;
+            this.cmbx_geneLabel.SelectedIndexChanged += new System.EventHandler(this.cmbx_geneLabel_SelectedIndexChanged);
             // 
             // label9
             // 
@@ -216,7 +242,7 @@
             this.label5.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.label5.AutoSize = true;
             this.label5.BackColor = System.Drawing.SystemColors.Control;
-            this.label5.Location = new System.Drawing.Point(138, 273);
+            this.label5.Location = new System.Drawing.Point(134, 274);
             this.label5.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(105, 13);
@@ -326,6 +352,7 @@
             // 
             // splitContainer3.Panel2
             // 
+            this.splitContainer3.Panel2.Controls.Add(this.cb_geneCentric);
             this.splitContainer3.Panel2.Controls.Add(this.btn_inclusion_list_all_families);
             this.splitContainer3.Panel2.Controls.Add(this.groupBox1);
             this.splitContainer3.Panel2.Controls.Add(this.btn_inclusion_list_selected_families);
@@ -363,6 +390,87 @@
             this.dgv_proteoform_family_members.Name = "dgv_proteoform_family_members";
             this.dgv_proteoform_family_members.Size = new System.Drawing.Size(675, 443);
             this.dgv_proteoform_family_members.TabIndex = 3;
+            // 
+            // cb_geneCentric
+            // 
+            this.cb_geneCentric.AutoSize = true;
+            this.cb_geneCentric.Checked = true;
+            this.cb_geneCentric.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cb_geneCentric.Location = new System.Drawing.Point(301, 87);
+            this.cb_geneCentric.Name = "cb_geneCentric";
+            this.cb_geneCentric.Size = new System.Drawing.Size(154, 17);
+            this.cb_geneCentric.TabIndex = 61;
+            this.cb_geneCentric.Text = "Build Gene-Centric Families";
+            this.cb_geneCentric.UseVisualStyleBackColor = true;
+            this.cb_geneCentric.CheckedChanged += new System.EventHandler(this.cb_geneCentric_CheckedChanged);
+            // 
+            // btn_inclusion_list_all_families
+            // 
+            this.btn_inclusion_list_all_families.Location = new System.Drawing.Point(75, 261);
+            this.btn_inclusion_list_all_families.Name = "btn_inclusion_list_all_families";
+            this.btn_inclusion_list_all_families.Size = new System.Drawing.Size(195, 23);
+            this.btn_inclusion_list_all_families.TabIndex = 60;
+            this.btn_inclusion_list_all_families.Text = "Export Inclusion List";
+            this.btn_inclusion_list_all_families.UseVisualStyleBackColor = true;
+            this.btn_inclusion_list_all_families.Click += new System.EventHandler(this.btn_inclusion_list_all_families_Click);
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.cb_orphans);
+            this.groupBox1.Controls.Add(this.cb_unidentified_families);
+            this.groupBox1.Controls.Add(this.cb_identified_families);
+            this.groupBox1.Location = new System.Drawing.Point(280, 237);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(200, 96);
+            this.groupBox1.TabIndex = 59;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Inclusion List";
+            // 
+            // cb_orphans
+            // 
+            this.cb_orphans.AutoSize = true;
+            this.cb_orphans.Checked = true;
+            this.cb_orphans.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cb_orphans.Location = new System.Drawing.Point(21, 76);
+            this.cb_orphans.Name = "cb_orphans";
+            this.cb_orphans.Size = new System.Drawing.Size(66, 17);
+            this.cb_orphans.TabIndex = 58;
+            this.cb_orphans.Text = "Orphans";
+            this.cb_orphans.UseVisualStyleBackColor = true;
+            // 
+            // cb_unidentified_families
+            // 
+            this.cb_unidentified_families.AutoSize = true;
+            this.cb_unidentified_families.Checked = true;
+            this.cb_unidentified_families.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cb_unidentified_families.Location = new System.Drawing.Point(21, 53);
+            this.cb_unidentified_families.Name = "cb_unidentified_families";
+            this.cb_unidentified_families.Size = new System.Drawing.Size(122, 17);
+            this.cb_unidentified_families.TabIndex = 57;
+            this.cb_unidentified_families.Text = "Unidentified Families";
+            this.cb_unidentified_families.UseVisualStyleBackColor = true;
+            // 
+            // cb_identified_families
+            // 
+            this.cb_identified_families.AutoSize = true;
+            this.cb_identified_families.Checked = true;
+            this.cb_identified_families.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cb_identified_families.Location = new System.Drawing.Point(21, 30);
+            this.cb_identified_families.Name = "cb_identified_families";
+            this.cb_identified_families.Size = new System.Drawing.Size(109, 17);
+            this.cb_identified_families.TabIndex = 56;
+            this.cb_identified_families.Text = "Identified Families";
+            this.cb_identified_families.UseVisualStyleBackColor = true;
+            // 
+            // btn_inclusion_list_selected_families
+            // 
+            this.btn_inclusion_list_selected_families.Location = new System.Drawing.Point(75, 291);
+            this.btn_inclusion_list_selected_families.Name = "btn_inclusion_list_selected_families";
+            this.btn_inclusion_list_selected_families.Size = new System.Drawing.Size(195, 23);
+            this.btn_inclusion_list_selected_families.TabIndex = 59;
+            this.btn_inclusion_list_selected_families.Text = "Export Selected Families Inclusion List";
+            this.btn_inclusion_list_selected_families.UseVisualStyleBackColor = true;
+            this.btn_inclusion_list_selected_families.Click += new System.EventHandler(this.btn_inclusion_list_selected_families_Click);
             // 
             // cb_buildAsQuantitative
             // 
@@ -427,7 +535,7 @@
             // btn_merge
             // 
             this.btn_merge.Enabled = false;
-            this.btn_merge.Location = new System.Drawing.Point(73, 188);
+            this.btn_merge.Location = new System.Drawing.Point(75, 212);
             this.btn_merge.Name = "btn_merge";
             this.btn_merge.Size = new System.Drawing.Size(195, 23);
             this.btn_merge.TabIndex = 45;
@@ -592,74 +700,6 @@
             this.Families_update.UseVisualStyleBackColor = true;
             this.Families_update.Click += new System.EventHandler(this.Families_update_Click);
             // 
-            // btn_inclusion_list_selected_families
-            // 
-            this.btn_inclusion_list_selected_families.Location = new System.Drawing.Point(75, 291);
-            this.btn_inclusion_list_selected_families.Name = "btn_inclusion_list_selected_families";
-            this.btn_inclusion_list_selected_families.Size = new System.Drawing.Size(195, 23);
-            this.btn_inclusion_list_selected_families.TabIndex = 59;
-            this.btn_inclusion_list_selected_families.Text = "Export Selected Families Inclusion List";
-            this.btn_inclusion_list_selected_families.UseVisualStyleBackColor = true;
-            this.btn_inclusion_list_selected_families.Click += new System.EventHandler(this.btn_inclusion_list_selected_families_Click);
-            // 
-            // groupBox1
-            // 
-            this.groupBox1.Controls.Add(this.cb_orphans);
-            this.groupBox1.Controls.Add(this.cb_unidentified_families);
-            this.groupBox1.Controls.Add(this.cb_identified_families);
-            this.groupBox1.Location = new System.Drawing.Point(280, 237);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(200, 96);
-            this.groupBox1.TabIndex = 59;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Inclusion List";
-            // 
-            // cb_orphans
-            // 
-            this.cb_orphans.AutoSize = true;
-            this.cb_orphans.Checked = true;
-            this.cb_orphans.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cb_orphans.Location = new System.Drawing.Point(21, 76);
-            this.cb_orphans.Name = "cb_orphans";
-            this.cb_orphans.Size = new System.Drawing.Size(66, 17);
-            this.cb_orphans.TabIndex = 58;
-            this.cb_orphans.Text = "Orphans";
-            this.cb_orphans.UseVisualStyleBackColor = true;
-            // 
-            // cb_unidentified_families
-            // 
-            this.cb_unidentified_families.AutoSize = true;
-            this.cb_unidentified_families.Checked = true;
-            this.cb_unidentified_families.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cb_unidentified_families.Location = new System.Drawing.Point(21, 53);
-            this.cb_unidentified_families.Name = "cb_unidentified_families";
-            this.cb_unidentified_families.Size = new System.Drawing.Size(122, 17);
-            this.cb_unidentified_families.TabIndex = 57;
-            this.cb_unidentified_families.Text = "Unidentified Families";
-            this.cb_unidentified_families.UseVisualStyleBackColor = true;
-            // 
-            // cb_identified_families
-            // 
-            this.cb_identified_families.AutoSize = true;
-            this.cb_identified_families.Checked = true;
-            this.cb_identified_families.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cb_identified_families.Location = new System.Drawing.Point(21, 30);
-            this.cb_identified_families.Name = "cb_identified_families";
-            this.cb_identified_families.Size = new System.Drawing.Size(109, 17);
-            this.cb_identified_families.TabIndex = 56;
-            this.cb_identified_families.Text = "Identified Families";
-            this.cb_identified_families.UseVisualStyleBackColor = true;
-            // 
-            // btn_inclusion_list_all_families
-            // 
-            this.btn_inclusion_list_all_families.Location = new System.Drawing.Point(75, 261);
-            this.btn_inclusion_list_all_families.Name = "btn_inclusion_list_all_families";
-            this.btn_inclusion_list_all_families.Size = new System.Drawing.Size(195, 23);
-            this.btn_inclusion_list_all_families.TabIndex = 60;
-            this.btn_inclusion_list_all_families.Text = "Export Inclusion List";
-            this.btn_inclusion_list_all_families.UseVisualStyleBackColor = true;
-            this.btn_inclusion_list_all_families.Click += new System.EventHandler(this.btn_inclusion_list_all_families_Click);
-            // 
             // ProteoformFamilies
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -689,11 +729,11 @@
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer3)).EndInit();
             this.splitContainer3.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dgv_proteoform_family_members)).EndInit();
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
             this.groupBox5.ResumeLayout(false);
             this.groupBox5.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nud_decimalRoundingLabels)).EndInit();
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -749,5 +789,8 @@
         private System.Windows.Forms.CheckBox cb_unidentified_families;
         private System.Windows.Forms.CheckBox cb_identified_families;
         private System.Windows.Forms.Button btn_inclusion_list_selected_families;
+        public System.Windows.Forms.CheckBox cb_geneCentric;
+        private System.Windows.Forms.Label label10;
+        public System.Windows.Forms.ComboBox cmbx_geneLabel;
     }
 }

--- a/ProteoformSuiteGUI/ProteoformFamilies.cs
+++ b/ProteoformSuiteGUI/ProteoformFamilies.cs
@@ -21,11 +21,11 @@ namespace ProteoformSuiteGUI
         public ProteoformFamilies()
         {
             InitializeComponent();
-        }
-        private void ProteoformFamilies_Load(object sender, EventArgs e)
-        {
             initialize_settings();
         }
+
+        private void ProteoformFamilies_Load(object sender, EventArgs e)
+        { }
 
         public void initialize_every_time()
         {
@@ -33,6 +33,8 @@ namespace ProteoformSuiteGUI
             this.nud_decimalRoundingLabels.Value = Convert.ToDecimal(Lollipop.deltaM_edge_display_rounding);
             this.cb_buildAsQuantitative.Enabled = Lollipop.qVals.Count > 0;
             this.cb_buildAsQuantitative.Checked = false;
+            this.cmbx_geneLabel.SelectedIndex = Lollipop.gene_name_labels.IndexOf(ProteoformCommunity.preferred_gene_label);
+            this.cb_geneCentric.Checked = ProteoformCommunity.gene_centric_families;
         }
 
         public void initialize_settings()
@@ -42,12 +44,16 @@ namespace ProteoformSuiteGUI
             cmbx_nodeLayout.Items.AddRange(Lollipop.node_positioning);
             cmbx_nodeLabelPositioning.Items.AddRange(CytoscapeScript.node_label_positions);
             cmbx_edgeLabel.Items.AddRange(Lollipop.edge_labels);
+            cmbx_geneLabel.Items.AddRange(Lollipop.gene_name_labels.ToArray());
             cmbx_tableSelector.Items.AddRange(table_names);
 
             cmbx_colorScheme.SelectedIndex = 0;
             cmbx_nodeLayout.SelectedIndex = 0;
             cmbx_nodeLabelPositioning.SelectedIndex = 0;
             cmbx_edgeLabel.SelectedIndex = 0;
+            cmbx_geneLabel.SelectedIndex = 1;
+            ProteoformCommunity.preferred_gene_label = cmbx_geneLabel.SelectedItem.ToString();
+            ProteoformCommunity.gene_centric_families = cb_geneCentric.Checked;
 
             cmbx_tableSelector.SelectedIndexChanged -= cmbx_tableSelector_SelectedIndexChanged;
             cmbx_tableSelector.SelectedIndex = 0;
@@ -238,7 +244,7 @@ namespace ProteoformSuiteGUI
         {
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
-            string message = CytoscapeScript.write_cytoscape_script(Lollipop.proteoform_community.families, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, cb_buildAsQuantitative.Checked, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding);
+            string message = CytoscapeScript.write_cytoscape_script(Lollipop.proteoform_community.families, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, cb_buildAsQuantitative.Checked, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding, cb_geneCentric.Checked, cmbx_geneLabel.SelectedItem.ToString());
             MessageBox.Show(message, "Cytoscape Build");
         }
 
@@ -247,7 +253,7 @@ namespace ProteoformSuiteGUI
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
             object[] selected = DisplayUtility.get_selected_objects(dgv_main);
-            string message = CytoscapeScript.write_cytoscape_script(selected, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, cb_buildAsQuantitative.Checked, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding);
+            string message = CytoscapeScript.write_cytoscape_script(selected, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, cb_buildAsQuantitative.Checked, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding, cb_geneCentric.Checked, cmbx_geneLabel.SelectedItem.ToString());
             MessageBox.Show(message, "Cytoscape Build");
         }
 
@@ -313,6 +319,16 @@ namespace ProteoformSuiteGUI
                 MessageBox.Show("Successfully exported inclusion list.");
             }
             else return;
+        }
+
+        private void cmbx_geneLabel_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            ProteoformCommunity.preferred_gene_label = cmbx_geneLabel.SelectedItem.ToString();
+        }
+
+        private void cb_geneCentric_CheckedChanged(object sender, EventArgs e)
+        {
+            ProteoformCommunity.gene_centric_families = cb_geneCentric.Checked;
         }
     }
 }

--- a/ProteoformSuiteGUI/Quantification.Designer.cs
+++ b/ProteoformSuiteGUI/Quantification.Designer.cs
@@ -71,7 +71,10 @@
             this.rb_allTheoreticalProteins = new System.Windows.Forms.RadioButton();
             this.rb_allSampleGOTerms = new System.Windows.Forms.RadioButton();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.cb_geneCentric = new System.Windows.Forms.CheckBox();
+            this.label14 = new System.Windows.Forms.Label();
             this.btn_buildFamiliesWithSignificantChange = new System.Windows.Forms.Button();
+            this.cmbx_geneLabel = new System.Windows.Forms.ComboBox();
             this.btn_buildFamiliesAllGO = new System.Windows.Forms.Button();
             this.label11 = new System.Windows.Forms.Label();
             this.btn_buildFromSelectedGoTerms = new System.Windows.Forms.Button();
@@ -552,7 +555,10 @@
             // 
             // groupBox4
             // 
+            this.groupBox4.Controls.Add(this.cb_geneCentric);
+            this.groupBox4.Controls.Add(this.label14);
             this.groupBox4.Controls.Add(this.btn_buildFamiliesWithSignificantChange);
+            this.groupBox4.Controls.Add(this.cmbx_geneLabel);
             this.groupBox4.Controls.Add(this.btn_buildFamiliesAllGO);
             this.groupBox4.Controls.Add(this.label11);
             this.groupBox4.Controls.Add(this.btn_buildFromSelectedGoTerms);
@@ -580,6 +586,30 @@
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Quantified Family Display with Cytoscape";
             // 
+            // cb_geneCentric
+            // 
+            this.cb_geneCentric.AutoSize = true;
+            this.cb_geneCentric.Checked = true;
+            this.cb_geneCentric.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cb_geneCentric.Location = new System.Drawing.Point(267, 181);
+            this.cb_geneCentric.Name = "cb_geneCentric";
+            this.cb_geneCentric.Size = new System.Drawing.Size(154, 17);
+            this.cb_geneCentric.TabIndex = 62;
+            this.cb_geneCentric.Text = "Build Gene-Centric Families";
+            this.cb_geneCentric.UseVisualStyleBackColor = true;
+            this.cb_geneCentric.CheckedChanged += new System.EventHandler(this.cb_geneCentric_CheckedChanged);
+            // 
+            // label14
+            // 
+            this.label14.AutoSize = true;
+            this.label14.BackColor = System.Drawing.SystemColors.Control;
+            this.label14.Location = new System.Drawing.Point(347, 157);
+            this.label14.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label14.Name = "label14";
+            this.label14.Size = new System.Drawing.Size(62, 13);
+            this.label14.TabIndex = 52;
+            this.label14.Text = "Gene Label";
+            // 
             // btn_buildFamiliesWithSignificantChange
             // 
             this.btn_buildFamiliesWithSignificantChange.Location = new System.Drawing.Point(6, 215);
@@ -589,6 +619,16 @@
             this.btn_buildFamiliesWithSignificantChange.Text = "Build All Quantified Families w/ Significant Change";
             this.btn_buildFamiliesWithSignificantChange.UseVisualStyleBackColor = true;
             this.btn_buildFamiliesWithSignificantChange.Click += new System.EventHandler(this.btn_buildFamiliesWithSignificantChange_Click);
+            // 
+            // cmbx_geneLabel
+            // 
+            this.cmbx_geneLabel.Enabled = false;
+            this.cmbx_geneLabel.FormattingEnabled = true;
+            this.cmbx_geneLabel.Location = new System.Drawing.Point(267, 154);
+            this.cmbx_geneLabel.Name = "cmbx_geneLabel";
+            this.cmbx_geneLabel.Size = new System.Drawing.Size(75, 21);
+            this.cmbx_geneLabel.TabIndex = 51;
+            this.cmbx_geneLabel.SelectedIndexChanged += new System.EventHandler(this.cmbx_geneLabel_SelectedIndexChanged);
             // 
             // btn_buildFamiliesAllGO
             // 
@@ -635,7 +675,7 @@
             this.groupBox5.Controls.Add(this.cb_moreOpacity);
             this.groupBox5.Controls.Add(this.cb_boldLabel);
             this.groupBox5.Controls.Add(this.cb_redBorder);
-            this.groupBox5.Location = new System.Drawing.Point(267, 189);
+            this.groupBox5.Location = new System.Drawing.Point(267, 214);
             this.groupBox5.Name = "groupBox5";
             this.groupBox5.Size = new System.Drawing.Size(200, 120);
             this.groupBox5.TabIndex = 56;
@@ -1048,5 +1088,8 @@
         private System.Windows.Forms.TextBox tb_goTermCustomBackground;
         private System.Windows.Forms.RadioButton rb_customBackgroundSet;
         private System.Windows.Forms.Button btn_customBackgroundBrowse;
+        private System.Windows.Forms.Label label14;
+        private System.Windows.Forms.ComboBox cmbx_geneLabel;
+        private System.Windows.Forms.CheckBox cb_geneCentric;
     }
 }

--- a/ProteoformSuiteGUI/Quantification.cs
+++ b/ProteoformSuiteGUI/Quantification.cs
@@ -77,6 +77,8 @@ namespace ProteoformSuiteGUI
         public void initialize_every_time()
         {
             this.tb_familyBuildFolder.Text = Lollipop.family_build_folder_path;
+            this.cmbx_geneLabel.SelectedIndex = Lollipop.gene_name_labels.IndexOf(ProteoformCommunity.preferred_gene_label);
+            this.cb_geneCentric.Checked = ProteoformCommunity.gene_centric_families;
         }
 
         private void initialize()
@@ -97,6 +99,7 @@ namespace ProteoformSuiteGUI
             cmbx_colorScheme.Items.AddRange(CytoscapeScript.color_scheme_names);
             cmbx_nodeLayout.Items.AddRange(Lollipop.node_positioning);
             cmbx_nodeLabelPositioning.Items.AddRange(CytoscapeScript.node_label_positions);
+            cmbx_geneLabel.Items.AddRange(Lollipop.gene_name_labels.ToArray());
             cb_redBorder.Checked = true;
             cb_boldLabel.Checked = true;
             cb_moreOpacity.Checked = false;
@@ -104,6 +107,9 @@ namespace ProteoformSuiteGUI
             cmbx_colorScheme.SelectedIndex = 0;
             cmbx_nodeLayout.SelectedIndex = 0;
             cmbx_nodeLabelPositioning.SelectedIndex = 0;
+            cmbx_geneLabel.SelectedIndex = 1;
+            ProteoformCommunity.preferred_gene_label = cmbx_geneLabel.SelectedItem.ToString();
+            ProteoformCommunity.gene_centric_families = cb_geneCentric.Checked;
 
             //Set parameters
             nud_bkgdShift.ValueChanged -= nud_bkgdShift_ValueChanged;
@@ -337,7 +343,7 @@ namespace ProteoformSuiteGUI
         {
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
-            string message = CytoscapeScript.write_cytoscape_script(Lollipop.proteoform_community.families, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding);
+            string message = CytoscapeScript.write_cytoscape_script(Lollipop.proteoform_community.families, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding, cb_geneCentric.Checked, cmbx_geneLabel.SelectedItem.ToString());
             MessageBox.Show(message, "Cytoscape Build");
         }
 
@@ -346,7 +352,7 @@ namespace ProteoformSuiteGUI
             List<ProteoformFamily> families = Lollipop.getInterestingFamilies(Lollipop.satisfactoryProteoforms, Lollipop.minProteoformFoldChange, Lollipop.minProteoformFDR, Lollipop.minProteoformIntensity).Distinct().ToList();
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
-            string message = CytoscapeScript.write_cytoscape_script(families, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding);
+            string message = CytoscapeScript.write_cytoscape_script(families, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding, cb_geneCentric.Checked, cmbx_geneLabel.SelectedItem.ToString());
             MessageBox.Show(message, "Cytoscape Build");
         }
 
@@ -355,7 +361,7 @@ namespace ProteoformSuiteGUI
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
             object[] selected = DisplayUtility.get_selected_objects(dgv_quantification_results);
-            string message = CytoscapeScript.write_cytoscape_script(selected, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding);
+            string message = CytoscapeScript.write_cytoscape_script(selected, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding, cb_geneCentric.Checked, cmbx_geneLabel.SelectedItem.ToString());
             MessageBox.Show(message, "Cytoscape Build");
         }
 
@@ -365,7 +371,7 @@ namespace ProteoformSuiteGUI
             List<ProteoformFamily> go_families = Lollipop.getInterestingFamilies(Lollipop.goTermNumbers.Where(n => n.Aspect == a).Distinct().ToList(), Lollipop.proteoform_community.families);
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
-            string message = CytoscapeScript.write_cytoscape_script(go_families, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding);
+            string message = CytoscapeScript.write_cytoscape_script(go_families, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding, cb_geneCentric.Checked, cmbx_geneLabel.SelectedItem.ToString());
             MessageBox.Show(message, "Cytoscape Build");
         }
 
@@ -375,7 +381,7 @@ namespace ProteoformSuiteGUI
             List<ProteoformFamily> selected_families = Lollipop.getInterestingFamilies(selected_gos, Lollipop.proteoform_community.families).Distinct().ToList();
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
-            string message = CytoscapeScript.write_cytoscape_script(selected_families, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding);
+            string message = CytoscapeScript.write_cytoscape_script(selected_families, Lollipop.proteoform_community.families, Lollipop.family_build_folder_path, time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked, cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), Lollipop.deltaM_edge_display_rounding, cb_geneCentric.Checked, cmbx_geneLabel.SelectedItem.ToString());
             MessageBox.Show(message, "Cytoscape Build");
         }
 
@@ -485,6 +491,16 @@ namespace ProteoformSuiteGUI
                     goTermBackgroundChanged(new object(), new EventArgs());
                 }
             }
+        }
+
+        private void cmbx_geneLabel_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            ProteoformCommunity.preferred_gene_label = cmbx_geneLabel.SelectedItem.ToString();
+        }
+
+        private void cb_geneCentric_CheckedChanged(object sender, EventArgs e)
+        {
+            ProteoformCommunity.gene_centric_families = cb_geneCentric.Checked;
         }
     }
 }

--- a/ProteoformSuiteGUI/Quantification.cs
+++ b/ProteoformSuiteGUI/Quantification.cs
@@ -77,7 +77,7 @@ namespace ProteoformSuiteGUI
         public void initialize_every_time()
         {
             this.tb_familyBuildFolder.Text = Lollipop.family_build_folder_path;
-            this.cmbx_geneLabel.SelectedIndex = Lollipop.gene_name_labels.IndexOf(ProteoformCommunity.preferred_gene_label);
+            if (cmbx_geneLabel.Items.Count > 0) this.cmbx_geneLabel.SelectedIndex = Lollipop.gene_name_labels.IndexOf(ProteoformCommunity.preferred_gene_label);
             this.cb_geneCentric.Checked = ProteoformCommunity.gene_centric_families;
         }
 

--- a/ProteoformSuiteGUI/RawExperimentalComponents.cs
+++ b/ProteoformSuiteGUI/RawExperimentalComponents.cs
@@ -30,8 +30,8 @@ namespace ProteoformSuiteGUI
 
                 Parallel.Invoke
                 (
-                    () => { if (Lollipop.raw_experimental_components.Count == 0) Lollipop.process_raw_components(); }, //Includes reading correction factors if present,
-                    () => { if (Lollipop.raw_quantification_components.Count == 0) Lollipop.process_raw_quantification_components(); },
+                    () => { if (Lollipop.raw_experimental_components.Count == 0) Lollipop.process_raw_components(Lollipop.input_files, Purpose.Identification); }, //Includes reading correction factors if present,
+                    () => { if (Lollipop.raw_quantification_components.Count == 0) Lollipop.process_raw_components(Lollipop.input_files, Purpose.Quantification); },
                     () => { if (Lollipop.get_files(Lollipop.input_files, Purpose.ProteinDatabase).Count() > 0) Lollipop.get_theoretical_proteoforms(); }
                 );
 

--- a/ProteoformSuiteInternal/CytoscapeScript.cs
+++ b/ProteoformSuiteInternal/CytoscapeScript.cs
@@ -12,13 +12,15 @@ namespace ProteoformSuiteInternal
     public static class CytoscapeScript
     {
         public static string write_cytoscape_script(List<ProteoformFamily> families, List<ProteoformFamily> all_families, string folder_path, string time_stamp, bool quantitative, bool quantitative_redBorder, bool quantitative_boldFace, bool quantitative_moreOpacity,
-            string color_scheme, string node_label_position, int double_rounding)
+            string color_scheme, string node_label_position, int double_rounding,
+            bool gene_centric_families, string prefered_gene_label)
         {
-            return write_script(families, all_families, folder_path, time_stamp, quantitative, quantitative_redBorder, quantitative_boldFace, quantitative_moreOpacity, color_scheme, node_label_position, double_rounding);
+            return write_script(families, all_families, folder_path, time_stamp, quantitative, quantitative_redBorder, quantitative_boldFace, quantitative_moreOpacity, color_scheme, node_label_position, double_rounding, gene_centric_families, prefered_gene_label);
         }
 
         public static string write_cytoscape_script(object[] stuff, List<ProteoformFamily> all_families, string folder_path, string time_stamp, bool quantitative, bool quantitative_redBorder, bool quantitative_boldFace, bool quantitative_moreOpacity,
-            string color_scheme, string node_label_position, int double_rounding)
+            string color_scheme, string node_label_position, int double_rounding,
+            bool gene_centric_families, string prefered_gene_label)
         {
             List<ProteoformFamily> families = stuff.OfType<ProteoformFamily>().ToList();
 
@@ -31,7 +33,7 @@ namespace ProteoformSuiteInternal
                 families = get_families(stuff.OfType<ExperimentalProteoform.quantitativeValues>(), all_families).Distinct().ToList();
             if (families.Count <= 0) return "Selected objects were not recognized.";
 
-            return write_script(families, all_families, folder_path, time_stamp, quantitative, quantitative_redBorder, quantitative_boldFace, quantitative_moreOpacity, color_scheme, node_label_position, double_rounding);
+            return write_script(families, all_families, folder_path, time_stamp, quantitative, quantitative_redBorder, quantitative_boldFace, quantitative_moreOpacity, color_scheme, node_label_position, double_rounding, gene_centric_families, prefered_gene_label);
         }
 
         private static IEnumerable<ProteoformFamily> get_families(IEnumerable<TheoreticalProteoform> theoreticals, List<ProteoformFamily> all_families)
@@ -69,7 +71,8 @@ namespace ProteoformSuiteInternal
         public static string style_file_extension = ".xml";
         public static string script_file_extension = ".txt";
         private static string write_script(List<ProteoformFamily> families, List<ProteoformFamily> all_families, string folder_path, string time_stamp, bool quantitative, bool quantitative_redBorder, bool quantitative_boldFace, bool quantitative_moreOpacity,
-            string color_scheme, string node_label_position, int double_rounding)
+            string color_scheme, string node_label_position, int double_rounding,
+            bool gene_centric_families, string preferred_gene_label)
         {
             //Check if valid folder
             if (folder_path == "" || !Directory.Exists(folder_path))
@@ -84,9 +87,19 @@ namespace ProteoformSuiteInternal
             string script_path = Path.Combine(folder_path, script_file_prefix + time_stamp + script_file_extension);
             string style_name = "ProteoformFamilies" + time_stamp;
 
+            IEnumerable<TheoreticalProteoform> theoreticals = families.SelectMany(f => f.theoretical_proteoforms);
+            //Dictionary<string, GeneName> gene_dict = new Dictionary<string, GeneName>();
+            //if (gene_centric_families)
+            //    foreach (TheoreticalProteoform t in theoreticals)
+            //    {
+            //        string preferred = t.gene_name.get_prefered_name(prefered_gene_label);
+            //        if (gene_dict.ContainsKey(preferred)) gene_dict[preferred].merge(t.gene_name);
+            //        else gene_dict.Add(preferred, t.gene_name);
+            //    }
+
             string script = get_script(families.Sum(f => f.proteoforms.Count() + f.relation_count), quantitative, edges_path, nodes_path, styles_path, style_name);
-            string node_table = get_cytoscape_nodes_tsv(families, quantitative, color_scheme, double_rounding);
-            string edge_table = get_cytoscape_edges_tsv(families, double_rounding);
+            string node_table = get_cytoscape_nodes_tsv(families, quantitative, color_scheme, double_rounding, theoreticals, gene_centric_families, preferred_gene_label);
+            string edge_table = get_cytoscape_edges_tsv(families, double_rounding, theoreticals, gene_centric_families, preferred_gene_label);
             File.WriteAllText(edges_path, edge_table);
             File.WriteAllText(nodes_path, node_table);
             File.WriteAllText(script_path, script);
@@ -102,7 +115,7 @@ namespace ProteoformSuiteInternal
         private static string get_script(int feature_count, bool quantitative, string edges_path, string nodes_path, string styles_path, string style_name)
         {
             double sleep_factor = feature_count / 1000;
-            string node_column_types = quantitative ? "s,s,d,d,d,boolean,s" : "s,s,d"; //Cytoscape bug: "b" doesn't work in 3.4.0, only "boolean" does
+            string node_column_types = quantitative ? "s,s,d,s,d,d,boolean,s" : "s,s,d,s"; //Cytoscape bug: "b" doesn't work in 3.4.0, only "boolean" does
             string edge_column_types = "s,s,s,s";
             return String.Join(Environment.NewLine, new string[] {
 
@@ -129,14 +142,17 @@ namespace ProteoformSuiteInternal
         public static string delta_mass_header = "delta_mass";
         public static string proteoform_type_header = "E_or_T";
         public static string size_header = "total_intensity";
+        public static string tooltip_header = "more_info";
         public static string piechart_header = "piechart_graphics";
         public static string significant_header = "significant_difference";
         public static string experimental_label = "experimental";
         public static string experimental_notQuantified_label = "experimental_below_quantification_threshold";
         public static string unmodified_theoretical_label = "theoretical";
         public static string modified_theoretical_label = "modified_theoretical";
+        public static string gene_name_label = "gene_name";
         public static string mock_intensity = "20"; //set all theoretical proteoforms with observations=20 for node sizing purposes
-        public static string get_cytoscape_edges_tsv(List<ProteoformFamily> families, int double_rounding)
+        public static string get_cytoscape_edges_tsv(List<ProteoformFamily> families, int double_rounding, 
+            IEnumerable<TheoreticalProteoform> theoreticals, bool gene_centric_families, string preferred_gene_label)
         {
             string tsv_header = "accession_1\t" + lysine_count_header + "\taccession_2\t" + delta_mass_header;
             string edge_rows = "";
@@ -151,12 +167,27 @@ namespace ProteoformSuiteInternal
                 });
                 edge_rows += Environment.NewLine;
             }
+
+            if (gene_centric_families)
+            {
+                foreach (TheoreticalProteoform t in theoreticals)
+                {
+                    edge_rows += String.Join("\t", new List<string>
+                    {
+                        get_proteoform_shared_name(t, double_rounding),
+                        t.lysine_count.ToString(),
+                        t.gene_name.get_prefered_name(preferred_gene_label),
+                    });
+                    edge_rows += Environment.NewLine;
+                }
+            }
             return tsv_header + Environment.NewLine + edge_rows;
         }
 
-        public static string get_cytoscape_nodes_tsv(List<ProteoformFamily> families, bool quantitative, string color_scheme, int double_rounding)
+        public static string get_cytoscape_nodes_tsv(List<ProteoformFamily> families, bool quantitative, string color_scheme, int double_rounding,
+            IEnumerable<TheoreticalProteoform> theoreticals, bool gene_centric_families, string preferred_gene_label)
         {
-            string tsv_header = "accession\t" + proteoform_type_header + "\t" + size_header;
+            string tsv_header = "accession\t" + proteoform_type_header + "\t" + size_header + "\t" + tooltip_header;
             if (quantitative) tsv_header += "\t" + Lollipop.numerator_condition + "\t" + Lollipop.denominator_condition + "\t" + significant_header + "\t" + piechart_header;
 
             string node_rows = "";
@@ -168,19 +199,47 @@ namespace ProteoformSuiteInternal
                 string total_intensity = quantitative ?
                     p.quant.intensitySum == 0 ? mock_intensity : ((double)p.quant.intensitySum).ToString() : 
                     p.agg_intensity.ToString();
+
+                //Names and size
                 node_rows += String.Join("\t", new List<string> { get_proteoform_shared_name(p, double_rounding), node_type, total_intensity });
+
+                //Set tooltip information
+                node_rows += "\t" + String.Join("; ", new string[] {
+                    "Accession = " + p.accession.ToString(),
+                    "Aggregated Mass = " + p.agg_mass.ToString(),
+                    "Aggregated Retention Time = " + p.agg_rt.ToString(),
+                    "Total Intensity = " + total_intensity.ToString(),
+                    "Aggregated Component Count = " + p.aggregated_components.Count.ToString(),
+                });
+                if (Lollipop.neucode_labeled) node_rows += "; Lysine Count = " + p.lysine_count;
+                if (quantitative && p.quant.intensitySum > 0)
+                {
+                    node_rows += "\\n\\nQuantitation Results:";
+                    node_rows += String.Join("; ", new string[] {
+                        "Q-Value = " + p.quant.FDR.ToString(),
+                        "Log2FC = " + p.quant.logFoldChange.ToString(),
+                        "Variance = " + p.quant.variance.ToString(),
+                        "Significant = " + p.quant.significant.ToString(),
+                        Lollipop.numerator_condition + " Quantitative Component Count = " + p.lt_quant_components.ToString(),
+                        Lollipop.denominator_condition + " Quantitative Component Count = " + p.hv_quant_components.ToString(),
+                    });
+                }
+
+                //Quantification information
                 if (quantitative && p.quant.intensitySum != 0) node_rows += "\t" + String.Join("\t", new List<string> { ((double)p.quant.lightIntensitySum).ToString(), ((double)p.quant.heavyIntensitySum).ToString(), p.quant.significant.ToString(), get_piechart_string(color_scheme) });
                 node_rows += Environment.NewLine;
             }
 
-            IEnumerable<TheoreticalProteoform> theoreticals = families.SelectMany(f => f.theoretical_proteoforms);
             foreach (TheoreticalProteoform p in theoreticals)
             {
                 string node_type = String.Equals(p.ptm_list_string(), "unmodified", StringComparison.CurrentCultureIgnoreCase) ? unmodified_theoretical_label : modified_theoretical_label;
                 node_rows += String.Join("\t", new List<string> { get_proteoform_shared_name(p, double_rounding), node_type, mock_intensity }) + Environment.NewLine;
             }
 
-            foreach (string gene_name in theoreticals.SelectMany(t => t.proteinList.SelectMany(p => p.GeneNames).Where(n => n.Item1 == "primary").Select(n => n.Item2))) { }
+            foreach (string gene_name in theoreticals.Select(t => t.gene_name.get_prefered_name(preferred_gene_label)).Distinct())
+            {
+                node_rows += gene_name + "\t" + gene_name_label + "\t" + mock_intensity + "\tOther Gene Names: " + Environment.NewLine; //TODO: implement tooltip for other gene names
+            }
 
             return tsv_header + Environment.NewLine + node_rows;
         }
@@ -194,7 +253,7 @@ namespace ProteoformSuiteInternal
 
             else if (typeof(TheoreticalProteoform).IsAssignableFrom(p.GetType()))
             {
-                return p.accession.Split(new char[] { '_' }).FirstOrDefault() + " " + ((TheoreticalProteoform)p).ptm_list_string();
+                return p.accession + " " + ((TheoreticalProteoform)p).ptm_list_string();
             }
 
             else
@@ -306,7 +365,8 @@ namespace ProteoformSuiteInternal
                             new Tuple<string, string>(quantitative ? "#FFFFFF" : color_schemes[color_scheme][0], experimental_label),
                             new Tuple<string, string>("#D3D3D3", experimental_notQuantified_label),
                             new Tuple<string, string>(color_schemes[color_scheme][1], modified_theoretical_label),
-                            new Tuple<string, string>(color_schemes[color_scheme][2], unmodified_theoretical_label)
+                            new Tuple<string, string>(color_schemes[color_scheme][2], unmodified_theoretical_label),
+                            new Tuple<string, string>(color_schemes[color_scheme][3], gene_name_label)
                         });
                     if (style.Key == "NODE_LABEL_COLOR") write_passthrough(writer, "string", "shared name");
                     if (style.Key == "NODE_LABEL") write_passthrough(writer, "string", "name");
@@ -345,6 +405,7 @@ namespace ProteoformSuiteInternal
                         {
                             new Tuple<string, string>("Dialog.bold,plain,14", "True"),
                         });
+                    if (style.Key == "NODE_TOOLTIP") write_passthrough(writer, "string", tooltip_header);
                     writer.WriteEndElement();
                 }
                 writer.WriteEndElement();

--- a/ProteoformSuiteInternal/CytoscapeScript.cs
+++ b/ProteoformSuiteInternal/CytoscapeScript.cs
@@ -172,13 +172,17 @@ namespace ProteoformSuiteInternal
             {
                 foreach (TheoreticalProteoform t in theoreticals)
                 {
-                    edge_rows += String.Join("\t", new List<string>
+                    string gene_name = t.gene_name.get_prefered_name(preferred_gene_label);
+                    if (gene_name != null)
                     {
-                        get_proteoform_shared_name(t, double_rounding),
-                        t.lysine_count.ToString(),
-                        t.gene_name.get_prefered_name(preferred_gene_label),
-                    });
-                    edge_rows += Environment.NewLine;
+                        edge_rows += String.Join("\t", new List<string>
+                        {
+                            get_proteoform_shared_name(t, double_rounding),
+                            t.lysine_count.ToString(),
+                            t.gene_name.get_prefered_name(preferred_gene_label),
+                        });
+                        edge_rows += Environment.NewLine;
+                    }
                 }
             }
             return tsv_header + Environment.NewLine + edge_rows;
@@ -236,10 +240,11 @@ namespace ProteoformSuiteInternal
                 node_rows += String.Join("\t", new List<string> { get_proteoform_shared_name(p, double_rounding), node_type, mock_intensity }) + Environment.NewLine;
             }
 
-            foreach (string gene_name in theoreticals.Select(t => t.gene_name.get_prefered_name(preferred_gene_label)).Distinct())
-            {
-                node_rows += gene_name + "\t" + gene_name_label + "\t" + mock_intensity + "\tOther Gene Names: " + Environment.NewLine; //TODO: implement tooltip for other gene names
-            }
+            if (gene_centric_families)
+                foreach (string gene_name in theoreticals.Select(t => t.gene_name.get_prefered_name(preferred_gene_label)).Distinct())
+                {
+                    if (gene_name != null) node_rows += gene_name + "\t" + gene_name_label + "\t" + mock_intensity + "\tOther Gene Names: " + Environment.NewLine; //TODO: implement tooltip for other gene names
+                }
 
             return tsv_header + Environment.NewLine + node_rows;
         }

--- a/ProteoformSuiteInternal/DeltaMassPeak.cs
+++ b/ProteoformSuiteInternal/DeltaMassPeak.cs
@@ -30,7 +30,8 @@ namespace ProteoformSuiteInternal
             }
 
             grouped_relations = !Lollipop.opening_results ? this.find_nearby_relations(relations_to_group) : relations_to_group.ToList();
-            this.peak_accepted = typeof(TheoreticalProteoform).IsAssignableFrom(grouped_relations.First().connected_proteoforms[1].GetType()) ?
+            this.peak_accepted = grouped_relations != null && grouped_relations.Count > 0 &&
+                typeof(TheoreticalProteoform).IsAssignableFrom(grouped_relations.First().connected_proteoforms[1].GetType()) ?
                      this.peak_relation_group_count >= Lollipop.min_peak_count_et :
                      this.peak_relation_group_count >= Lollipop.min_peak_count_ee;
             if (!Lollipop.opening_results && Lollipop.updated_theoretical) this.possiblePeakAssignments = nearestPTMs(this.peak_deltaM_average);
@@ -40,6 +41,12 @@ namespace ProteoformSuiteInternal
             of incorrect relations (average shouldn't include relations already grouped into peaks)*/
         private List<ProteoformRelation> find_nearby_relations(List<ProteoformRelation> ungrouped_relations)
         {
+            if (ungrouped_relations.Count <= 0)
+            {
+                this.grouped_relations = new List<ProteoformRelation>();
+                return this.grouped_relations;
+            }
+
             for (int i = 0; i < Lollipop.relation_group_centering_iterations; i++)
             {
                 double center_deltaM = i > 0 ? peak_deltaM_average : this.delta_mass;

--- a/ProteoformSuiteInternal/ExperimentalProteoform.cs
+++ b/ProteoformSuiteInternal/ExperimentalProteoform.cs
@@ -92,37 +92,7 @@ namespace ProteoformSuiteInternal
 
 
         // TESTING CONSTRUCTORS
-        public ExperimentalProteoform(string accession) : base(accession)
-        {
-            quant = new quantitativeValues(this);
-            this.aggregated_components = new List<Component>() { root };
-            this.accession = accession;
-        }
-
-        public ExperimentalProteoform(string accession, double modified_mass, int lysine_count, bool is_target) : base(accession)
-        {
-            quant = new quantitativeValues(this);
-            this.aggregated_components = new List<Component>() { root };
-            this.accession = accession;
-            this.modified_mass = modified_mass;
-            this.lysine_count = lysine_count;
-            this.is_target = is_target;
-            this.is_decoy = !is_target;
-        }
-
-        public ExperimentalProteoform(string accession, Component root, List<Component> candidate_observations, List<Component> quantitative_observations, bool is_target) : base(accession)
-        {
-            quant = new quantitativeValues(this);
-            this.root = root;
-            this.aggregated_components.AddRange(candidate_observations.Where(p => this.includes(p, this.root)));
-            this.calculate_properties();
-            if (quantitative_observations.Count > 0)
-            {
-                this.lt_quant_components.AddRange(quantitative_observations.Where(r => this.includes_neucode_component(r, this, true)));
-                if (Lollipop.neucode_labeled) this.hv_quant_components.AddRange(quantitative_observations.Where(r => this.includes_neucode_component(r, this, false)));
-            }
-            this.root = this.aggregated_components.OrderByDescending(a => a.intensity_sum).FirstOrDefault();
-        }
+        
 
 
         // COPYING CONSTRUCTOR

--- a/ProteoformSuiteInternal/ExperimentalProteoform.cs
+++ b/ProteoformSuiteInternal/ExperimentalProteoform.cs
@@ -408,7 +408,7 @@ namespace ProteoformSuiteInternal
                             (double)(((decimal)lights_in_biorep.Sum(i => i.intensity)) /
                             ((decimal)heavies_in_biorep.Sum(i => i.intensity)))
                             , 2);
-                    squaredVariance = squaredVariance + (decimal)Math.Pow(((double)logRepRatio - (double)logFoldChange), 2);
+                    squaredVariance += (decimal)Math.Pow(((double)logRepRatio - (double)logFoldChange), 2);
                 }
                 return (decimal)Math.Pow((double)squaredVariance, 0.5);
             }

--- a/ProteoformSuiteInternal/GeneName.cs
+++ b/ProteoformSuiteInternal/GeneName.cs
@@ -29,8 +29,8 @@ namespace ProteoformSuiteInternal
         public string get_prefered_name(string prefered_gene_label)
         {
             string name;
-            if (prefered_gene_label.ToLower().StartsWith("primary")) name = primary != null ? primary : ordered_locus;
-            else if (prefered_gene_label.ToLower().StartsWith("ordered locus")) name = ordered_locus != null ? ordered_locus : primary;
+            if (prefered_gene_label != null && prefered_gene_label.ToLower().StartsWith("primary")) name = primary != null ? primary : ordered_locus;
+            else if (prefered_gene_label != null && prefered_gene_label.ToLower().StartsWith("ordered locus")) name = ordered_locus != null ? ordered_locus : primary;
             else name = null;
             return name != null || gene_names.Count() == 0 ? name : gene_names.FirstOrDefault().Item2;
         }

--- a/ProteoformSuiteInternal/GeneName.cs
+++ b/ProteoformSuiteInternal/GeneName.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ProteoformSuiteInternal
+{
+    public class GeneName
+    {
+        public IEnumerable<Tuple<string,string>> gene_names { get; private set; }
+        public string ordered_locus { get; private set; }
+        public string primary { get; private set; }
+
+        public GeneName(IEnumerable<Tuple<string, string>> gene_names)
+        {
+            this.gene_names = gene_names;
+            Tuple<string, string> first_ordered = gene_names.FirstOrDefault(v => v.Item1 == "ordered locus");
+            Tuple<string, string> first_primary = gene_names.FirstOrDefault(v => v.Item1 == "primary");
+            this.ordered_locus = first_ordered != null ? first_ordered.Item2 : null;
+            this.primary = first_primary != null ? first_primary.Item2 : null;
+        }
+
+        public GeneName(IEnumerable<GeneName> gene_names)
+        {
+            GeneName first = gene_names.FirstOrDefault();
+            this.ordered_locus = first != null ? first.ordered_locus : null;
+            this.primary = first != null ? first.primary : null;
+            this.gene_names = gene_names.SelectMany(g => g.gene_names);
+        }
+
+        public string get_prefered_name(string prefered_gene_label)
+        {
+            string name;
+            if (prefered_gene_label.ToLower().StartsWith("primary")) name = primary != null ? primary : ordered_locus;
+            else if (prefered_gene_label.ToLower().StartsWith("ordered locus")) name = ordered_locus != null ? ordered_locus : primary;
+            else name = null;
+            return name != null || gene_names.Count() == 0 ? name : gene_names.FirstOrDefault().Item2;
+        }
+
+        public void merge(GeneName more_names)
+        {
+            gene_names = gene_names.Concat(more_names.gene_names).Distinct();
+        }
+
+        public void set_preferred(GeneName top_name)
+        {
+            this.primary = top_name.primary;
+            this.ordered_locus = top_name.primary;
+        }
+    }
+}

--- a/ProteoformSuiteInternal/GeneName.cs
+++ b/ProteoformSuiteInternal/GeneName.cs
@@ -21,9 +21,8 @@ namespace ProteoformSuiteInternal
 
         public GeneName(IEnumerable<GeneName> gene_names)
         {
-            GeneName first = gene_names.FirstOrDefault();
-            this.ordered_locus = first != null ? first.ordered_locus : null;
-            this.primary = first != null ? first.primary : null;
+            this.ordered_locus = gene_names.Count(g => g.ordered_locus != null) > 0 ? gene_names.FirstOrDefault(g => g.ordered_locus != null).ordered_locus : null;
+            this.primary = gene_names.Count(g => g.primary != null) > 0 ? gene_names.FirstOrDefault(g => g.primary != null).primary : null;
             this.gene_names = gene_names.SelectMany(g => g.gene_names);
         }
 
@@ -34,17 +33,6 @@ namespace ProteoformSuiteInternal
             else if (prefered_gene_label.ToLower().StartsWith("ordered locus")) name = ordered_locus != null ? ordered_locus : primary;
             else name = null;
             return name != null || gene_names.Count() == 0 ? name : gene_names.FirstOrDefault().Item2;
-        }
-
-        public void merge(GeneName more_names)
-        {
-            gene_names = gene_names.Concat(more_names.gene_names).Distinct();
-        }
-
-        public void set_preferred(GeneName top_name)
-        {
-            this.primary = top_name.primary;
-            this.ordered_locus = top_name.primary;
         }
     }
 }

--- a/ProteoformSuiteInternal/ProteinSequenceGroup.cs
+++ b/ProteoformSuiteInternal/ProteinSequenceGroup.cs
@@ -8,36 +8,24 @@ namespace ProteoformSuiteInternal
     {
         public List<ProteinWithGoTerms> proteinList { get; private set; }
 
-        public ProteinSequenceGroup(IEnumerable<ProteinWithGoTerms> proteins)
-            : base(proteins.First().BaseSequence,
-                proteins.Any(p => p.IsContaminant) ? 
-                  proteins.FirstOrDefault(p => p.IsContaminant).Accession + "_" + proteins.Count() + "G" : 
-                  proteins.First().Accession + "_" + proteins.Count() + "G",
-                proteins.SelectMany(p => p.GeneNames),
-                proteins.SelectMany(p => p.OneBasedPossibleLocalizedModifications.Keys).Distinct()
-                  .ToDictionary(i => i, i => proteins.Where(p => p.OneBasedPossibleLocalizedModifications.ContainsKey(i)).SelectMany(p => p.OneBasedPossibleLocalizedModifications[i]).ToList()),
-                proteins.Any(p => p.IsContaminant) ? 
-                  proteins.FirstOrDefault(p => p.IsContaminant).ProteolysisProducts.Select(p => p.OneBasedBeginPosition).ToArray() : 
-                  proteins.First().ProteolysisProducts.Select(p => p.OneBasedBeginPosition).ToArray(),
-                proteins.Any(p => p.IsContaminant) ? 
-                  proteins.FirstOrDefault(p => p.IsContaminant).ProteolysisProducts.Select(p => p.OneBasedEndPosition).ToArray() : 
-                  proteins.First().ProteolysisProducts.Select(p => p.OneBasedEndPosition).ToArray(),
-                proteins.Any(p => p.IsContaminant) ? 
-                  proteins.FirstOrDefault(p => p.IsContaminant).ProteolysisProducts.Select(p => p.Type).ToArray() : 
-                  proteins.First().ProteolysisProducts.Select(p => p.Type).ToArray(),
-                proteins.Any(p => p.IsContaminant) ? 
-                  proteins.FirstOrDefault(p => p.IsContaminant).Name : 
-                  proteins.First().Name,
-                proteins.Any(p => p.IsContaminant) ? 
-                  proteins.FirstOrDefault(p => p.IsContaminant).FullName : 
-                  proteins.First().FullName, 
+        public ProteinSequenceGroup(IEnumerable<ProteinWithGoTerms> proteins_with_contaminants_first)
+            : base(proteins_with_contaminants_first.First().BaseSequence,
+                proteins_with_contaminants_first.First().Accession + "_" + proteins_with_contaminants_first.Count() + "G",
+                proteins_with_contaminants_first.SelectMany(p => p.GeneNames),
+                proteins_with_contaminants_first.SelectMany(p => p.OneBasedPossibleLocalizedModifications.Keys).Distinct()
+                  .ToDictionary(i => i, i => proteins_with_contaminants_first.Where(p => p.OneBasedPossibleLocalizedModifications.ContainsKey(i)).SelectMany(p => p.OneBasedPossibleLocalizedModifications[i]).ToList()),
+                proteins_with_contaminants_first.First().ProteolysisProducts.Select(p => p.OneBasedBeginPosition).ToArray(),
+                proteins_with_contaminants_first.First().ProteolysisProducts.Select(p => p.OneBasedEndPosition).ToArray(),
+                proteins_with_contaminants_first.First().ProteolysisProducts.Select(p => p.Type).ToArray(),
+                proteins_with_contaminants_first.First().Name,
+                proteins_with_contaminants_first.First().FullName,
                 false, 
-                proteins.Any(p => p.IsContaminant), 
-                proteins.SelectMany(p => p.DatabaseReferences),
-                proteins.SelectMany(p => p.GoTerms))
+                proteins_with_contaminants_first.Any(p => p.IsContaminant), 
+                proteins_with_contaminants_first.SelectMany(p => p.DatabaseReferences),
+                proteins_with_contaminants_first.SelectMany(p => p.GoTerms))
         {
-            this.proteinList = proteins.ToList();
-            this.AccessionList = proteins.Select(p => p.Accession).ToList();
+            this.proteinList = proteins_with_contaminants_first.ToList();
+            this.AccessionList = proteins_with_contaminants_first.Select(p => p.Accession).ToList();
             this.AccessionList.Sort();
         }
     }

--- a/ProteoformSuiteInternal/ProteinSequenceGroup.cs
+++ b/ProteoformSuiteInternal/ProteinSequenceGroup.cs
@@ -10,14 +10,27 @@ namespace ProteoformSuiteInternal
 
         public ProteinSequenceGroup(IEnumerable<ProteinWithGoTerms> proteins)
             : base(proteins.First().BaseSequence,
-                proteins.Any(p => p.IsContaminant) ? proteins.FirstOrDefault(p => p.IsContaminant).Accession + "_G" + proteins.Count() : proteins.First().Accession + "_G" + proteins.Count(),
+                proteins.Any(p => p.IsContaminant) ? 
+                  proteins.FirstOrDefault(p => p.IsContaminant).Accession + "_" + proteins.Count() + "G" : 
+                  proteins.First().Accession + "_" + proteins.Count() + "G",
                 proteins.SelectMany(p => p.GeneNames),
-                proteins.SelectMany(p => p.OneBasedPossibleLocalizedModifications.Keys).Distinct().ToDictionary(i => i, i => proteins.Where(p => p.OneBasedPossibleLocalizedModifications.ContainsKey(i)).SelectMany(p => p.OneBasedPossibleLocalizedModifications[i]).ToList()),
-                proteins.Any(p => p.IsContaminant) ? proteins.FirstOrDefault(p => p.IsContaminant).ProteolysisProducts.Select(p => p.OneBasedBeginPosition).ToArray() : proteins.First().ProteolysisProducts.Select(p => p.OneBasedBeginPosition).ToArray(),
-                proteins.Any(p => p.IsContaminant) ? proteins.FirstOrDefault(p => p.IsContaminant).ProteolysisProducts.Select(p => p.OneBasedEndPosition).ToArray() : proteins.First().ProteolysisProducts.Select(p => p.OneBasedEndPosition).ToArray(),
-                proteins.Any(p => p.IsContaminant) ? proteins.FirstOrDefault(p => p.IsContaminant).ProteolysisProducts.Select(p => p.Type).ToArray() : proteins.First().ProteolysisProducts.Select(p => p.Type).ToArray(),
-                proteins.Any(p => p.IsContaminant) ? proteins.FirstOrDefault(p => p.IsContaminant).Name : proteins.First().Name,
-                proteins.Any(p => p.IsContaminant) ? proteins.FirstOrDefault(p => p.IsContaminant).FullName : proteins.First().FullName, 
+                proteins.SelectMany(p => p.OneBasedPossibleLocalizedModifications.Keys).Distinct()
+                  .ToDictionary(i => i, i => proteins.Where(p => p.OneBasedPossibleLocalizedModifications.ContainsKey(i)).SelectMany(p => p.OneBasedPossibleLocalizedModifications[i]).ToList()),
+                proteins.Any(p => p.IsContaminant) ? 
+                  proteins.FirstOrDefault(p => p.IsContaminant).ProteolysisProducts.Select(p => p.OneBasedBeginPosition).ToArray() : 
+                  proteins.First().ProteolysisProducts.Select(p => p.OneBasedBeginPosition).ToArray(),
+                proteins.Any(p => p.IsContaminant) ? 
+                  proteins.FirstOrDefault(p => p.IsContaminant).ProteolysisProducts.Select(p => p.OneBasedEndPosition).ToArray() : 
+                  proteins.First().ProteolysisProducts.Select(p => p.OneBasedEndPosition).ToArray(),
+                proteins.Any(p => p.IsContaminant) ? 
+                  proteins.FirstOrDefault(p => p.IsContaminant).ProteolysisProducts.Select(p => p.Type).ToArray() : 
+                  proteins.First().ProteolysisProducts.Select(p => p.Type).ToArray(),
+                proteins.Any(p => p.IsContaminant) ? 
+                  proteins.FirstOrDefault(p => p.IsContaminant).Name : 
+                  proteins.First().Name,
+                proteins.Any(p => p.IsContaminant) ? 
+                  proteins.FirstOrDefault(p => p.IsContaminant).FullName : 
+                  proteins.First().FullName, 
                 false, 
                 proteins.Any(p => p.IsContaminant), 
                 proteins.SelectMany(p => p.DatabaseReferences),

--- a/ProteoformSuiteInternal/ProteoformCommunity.cs
+++ b/ProteoformSuiteInternal/ProteoformCommunity.cs
@@ -44,10 +44,10 @@ namespace ProteoformSuiteInternal
 
             Parallel.ForEach(pfs1, pf1 => 
             {
-                HashSet<string> pf1_prot_accessions = new HashSet<string>(pf1.candidate_relatives.OfType<TheoreticalProteoform>().Select(t => t.proteinList[0].Accession + "_G" + t.proteinList.Count + (t as TheoreticalProteoformGroup != null ? "_T" + ((TheoreticalProteoformGroup)t).accessionList.Count : "")));
+                HashSet<string> pf1_prot_accessions = new HashSet<string>(pf1.candidate_relatives.OfType<TheoreticalProteoform>().Select(t => t.proteinList.FirstOrDefault().Accession + "_G" + t.proteinList.Count() + (t as TheoreticalProteoformGroup != null ? "_T" + ((TheoreticalProteoformGroup)t).accessionList.Count : "")));
                 foreach (string accession in pf1_prot_accessions)
                 {
-                    List<Proteoform> candidate_pfs2_with_accession = pf1.candidate_relatives.OfType<TheoreticalProteoform>().Where(t => t.proteinList[0].Accession + "_G" + t.proteinList.Count + (t as TheoreticalProteoformGroup != null ? "_T" + ((TheoreticalProteoformGroup)t).accessionList.Count : "") == accession).ToList<Proteoform>();
+                    List<Proteoform> candidate_pfs2_with_accession = pf1.candidate_relatives.OfType<TheoreticalProteoform>().Where(t => t.proteinList.FirstOrDefault().Accession + "_G" + t.proteinList.Count() + (t as TheoreticalProteoformGroup != null ? "_T" + ((TheoreticalProteoformGroup)t).accessionList.Count : "") == accession).ToList<Proteoform>();
                     candidate_pfs2_with_accession.Sort(Comparer<Proteoform>.Create((x, y) => Math.Abs(pf1.modified_mass - x.modified_mass).CompareTo(Math.Abs(pf1.modified_mass - y.modified_mass))));
                     Proteoform best_pf2 = candidate_pfs2_with_accession.First();
                     lock (best_pf2) lock (relations)

--- a/ProteoformSuiteInternal/ProteoformCommunity.cs
+++ b/ProteoformSuiteInternal/ProteoformCommunity.cs
@@ -138,7 +138,7 @@ namespace ProteoformSuiteInternal
                 while (root != null && active.Count < Environment.ProcessorCount)
                 {
                     if (root.relation_type != ProteoformComparison.ee && root.relation_type != ProteoformComparison.et)
-                        throw new Exception("Only EE and ET peaks can be accepted");
+                        throw new ArgumentException("Only EE and ET peaks can be accepted");
 
                     Thread t = new Thread(new ThreadStart(root.generate_peak));
                     t.Start();

--- a/ProteoformSuiteInternal/ProteoformFamily.cs
+++ b/ProteoformSuiteInternal/ProteoformFamily.cs
@@ -24,7 +24,7 @@ namespace ProteoformSuiteInternal
         public int relation_count { get { return this.relations.Count; } }
         public HashSet<Proteoform> proteoforms { get; set; }
         private Proteoform seed { get; set; }
-
+        
         public ProteoformFamily(Proteoform seed)
         {
             family_counter++;

--- a/ProteoformSuiteInternal/ProteoformFamily.cs
+++ b/ProteoformSuiteInternal/ProteoformFamily.cs
@@ -11,7 +11,7 @@ namespace ProteoformSuiteInternal
         public int family_id { get; set; }
         public string name_list { get { return String.Join("; ", theoretical_proteoforms.Select(p => p.name)); } }
         public string accession_list { get { return String.Join("; ", theoretical_proteoforms.Select(p => p.accession)); } }
-        public string gene_list { get { return String.Join("; ", gene_names.Select(p => p.get_prefered_name(ProteoformCommunity.preferred_gene_label)).Distinct()); } }
+        public string gene_list { get { return String.Join("; ", gene_names.Select(p => p.get_prefered_name(ProteoformCommunity.preferred_gene_label)).Where(n => n != null).Distinct()); } }
         public string experimentals_list { get { return String.Join("; ", experimental_proteoforms.Select(p => p.accession)); } }
         public string agg_mass_list { get { return String.Join("; ", experimental_proteoforms.Select(p => Math.Round(p.agg_mass, Lollipop.deltaM_edge_display_rounding))); } }
         public int lysine_count { get; set; } = -1;

--- a/ProteoformSuiteInternal/ProteoformRelation.cs
+++ b/ProteoformSuiteInternal/ProteoformRelation.cs
@@ -99,7 +99,7 @@ namespace ProteoformSuiteInternal
 
         public void generate_peak()
         {
-            new DeltaMassPeak(this, Lollipop.proteoform_community.remaining_relations_outside_no_mans);
+            new DeltaMassPeak(this, Lollipop.proteoform_community.remaining_relations_outside_no_mans); //setting the peak takes place elsewhere, but this constructs it
             if (Lollipop.decoy_databases > 0) this.peak.calculate_fdr(Lollipop.ed_relations);
         }
 

--- a/ProteoformSuiteInternal/ProteoformSuiteInternal.csproj
+++ b/ProteoformSuiteInternal/ProteoformSuiteInternal.csproj
@@ -123,6 +123,7 @@
     <Compile Include="ComponentReader.cs" />
     <Compile Include="ExperimentalProteoform.cs" />
     <Compile Include="ExtensionMethods.cs" />
+    <Compile Include="GeneName.cs" />
     <Compile Include="GoTerm.cs" />
     <Compile Include="IBiorepable.cs" />
     <Compile Include="InputFile.cs" />

--- a/ProteoformSuiteInternal/ResultsSummaryGenerator.cs
+++ b/ProteoformSuiteInternal/ResultsSummaryGenerator.cs
@@ -62,13 +62,13 @@ namespace ProteoformSuiteInternal
         public static string proteins_of_significance()
         {
             return "Identified Proteins with Significant Change: " + Environment.NewLine 
-                + String.Join(Environment.NewLine, Lollipop.inducedOrRepressedProteins.Select(p => p.Accession).Distinct()) + Environment.NewLine + Environment.NewLine;
+                + String.Join(Environment.NewLine, Lollipop.inducedOrRepressedProteins.Select(p => p.Accession).Distinct().OrderBy(x => x)) + Environment.NewLine + Environment.NewLine;
         }
 
         public static string go_terms_of_significance()
         {
             return "GO Terms of Significance (Benjimini-Yekeulti p-value < " + Lollipop.minProteoformFDR.ToString() + "): " + Environment.NewLine 
-                + String.Join(Environment.NewLine, Lollipop.goTermNumbers.Where(g => g.by < (double)Lollipop.minProteoformFDR).Select(g => g.ToString())) + Environment.NewLine + Environment.NewLine;
+                + String.Join(Environment.NewLine, Lollipop.goTermNumbers.Where(g => g.by < (double)Lollipop.minProteoformFDR).Select(g => g.ToString()).OrderBy(x => x)) + Environment.NewLine + Environment.NewLine;
 
         }
     }

--- a/ProteoformSuiteInternal/TheoreticalProteoform.cs
+++ b/ProteoformSuiteInternal/TheoreticalProteoform.cs
@@ -21,6 +21,7 @@ namespace ProteoformSuiteInternal
         public double unmodified_mass { get; set; }
         public List<GoTerm> goTerms { get; set; } = new List<GoTerm>();
         public string goTerm_IDs { get { return String.Join("; ", goTerms.Select(g => g.Id)); } }
+        public GeneName gene_name { get; set; }
         public PtmSet ptm_set { get; set; } = new PtmSet(new List<Ptm>());
         public List<Ptm> ptm_list { get { return ptm_set.ptm_combination.ToList(); } }
         public double ptm_mass { get { return ptm_set.mass; } }
@@ -54,8 +55,8 @@ namespace ProteoformSuiteInternal
         public string of_interest { get; set; } = "";
         public bool contaminant { get; set; }
 
-        public TheoreticalProteoform(string accession, string description, ProteinWithGoTerms protein, bool is_metCleaved, double unmodified_mass, int lysine_count, PtmSet ptm_set, double modified_mass, bool is_target, bool check_contaminants, Dictionary<InputFile, Protein[]> theoretical_proteins) :
-            base(accession, modified_mass, lysine_count, is_target)
+        public TheoreticalProteoform(string accession, string description, ProteinWithGoTerms protein, bool is_metCleaved, double unmodified_mass, int lysine_count, PtmSet ptm_set, double modified_mass, bool is_target, bool check_contaminants, Dictionary<InputFile, Protein[]> theoretical_proteins) 
+            : base(accession, modified_mass, lysine_count, is_target)
         {
             this.proteinList.Add(protein);
             this.accession = accession;
@@ -65,13 +66,14 @@ namespace ProteoformSuiteInternal
             this.begin = (int)protein.ProteolysisProducts.FirstOrDefault().OneBasedBeginPosition + Convert.ToInt32(is_metCleaved);
             this.end = (int)protein.ProteolysisProducts.FirstOrDefault().OneBasedEndPosition;
             this.goTerms = protein.GoTerms.ToList();
+            this.gene_name = new GeneName(protein.GeneNames);
             this.ptm_set = ptm_set;
             this.unmodified_mass = unmodified_mass;
             if (check_contaminants) this.contaminant = theoretical_proteins.Where(item => item.Key.ContaminantDB).SelectMany(kv => kv.Value).Any(p => p.Accession == this.accession.Split(new char[] { '_' })[0]);
         }
 
-        public TheoreticalProteoform(string accession, string description, string name, string fragment, int begin, int end, double unmodified_mass, int lysine_count, PtmSet ptm_set, double modified_mass, bool is_target) :
-            base(accession, modified_mass, lysine_count, is_target)
+        public TheoreticalProteoform(string accession, string description, string name, string fragment, int begin, int end, double unmodified_mass, int lysine_count, PtmSet ptm_set, double modified_mass, bool is_target)
+            : base(accession, modified_mass, lysine_count, is_target)
         {
             this.accession = accession;
             this.description = description;
@@ -84,13 +86,15 @@ namespace ProteoformSuiteInternal
         }
 
         //for Tests
-        public TheoreticalProteoform(string accession) : base(accession)
+        public TheoreticalProteoform(string accession) 
+            : base(accession)
         {
             this.accession = accession;
         }
 
         //for Tests
-        public TheoreticalProteoform(string accession, double modified_mass, int lysine_count, bool is_target) : base(accession, modified_mass, lysine_count, is_target)
+        public TheoreticalProteoform(string accession, double modified_mass, int lysine_count, bool is_target) 
+            : base(accession, modified_mass, lysine_count, is_target)
         {
             this.accession = accession;
             this.modified_mass = modified_mass;

--- a/ProteoformSuiteInternal/TheoreticalProteoform.cs
+++ b/ProteoformSuiteInternal/TheoreticalProteoform.cs
@@ -92,17 +92,6 @@ namespace ProteoformSuiteInternal
             this.accession = accession;
         }
 
-        //for Tests
-        public TheoreticalProteoform(string accession, double modified_mass, int lysine_count, bool is_target) 
-            : base(accession, modified_mass, lysine_count, is_target)
-        {
-            this.accession = accession;
-            this.modified_mass = modified_mass;
-            this.lysine_count = lysine_count;
-            this.is_target = is_target;
-            this.is_decoy = !is_target;
-        }
-
         public static double CalculateProteoformMass(string pForm, Dictionary<char, double> aaIsotopeMassList)
         {
             double proteoformMass = 18.010565; // start with water

--- a/ProteoformSuiteInternal/TheoreticalProteoformGroup.cs
+++ b/ProteoformSuiteInternal/TheoreticalProteoformGroup.cs
@@ -9,33 +9,23 @@ namespace ProteoformSuiteInternal
     {
         public List<string> accessionList { get; set; } // this is the list of accession numbers for all proteoforms that share the same modified mass. the list gets alphabetical order
 
-        public TheoreticalProteoformGroup(List<TheoreticalProteoform> theoreticals, bool contaminants, Dictionary<InputFile, Protein[]> theoretical_proteins)
-            : base(theoreticals[0].accession + "_" + theoreticals.Count + "T", String.Join(";", theoreticals.Select(t => t.description)), String.Join(";", theoreticals.Select(t => t.name)), String.Join(";", theoreticals.Select(t => t.fragment)), theoreticals[0].begin, theoreticals[0].end, theoreticals[0].unmodified_mass, theoreticals[0].lysine_count, theoreticals[0].ptm_set, theoreticals[0].modified_mass, theoreticals[0].is_target)
+        public TheoreticalProteoformGroup(IEnumerable<TheoreticalProteoform> theoreticals_with_contaminants_first)
+            : base(theoreticals_with_contaminants_first.FirstOrDefault().accession + "_" + theoreticals_with_contaminants_first.Count() + "T",
+                theoreticals_with_contaminants_first.FirstOrDefault().description,
+                theoreticals_with_contaminants_first.SelectMany(p => p.proteinList),
+                false, //don't increment begin...
+                theoreticals_with_contaminants_first.FirstOrDefault().unmodified_mass,
+                theoreticals_with_contaminants_first.FirstOrDefault().lysine_count,
+                theoreticals_with_contaminants_first.FirstOrDefault().ptm_set,
+                theoreticals_with_contaminants_first.FirstOrDefault().is_target,
+                false,
+                new Dictionary<InputFile, Protein[]>())
         {
-            this.accessionList = theoreticals.Select(p => p.accession).ToList();
-            this.proteinList = theoreticals.SelectMany(p => p.proteinList).ToList();
-            this.goTerms = this.proteinList.SelectMany(p => p.GoTerms).ToList();
-            this.gene_name = new GeneName(theoreticals.Select(t => t.gene_name));
-            if (contaminants)
-            {
-                List<Protein> matching_contaminants = theoretical_proteins.Where(item => item.Key.ContaminantDB).SelectMany(kv => kv.Value).Where(p => this.accessionList.Select(acc => acc.Split(new char[] { '_' })[0]).Contains(p.Accession)).ToList();
-                this.contaminant = matching_contaminants.Count > 0;
-                if (!contaminant) return;
-                this.accession = matching_contaminants[0].Accession + "_T" + accessionList.Count();
-                this.description = String.Join(";", matching_contaminants.Select(t => t.FullDescription));
-                this.name = String.Join(";", matching_contaminants.Select(t => t.Name));
-                TheoreticalProteoform first_contaminant = theoreticals.FirstOrDefault(t => t.contaminant);
-                this.begin = first_contaminant.begin;
-                this.end = first_contaminant.end;
-                this.unmodified_mass = first_contaminant.unmodified_mass;
-                this.modified_mass = first_contaminant.modified_mass;
-                this.lysine_count = first_contaminant.lysine_count;
-                this.goTerms = first_contaminant.goTerms;
-                this.gene_name.set_preferred(first_contaminant.gene_name);
-                this.ptm_set = first_contaminant.ptm_set;
-                this.is_target = first_contaminant.is_target;
-                this.is_decoy = first_contaminant.is_decoy;
-            }
+            this.description = String.Join(";", theoreticals_with_contaminants_first.Select(t => t.description));
+            this.name = String.Join(";", theoreticals_with_contaminants_first.Select(t => t.name));
+            this.fragment = String.Join(";", theoreticals_with_contaminants_first.Select(t => t.fragment));
+            this.accessionList = theoreticals_with_contaminants_first.Select(p => p.accession).ToList();
+            this.contaminant = theoreticals_with_contaminants_first.FirstOrDefault().contaminant;
         }
     }
 }

--- a/ProteoformSuiteInternal/TheoreticalProteoformGroup.cs
+++ b/ProteoformSuiteInternal/TheoreticalProteoformGroup.cs
@@ -10,11 +10,12 @@ namespace ProteoformSuiteInternal
         public List<string> accessionList { get; set; } // this is the list of accession numbers for all proteoforms that share the same modified mass. the list gets alphabetical order
 
         public TheoreticalProteoformGroup(List<TheoreticalProteoform> theoreticals, bool contaminants, Dictionary<InputFile, Protein[]> theoretical_proteins)
-            : base(theoreticals[0].accession + "_T" + theoreticals.Count, String.Join(";", theoreticals.Select(t => t.description)), String.Join(";", theoreticals.Select(t => t.name)), String.Join(";", theoreticals.Select(t => t.fragment)), theoreticals[0].begin, theoreticals[0].end, theoreticals[0].unmodified_mass, theoreticals[0].lysine_count, theoreticals[0].ptm_set, theoreticals[0].modified_mass, theoreticals[0].is_target)
+            : base(theoreticals[0].accession + "_" + theoreticals.Count + "T", String.Join(";", theoreticals.Select(t => t.description)), String.Join(";", theoreticals.Select(t => t.name)), String.Join(";", theoreticals.Select(t => t.fragment)), theoreticals[0].begin, theoreticals[0].end, theoreticals[0].unmodified_mass, theoreticals[0].lysine_count, theoreticals[0].ptm_set, theoreticals[0].modified_mass, theoreticals[0].is_target)
         {
             this.accessionList = theoreticals.Select(p => p.accession).ToList();
             this.proteinList = theoreticals.SelectMany(p => p.proteinList).ToList();
             this.goTerms = this.proteinList.SelectMany(p => p.GoTerms).ToList();
+            this.gene_name = new GeneName(theoreticals.Select(t => t.gene_name));
             if (contaminants)
             {
                 List<Protein> matching_contaminants = theoretical_proteins.Where(item => item.Key.ContaminantDB).SelectMany(kv => kv.Value).Where(p => this.accessionList.Select(acc => acc.Split(new char[] { '_' })[0]).Contains(p.Accession)).ToList();
@@ -30,6 +31,7 @@ namespace ProteoformSuiteInternal
                 this.modified_mass = first_contaminant.modified_mass;
                 this.lysine_count = first_contaminant.lysine_count;
                 this.goTerms = first_contaminant.goTerms;
+                this.gene_name.set_preferred(first_contaminant.gene_name);
                 this.ptm_set = first_contaminant.ptm_set;
                 this.is_target = first_contaminant.is_target;
                 this.is_decoy = first_contaminant.is_decoy;

--- a/ProteoformSuiteInternal/inputFile.cs
+++ b/ProteoformSuiteInternal/inputFile.cs
@@ -37,24 +37,6 @@ namespace ProteoformSuiteInternal
         public int technical_replicate { get; set; } = 1;
         public string lt_condition { get; set; } = "lt_condition";
         public string hv_condition { get; set; } = "hv_condition";
-        public InputFile(string complete_path, Labeling label, Purpose purpose, string lt_con, string hv_con, int biorep) // for neucode files. here both conditions are present in one file
-        {
-            this.complete_path = complete_path;
-            this.label = label;
-            this.purpose = purpose;
-            this.lt_condition = lt_con;
-            this.hv_condition = hv_con;
-            this.biological_replicate = biorep;
-        }
-        public InputFile(string complete_path, Labeling label, Purpose purpose, string lt_con, int biorep) // for non-neucode files. here only one condition is present per file
-        {
-            this.complete_path = complete_path;
-            this.label = label;
-            this.purpose = purpose;
-            this.lt_condition = lt_con;
-            this.biological_replicate = biorep;
-        }
-
 
         //For database files
         public bool ContaminantDB { get; set; } = false;

--- a/Test/ConstructorsForTesting.cs
+++ b/Test/ConstructorsForTesting.cs
@@ -95,5 +95,18 @@ namespace Test
             e.root = e.aggregated_components.OrderByDescending(a => a.intensity_sum).FirstOrDefault();
             return e;
         }
+
+
+        //INPUT FILE
+        public static InputFile InputFile(string complete_path, Labeling label, Purpose purpose, string lt_con, string hv_con, int biorep, int fraction, int techrep) // for neucode files. here both conditions are present in one file
+        {
+            InputFile f = new InputFile(complete_path, label, purpose);
+            f.lt_condition = lt_con;
+            f.hv_condition = hv_con;
+            f.biological_replicate = biorep;
+            f.fraction = fraction;
+            f.technical_replicate = techrep;
+            return f;
+        }
     }
 }

--- a/Test/ConstructorsForTesting.cs
+++ b/Test/ConstructorsForTesting.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Proteomics;
 using ProteoformSuiteInternal;
 
@@ -55,9 +53,20 @@ namespace Test
             ModificationMotif.TryGetMotif("K", out motif);
             string mod_title = "oxidation";
             ModificationWithMass m = new ModificationWithMass(mod_title, new Tuple<string, string>("", mod_title), motif, ModificationSites.K, 1, new Dictionary<string, IList<string>>(), -1, new List<double>(), new List<double>(), "");
-            ProteinWithGoTerms p1 = new ProteinWithGoTerms("MSSSSSSSSSSS", "T1", new List<Tuple<string, string>> { new Tuple<string, string>("", "") }, new Dictionary<int, List<Modification>> { { 1, new List<Modification> { m } } }, new int?[] { 0 }, new int?[] { 0 }, new string[] { "" }, "T2", "T3", true, false, new List<DatabaseReference> { new DatabaseReference("GO", ":", new List<Tuple<string, string>> { new Tuple<string, string>("term", "P:") }) }, new List<GoTerm> { new GoTerm(new DatabaseReference("GO", ":", new List<Tuple<string, string>> { new Tuple<string, string>("term", "P:") })) });
+            ProteinWithGoTerms p1 = new ProteinWithGoTerms("MSSSSSSSSSSS", "T1", new List<Tuple<string, string>> { new Tuple<string, string>("ordered locus", "GENE") }, new Dictionary<int, List<Modification>> { { 1, new List<Modification> { m } } }, new int?[] { 0 }, new int?[] { 0 }, new string[] { "" }, "T2", "T3", true, false, new List<DatabaseReference> { new DatabaseReference("GO", ":", new List<Tuple<string, string>> { new Tuple<string, string>("term", "P:") }) }, new List<GoTerm> { new GoTerm(new DatabaseReference("GO", ":", new List<Tuple<string, string>> { new Tuple<string, string>("term", "P:") })) });
             PtmSet set = new PtmSet(new List<Ptm> { new Ptm(0, m) });
             return new TheoreticalProteoform(a, d, new List<ProteinWithGoTerms> { p }, false, mass, 0, set, true, false, dict);
+        }
+
+        public static TheoreticalProteoform make_a_theoretical(string a, string d, double mass, Dictionary<InputFile, Protein[]> dict)
+        {
+            ModificationMotif motif;
+            ModificationMotif.TryGetMotif("K", out motif);
+            string mod_title = "oxidation";
+            ModificationWithMass m = new ModificationWithMass(mod_title, new Tuple<string, string>("", mod_title), motif, ModificationSites.K, 1, new Dictionary<string, IList<string>>(), -1, new List<double>(), new List<double>(), "");
+            ProteinWithGoTerms p1 = new ProteinWithGoTerms("MSSSSSSSSSSS", "T1", new List<Tuple<string, string>> { new Tuple<string, string>("ordered locus", "GENE") }, new Dictionary<int, List<Modification>> { { 1, new List<Modification> { m } } }, new int?[] { 0 }, new int?[] { 0 }, new string[] { "" }, "T2", "T3", true, false, new List<DatabaseReference> { new DatabaseReference("GO", ":", new List<Tuple<string, string>> { new Tuple<string, string>("term", "P:") }) }, new List<GoTerm> { new GoTerm(new DatabaseReference("GO", ":", new List<Tuple<string, string>> { new Tuple<string, string>("term", "P:") })) });
+            PtmSet set = new PtmSet(new List<Ptm> { new Ptm(0, m) });
+            return new TheoreticalProteoform(a, d, new List<ProteinWithGoTerms> { p1 }, false, mass, 0, set, true, false, dict);
         }
 
         public static TheoreticalProteoform make_a_theoretical(string a, double mass, int lysine_count)

--- a/Test/ConstructorsForTesting.cs
+++ b/Test/ConstructorsForTesting.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Proteomics;
+using ProteoformSuiteInternal;
+
+namespace Test
+{
+    public class ConstructorsForTesting
+    {
+        //MAKE RELATION
+        public static void make_relation(Proteoform p1, Proteoform p2)
+        {
+            ProteoformRelation pp = new ProteoformRelation(p1, p2, ProteoformComparison.ee, 0);
+            DeltaMassPeak ppp = new DeltaMassPeak(pp, new List<ProteoformRelation> { pp });
+            pp.peak = ppp;
+            ppp.peak_accepted = true;
+            p1.relationships.Add(pp);
+            p2.relationships.Add(pp);
+        }
+
+        public static void make_relation(Proteoform p1, Proteoform p2, ProteoformComparison c, double delta_mass)
+        {
+            ProteoformRelation pp = new ProteoformRelation(p1, p2, c, delta_mass);
+            p1.relationships.Add(pp);
+            p2.relationships.Add(pp);
+        }
+
+
+        //MAKE THEORETICAL
+        public static TheoreticalProteoform make_a_theoretical(string a, ProteinWithGoTerms p, Dictionary<InputFile, Protein[]> dict)
+        {
+            ModificationMotif motif;
+            ModificationMotif.TryGetMotif("K", out motif);
+            PtmSet set = new PtmSet(p.OneBasedPossibleLocalizedModifications.SelectMany(m => m.Value.OfType<ModificationWithMass>().SelectMany(mmm => new List<Ptm> { new Ptm(0, mmm) })).ToList());
+            return new TheoreticalProteoform(a, "", new List<ProteinWithGoTerms> { p }, false, 100, 0, set, true, true, dict);
+        }
+
+        public static TheoreticalProteoform make_a_theoretical()
+        {
+            ModificationMotif motif;
+            ModificationMotif.TryGetMotif("K", out motif);
+            string mod_title = "oxidation";
+            ModificationWithMass m = new ModificationWithMass(mod_title, new Tuple<string, string>("", mod_title), motif, ModificationSites.K, 1, new Dictionary<string, IList<string>>(), -1, new List<double>(), new List<double>(), "");
+            ProteinWithGoTerms p1 = new ProteinWithGoTerms("MSSSSSSSSSSS", "T1", new List<Tuple<string, string>> { new Tuple<string, string>("", "") }, new Dictionary<int, List<Modification>> { { 1, new List<Modification> { m } } }, new int?[] { 0 }, new int?[] { 0 }, new string[] { "" }, "T2", "T3", true, false, new List<DatabaseReference> { new DatabaseReference("GO", ":", new List<Tuple<string, string>> { new Tuple<string, string>("term", "P:") }) }, new List<GoTerm> { new GoTerm(new DatabaseReference("GO", ":", new List<Tuple<string, string>> { new Tuple<string, string>("term", "P:") })) });
+            PtmSet set = new PtmSet(new List<Ptm> { new Ptm(0, m) });
+            return new TheoreticalProteoform("T1", "T1_1", new List<ProteinWithGoTerms> { p1 }, false, 100, 0, set, true, false, new Dictionary<InputFile, Protein[]>());
+        }
+
+        public static TheoreticalProteoform make_a_theoretical(string a, string d, double mass, ProteinWithGoTerms p, Dictionary<InputFile, Protein[]> dict)
+        {
+            ModificationMotif motif;
+            ModificationMotif.TryGetMotif("K", out motif);
+            string mod_title = "oxidation";
+            ModificationWithMass m = new ModificationWithMass(mod_title, new Tuple<string, string>("", mod_title), motif, ModificationSites.K, 1, new Dictionary<string, IList<string>>(), -1, new List<double>(), new List<double>(), "");
+            ProteinWithGoTerms p1 = new ProteinWithGoTerms("MSSSSSSSSSSS", "T1", new List<Tuple<string, string>> { new Tuple<string, string>("", "") }, new Dictionary<int, List<Modification>> { { 1, new List<Modification> { m } } }, new int?[] { 0 }, new int?[] { 0 }, new string[] { "" }, "T2", "T3", true, false, new List<DatabaseReference> { new DatabaseReference("GO", ":", new List<Tuple<string, string>> { new Tuple<string, string>("term", "P:") }) }, new List<GoTerm> { new GoTerm(new DatabaseReference("GO", ":", new List<Tuple<string, string>> { new Tuple<string, string>("term", "P:") })) });
+            PtmSet set = new PtmSet(new List<Ptm> { new Ptm(0, m) });
+            return new TheoreticalProteoform(a, d, new List<ProteinWithGoTerms> { p }, false, mass, 0, set, true, false, dict);
+        }
+
+        public static TheoreticalProteoform make_a_theoretical(string a, double mass, int lysine_count)
+        {
+            ProteinWithGoTerms p1 = new ProteinWithGoTerms("MSSSSSSSSSSS", "T1", new List<Tuple<string, string>> { new Tuple<string, string>("", "") }, new Dictionary<int, List<Modification>> { { 0, new List<Modification> { new Modification("unmodified") } } }, new int?[] { 0 }, new int?[] { 0 }, new string[] { "" }, "T2", "T3", true, false, new List<DatabaseReference> { new DatabaseReference("GO", ":", new List<Tuple<string, string>> { new Tuple<string, string>("term", "P:") }) }, new List<GoTerm> { new GoTerm(new DatabaseReference("GO", ":", new List<Tuple<string, string>> { new Tuple<string, string>("term", "P:") })) });
+            PtmSet set = new PtmSet(new List<Ptm>());
+            return new TheoreticalProteoform(a, "", new List<ProteinWithGoTerms> { p1 }, false, mass, lysine_count, set, true, false, new Dictionary<InputFile, Protein[]>());
+        }
+
+
+        //EXPERIMENTAL PROTEOFORMS
+        public static ExperimentalProteoform ExperimentalProteoform(string accession)
+        {
+            return new ExperimentalProteoform(accession, new Component(), true);
+        }
+
+        public static ExperimentalProteoform ExperimentalProteoform(string accession, double modified_mass, int lysine_count, bool is_target)
+        {
+            ExperimentalProteoform e = new ExperimentalProteoform(accession, new Component(), is_target);
+            e.modified_mass = modified_mass;
+            e.lysine_count = lysine_count;
+            return e;
+        }
+
+        public static ExperimentalProteoform ExperimentalProteoform(string accession, Component root, List<Component> candidate_observations, List<Component> quantitative_observations, bool is_target)
+        {
+            ExperimentalProteoform e = new ExperimentalProteoform(accession, root, is_target);
+            e.aggregated_components.AddRange(candidate_observations.Where(p => e.includes(p, e.root)));
+            e.calculate_properties();
+            if (quantitative_observations.Count > 0)
+            {
+                e.lt_quant_components.AddRange(quantitative_observations.Where(r => e.includes_neucode_component(r, e, true)));
+                if (Lollipop.neucode_labeled) e.hv_quant_components.AddRange(quantitative_observations.Where(r => e.includes_neucode_component(r, e, false)));
+            }
+            e.root = e.aggregated_components.OrderByDescending(a => a.intensity_sum).FirstOrDefault();
+            return e;
+        }
+    }
+}

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -96,6 +96,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConstructorsForTesting.cs" />
     <Compile Include="TestAggregationMethods.cs" />
     <Compile Include="TestBigRational.cs" />
     <Compile Include="TestComponent.cs" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -100,6 +100,7 @@
     <Compile Include="TestBigRational.cs" />
     <Compile Include="TestComponent.cs" />
     <Compile Include="TestExtensions.cs" />
+    <Compile Include="TestGeneName.cs" />
     <Compile Include="TestGoTermNumber.cs" />
     <Compile Include="TestInputFile.cs" />
     <Compile Include="TestQuantification.cs" />

--- a/Test/TestAggregationMethods.cs
+++ b/Test/TestAggregationMethods.cs
@@ -38,7 +38,7 @@ namespace Test
             Assert.AreEqual(4, next.intensity_sum_olcs);
 
             //Based on experimental proteoforms
-            ExperimentalProteoform exp = new ExperimentalProteoform("E");
+            ExperimentalProteoform exp = ConstructorsForTesting.ExperimentalProteoform("E");
             exp.root = is_running;
             List<ExperimentalProteoform> active2 = new List<ExperimentalProteoform> { exp };
             Component next2 = Lollipop.find_next_root(ordered, active2);
@@ -49,10 +49,10 @@ namespace Test
         [Test]
         public void choose_next_exp_proteoform()
         {
-            ExperimentalProteoform c = new ExperimentalProteoform("E");
-            ExperimentalProteoform d = new ExperimentalProteoform("E");
-            ExperimentalProteoform e = new ExperimentalProteoform("E");
-            ExperimentalProteoform f = new ExperimentalProteoform("E");
+            ExperimentalProteoform c = ConstructorsForTesting.ExperimentalProteoform("E");
+            ExperimentalProteoform d = ConstructorsForTesting.ExperimentalProteoform("E");
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E");
+            ExperimentalProteoform f = ConstructorsForTesting.ExperimentalProteoform("E");
             c.agg_mass = 100;
             d.agg_mass = 119;
             e.agg_mass = 121;
@@ -62,7 +62,7 @@ namespace Test
             e.agg_intensity = 3;
             f.agg_intensity = 4;
             List<ExperimentalProteoform> ordered = new List<ExperimentalProteoform> { c, d, e, f }.OrderByDescending(cc => cc.agg_intensity).ToList();
-            ExperimentalProteoform is_running = new ExperimentalProteoform("E");
+            ExperimentalProteoform is_running = ConstructorsForTesting.ExperimentalProteoform("E");
             is_running.agg_mass = 100;
             is_running.agg_intensity = 100;
 
@@ -192,7 +192,7 @@ namespace Test
             Lollipop.neucode_labeled = false;
             Lollipop.remaining_components = new List<Component>(components);
             Lollipop.remaining_verification_components = new List<Component>(components);
-            ExperimentalProteoform e = new ExperimentalProteoform("E");
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E");
             e.root = components[0];
             e.aggregate();
             e.verify();

--- a/Test/TestAggregationMethods.cs
+++ b/Test/TestAggregationMethods.cs
@@ -155,7 +155,7 @@ namespace Test
             Assert.AreEqual(1, vetted_quant[0].hv_quant_components.Count);
             Assert.AreEqual(2, quant_components.Count);
             Assert.AreEqual(0, Lollipop.remaining_quantification_components.Count);
-        }
+        }        
         
         [Test]
         public void full_agg_without_validation()
@@ -202,6 +202,15 @@ namespace Test
             Assert.AreEqual(0, e.hv_verification_components.Count); // everything goes into light with unlabeled
             Assert.AreEqual(0, e.lt_quant_components.Count); // no quantitation for unlabeled, yet
             Assert.AreEqual(0, e.hv_quant_components.Count);
+        }
+
+        [Test]
+        public void basic_regroup_test()
+        {
+            Lollipop.raw_neucode_pairs.Add(new NeuCodePair());
+            Assert.IsNotEmpty(Lollipop.raw_neucode_pairs);
+            Assert.IsEmpty(Lollipop.regroup_components(true, false, new List<InputFile>(), Lollipop.raw_neucode_pairs, Lollipop.raw_experimental_components, Lollipop.raw_quantification_components, 0, 0));
+            Assert.IsEmpty(Lollipop.raw_neucode_pairs);
         }
     }
 }

--- a/Test/TestBigRational.cs
+++ b/Test/TestBigRational.cs
@@ -152,5 +152,14 @@ namespace Test
             //Assert.True(new BigRational(1.5) % new BigRational(1.0) == new BigRational(0.5));
             //Assert.True(new BigRational(1.0) % new BigRational(2.0) == 0);
         }
+
+        [Test]
+        public void bigrational_basic_equals_compare()
+        {
+            Assert.False(BigRational.One.Equals(new object()));
+            Assert.Throws<ArgumentException>(() => ((IComparable)BigRational.One).CompareTo(new object()));
+            Assert.AreEqual(1, ((IComparable)BigRational.One).CompareTo(null));
+            Assert.AreEqual(1, ((IComparable)BigRational.One).CompareTo(BigRational.Zero));
+        }
     }
 }

--- a/Test/TestCytoscapeScript.cs
+++ b/Test/TestCytoscapeScript.cs
@@ -187,7 +187,7 @@ namespace Test
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
             Lollipop.proteoform_community = community;
-            CytoscapeScript.write_cytoscape_script(community.families.SelectMany(f => f.theoretical_proteoforms).ToArray(), community.families, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2, false, Lollipop.gene_name_labels[1]);
+            CytoscapeScript.write_cytoscape_script(community.families.SelectMany(f => f.theoretical_proteoforms.Where(t => t.proteinList.Select(p => p.FullName).Contains(TestProteoformFamilies.p1_fullName))).ToArray(), community.families, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2, false, Lollipop.gene_name_labels[1]);
             string[] edge_lines = File.ReadAllLines(Path.Combine(TestContext.CurrentContext.TestDirectory, CytoscapeScript.edge_file_prefix + "test" + CytoscapeScript.edge_file_extension));
             HashSet<string> shared_pf_names_edges = new HashSet<string>();
             for (int i = 1; i < edge_lines.Length; i++)

--- a/Test/TestCytoscapeScript.cs
+++ b/Test/TestCytoscapeScript.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using ProteoformSuiteInternal;
 using Proteomics;
@@ -14,15 +12,12 @@ namespace Test
     [TestFixture]
     class TestCytoscapeScript
     {
+        
+
         [Test]
         public void nodes_table_gives_meaningful_modified_theoreticals()
         {
-            ModificationMotif motif;
-            ModificationMotif.TryGetMotif("K", out motif);
-            string mod_title = "oxidation";
-            ModificationWithMass m = new ModificationWithMass(mod_title, new Tuple<string, string>("", mod_title), motif, ModificationSites.K, 1, new Dictionary<string, IList<string>>(), -1, new List<double>(), new List<double>(), "");
-
-            Proteoform p = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new PtmSet(new List<Ptm> { new Ptm(0, m) }), 100, true);
+            Proteoform p = ConstructorsForTesting.make_a_theoretical();
             ProteoformFamily f = new ProteoformFamily(p);
             f.construct_family();
             string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2, f.theoretical_proteoforms, false, Lollipop.gene_name_labels[1]);
@@ -37,7 +32,7 @@ namespace Test
             ModificationMotif.TryGetMotif("K", out motif);
             ModificationWithMass m = new ModificationWithMass("oxidation", new Tuple<string, string>("", ""), motif, ModificationSites.K, 1, new Dictionary<string, IList<string>>(), -1, new List<double>(), new List<double>(), "");
 
-            Proteoform p = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new PtmSet(new List<Ptm> { new Ptm(0, m), new Ptm(0, m) }), 100, true);
+            Proteoform p = ConstructorsForTesting.make_a_theoretical();
             ProteoformFamily f = new ProteoformFamily(p);
             f.construct_family();
             string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2, f.theoretical_proteoforms, false, Lollipop.gene_name_labels[1]);
@@ -48,7 +43,7 @@ namespace Test
         [Test]
         public void nodes_table_gives_meaningful_unmodified_theoreticals()
         {
-            Proteoform p = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new PtmSet(new List<Ptm> { new Ptm() }), 100, true); //unmodified has one PTM labeled unmodified
+            Proteoform p = ConstructorsForTesting.make_a_theoretical();
             ProteoformFamily f = new ProteoformFamily(p);
             f.construct_family();
             string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2, f.theoretical_proteoforms, false, Lollipop.gene_name_labels[1]);
@@ -64,7 +59,7 @@ namespace Test
             string mod_title = "unmodified".ToUpper();
             ModificationWithMass m = new ModificationWithMass(mod_title, new Tuple<string, string>("N/A", mod_title), motif, ModificationSites.K, 0, new Dictionary<string, IList<string>>(), -1, new List<double>(), new List<double>(), "");
 
-            Proteoform p = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new PtmSet(new List<Ptm> { new Ptm() }), 100, true); //unmodified has one PTM labeled unmodified
+            Proteoform p = ConstructorsForTesting.make_a_theoretical();
             ProteoformFamily f = new ProteoformFamily(p);
             f.construct_family();
             string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2, f.theoretical_proteoforms, false, Lollipop.gene_name_labels[1]);
@@ -75,7 +70,7 @@ namespace Test
         [Test]
         public void nodes_table_gives_meaningful_experimentals()
         {
-            ExperimentalProteoform e = new ExperimentalProteoform("E1");
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1");
             e.agg_intensity = 999.99;
             e.agg_mass = 888.88;
             e.agg_rt = 777.77;
@@ -89,7 +84,7 @@ namespace Test
         [Test]
         public void test_write_families_no_experimentals_which_shouldnt_happen()
         {
-            List<ProteoformFamily> f = new List<ProteoformFamily> { new ProteoformFamily(new TheoreticalProteoform("T1","","T1_1","",0,0,100,20, new PtmSet(new List<Ptm> { new Ptm() }),100,true)) };
+            List<ProteoformFamily> f = new List<ProteoformFamily> { new ProteoformFamily(ConstructorsForTesting.make_a_theoretical()) };
             f.First().construct_family();
             string message = CytoscapeScript.write_cytoscape_script(f, f, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2, false, Lollipop.gene_name_labels[1]);
             Assert.True(message.Contains("Error"));
@@ -98,8 +93,8 @@ namespace Test
         [Test]
         public void test_write_families_regular_display()
         {
-            TheoreticalProteoform t = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new PtmSet(new List<Ptm> { new Ptm() }), 100, true);
-            ExperimentalProteoform e = new ExperimentalProteoform("E1");
+            TheoreticalProteoform t = ConstructorsForTesting.make_a_theoretical();
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1");
             ProteoformRelation et = new ProteoformRelation(e, t, ProteoformComparison.et, 0);
             et.peak = new DeltaMassPeak(et, new List<ProteoformRelation> { et });
             et.peak.peak_accepted = true;
@@ -142,8 +137,8 @@ namespace Test
         [Test]
         public void cytoscape_improper_build_folder()
         {
-            TheoreticalProteoform t = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new PtmSet(new List<Ptm> { new Ptm() }), 100, true);
-            ExperimentalProteoform e = new ExperimentalProteoform("E1");
+            TheoreticalProteoform t = ConstructorsForTesting.make_a_theoretical();
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1");
             ProteoformRelation et = new ProteoformRelation(e, t, ProteoformComparison.et, 0);
             e.agg_intensity = 999.99;
             e.quant.lightIntensitySum = 444.44m;

--- a/Test/TestCytoscapeScript.cs
+++ b/Test/TestCytoscapeScript.cs
@@ -25,7 +25,7 @@ namespace Test
             Proteoform p = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new PtmSet(new List<Ptm> { new Ptm(0, m) }), 100, true);
             ProteoformFamily f = new ProteoformFamily(p);
             f.construct_family();
-            string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2);
+            string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2, f.theoretical_proteoforms, false, Lollipop.gene_name_labels[1]);
             Assert.True(node_table.Contains(CytoscapeScript.modified_theoretical_label));
             Assert.AreNotEqual(f.theoretical_proteoforms[0].accession, CytoscapeScript.get_proteoform_shared_name(p, 2));
         }
@@ -40,7 +40,7 @@ namespace Test
             Proteoform p = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new PtmSet(new List<Ptm> { new Ptm(0, m), new Ptm(0, m) }), 100, true);
             ProteoformFamily f = new ProteoformFamily(p);
             f.construct_family();
-            string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2);
+            string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2, f.theoretical_proteoforms, false, Lollipop.gene_name_labels[1]);
             Assert.True(node_table.Contains(CytoscapeScript.modified_theoretical_label));
             Assert.AreNotEqual(f.theoretical_proteoforms[0].accession, CytoscapeScript.get_proteoform_shared_name(p, 2));
         }
@@ -51,7 +51,7 @@ namespace Test
             Proteoform p = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new PtmSet(new List<Ptm> { new Ptm() }), 100, true); //unmodified has one PTM labeled unmodified
             ProteoformFamily f = new ProteoformFamily(p);
             f.construct_family();
-            string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2);
+            string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2, f.theoretical_proteoforms, false, Lollipop.gene_name_labels[1]);
             Assert.True(node_table.Contains(CytoscapeScript.unmodified_theoretical_label));
             Assert.AreNotEqual(f.theoretical_proteoforms[0].accession, CytoscapeScript.get_proteoform_shared_name(p, 2));
         }
@@ -67,7 +67,7 @@ namespace Test
             Proteoform p = new TheoreticalProteoform("T1", "", "T1_1", "", 0, 0, 100, 20, new PtmSet(new List<Ptm> { new Ptm() }), 100, true); //unmodified has one PTM labeled unmodified
             ProteoformFamily f = new ProteoformFamily(p);
             f.construct_family();
-            string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2);
+            string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2, f.theoretical_proteoforms, false, Lollipop.gene_name_labels[1]);
             Assert.True(node_table.Contains(CytoscapeScript.unmodified_theoretical_label));
             Assert.AreNotEqual(f.theoretical_proteoforms[0].accession, CytoscapeScript.get_proteoform_shared_name(p, 2));
         }
@@ -81,7 +81,7 @@ namespace Test
             e.agg_rt = 777.77;
             ProteoformFamily f = new ProteoformFamily(e);
             f.construct_family();
-            string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2);
+            string node_table = CytoscapeScript.get_cytoscape_nodes_tsv(new List<ProteoformFamily> { f }, false, CytoscapeScript.color_scheme_names[0], 2, f.theoretical_proteoforms, false, Lollipop.gene_name_labels[1]);
             Assert.True(node_table.Contains("E1"));
             Assert.True(node_table.Contains("999.99"));
         }
@@ -91,7 +91,7 @@ namespace Test
         {
             List<ProteoformFamily> f = new List<ProteoformFamily> { new ProteoformFamily(new TheoreticalProteoform("T1","","T1_1","",0,0,100,20, new PtmSet(new List<Ptm> { new Ptm() }),100,true)) };
             f.First().construct_family();
-            string message = CytoscapeScript.write_cytoscape_script(f, f, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2);
+            string message = CytoscapeScript.write_cytoscape_script(f, f, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2, false, Lollipop.gene_name_labels[1]);
             Assert.True(message.Contains("Error"));
         }
 
@@ -111,7 +111,7 @@ namespace Test
             e.quant.intensitySum = 777.77m;
             List<ProteoformFamily> f = new List<ProteoformFamily> { new ProteoformFamily(e) };
             f.First().construct_family();
-            string message = CytoscapeScript.write_cytoscape_script(f, f, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2);
+            string message = CytoscapeScript.write_cytoscape_script(f, f, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2, false, Lollipop.gene_name_labels[1]);
             Assert.True(File.Exists(Path.Combine(TestContext.CurrentContext.TestDirectory, CytoscapeScript.script_file_prefix + "test" + CytoscapeScript.script_file_extension)));
             Assert.True(File.Exists(Path.Combine(TestContext.CurrentContext.TestDirectory, CytoscapeScript.style_file_prefix + "test" + CytoscapeScript.style_file_extension)));
             Assert.True(File.Exists(Path.Combine(TestContext.CurrentContext.TestDirectory, CytoscapeScript.node_file_prefix + "test" + CytoscapeScript.node_file_extension)));
@@ -151,7 +151,7 @@ namespace Test
             e.quant.intensitySum = 777.77m;
             List<ProteoformFamily> f = new List<ProteoformFamily> { new ProteoformFamily(e) };
             f.First().construct_family();
-            string message = CytoscapeScript.write_cytoscape_script(f, f, "", "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2);
+            string message = CytoscapeScript.write_cytoscape_script(f, f, "", "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2, false, Lollipop.gene_name_labels[1]);
             Assert.False(message.StartsWith("Finished"));
         }
 
@@ -160,7 +160,8 @@ namespace Test
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
             Lollipop.proteoform_community = community;
-            string edges = CytoscapeScript.get_cytoscape_edges_tsv(community.families, 2);
+            IEnumerable<TheoreticalProteoform> theoreticals = community.families.SelectMany(f => f.theoretical_proteoforms);
+            string edges = CytoscapeScript.get_cytoscape_edges_tsv(community.families, 2, theoreticals, false, Lollipop.gene_name_labels[1]);
             string[] lines = edges.Split(new char[] { '\n' });
             HashSet<string> shared_pf_names_edges = new HashSet<string>();
             for (int i = 1; i < lines.Length; i++)
@@ -171,7 +172,7 @@ namespace Test
                 shared_pf_names_edges.Add(line[2]);
             }
 
-            string nodes = CytoscapeScript.get_cytoscape_nodes_tsv(community.families, false, CytoscapeScript.color_scheme_names[0], 2);
+            string nodes = CytoscapeScript.get_cytoscape_nodes_tsv(community.families, false, CytoscapeScript.color_scheme_names[0], 2, theoreticals, false, Lollipop.gene_name_labels[1]);
             lines = nodes.Split(new char[] { '\n' });
             HashSet<string> shared_pf_names_nodes = new HashSet<string>();
             for (int i = 1; i < lines.Length; i++)
@@ -191,7 +192,7 @@ namespace Test
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
             Lollipop.proteoform_community = community;
-            CytoscapeScript.write_cytoscape_script(community.families.SelectMany(f => f.theoretical_proteoforms).ToArray(), community.families, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2);
+            CytoscapeScript.write_cytoscape_script(community.families.SelectMany(f => f.theoretical_proteoforms).ToArray(), community.families, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2, false, Lollipop.gene_name_labels[1]);
             string[] edge_lines = File.ReadAllLines(Path.Combine(TestContext.CurrentContext.TestDirectory, CytoscapeScript.edge_file_prefix + "test" + CytoscapeScript.edge_file_extension));
             HashSet<string> shared_pf_names_edges = new HashSet<string>();
             for (int i = 1; i < edge_lines.Length; i++)
@@ -221,7 +222,7 @@ namespace Test
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
             Lollipop.proteoform_community = community;
-            CytoscapeScript.write_cytoscape_script(new GoTerm[] { TestProteoformFamilies.p1_goterm }, community.families, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2);
+            CytoscapeScript.write_cytoscape_script(new GoTerm[] { TestProteoformFamilies.p1_goterm }, community.families, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2, false, Lollipop.gene_name_labels[1]);
             string[] edge_lines = File.ReadAllLines(Path.Combine(TestContext.CurrentContext.TestDirectory, CytoscapeScript.edge_file_prefix + "test" + CytoscapeScript.edge_file_extension));
             HashSet<string> shared_pf_names_edges = new HashSet<string>();
             for (int i = 1; i < edge_lines.Length; i++)
@@ -251,7 +252,7 @@ namespace Test
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
             Lollipop.proteoform_community = community;
-            CytoscapeScript.write_cytoscape_script(community.families.SelectMany(f => f.experimental_proteoforms.Select(ex => ex.quant)).ToArray(), community.families, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2);
+            CytoscapeScript.write_cytoscape_script(community.families.SelectMany(f => f.experimental_proteoforms.Select(ex => ex.quant)).ToArray(), community.families, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2, false, Lollipop.gene_name_labels[1]);
             string[] edge_lines = File.ReadAllLines(Path.Combine(TestContext.CurrentContext.TestDirectory, CytoscapeScript.edge_file_prefix + "test" + CytoscapeScript.edge_file_extension));
             HashSet<string> shared_pf_names_edges = new HashSet<string>();
             for (int i = 1; i < edge_lines.Length; i++)
@@ -281,7 +282,7 @@ namespace Test
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
             Lollipop.proteoform_community = community;
-            CytoscapeScript.write_cytoscape_script(new List<ProteoformFamily> { community.families[0] }, community.families, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2);
+            CytoscapeScript.write_cytoscape_script(new List<ProteoformFamily> { community.families[0] }, community.families, TestContext.CurrentContext.TestDirectory, "test", false, false, false, false, CytoscapeScript.color_scheme_names[0], CytoscapeScript.node_label_positions[0], 2, false, Lollipop.gene_name_labels[1]);
             string[] edge_lines = File.ReadAllLines(Path.Combine(TestContext.CurrentContext.TestDirectory, CytoscapeScript.edge_file_prefix + "test" + CytoscapeScript.edge_file_extension));
             HashSet<string> shared_pf_names_edges = new HashSet<string>();
             for (int i = 1; i < edge_lines.Length; i++)

--- a/Test/TestDeltaMassPeak.cs
+++ b/Test/TestDeltaMassPeak.cs
@@ -306,5 +306,15 @@ namespace Test
             ProteoformCommunity c = new ProteoformCommunity();
             Assert.AreEqual(0, c.accept_deltaMass_peaks(new List<ProteoformRelation>(), new List<ProteoformRelation>()).Count);
         }
+
+        [Test]
+        public static void accept_peaks_doesnt_crash_with_weird_relation()
+        {
+            ProteoformCommunity c = new ProteoformCommunity();
+            ProteoformRelation r = new ProteoformRelation(ConstructorsForTesting.ExperimentalProteoform("E1"), ConstructorsForTesting.ExperimentalProteoform("E1"), ProteoformComparison.ef, 0);
+            r.outside_no_mans_land = true;
+            r.nearby_relations = new List<ProteoformRelation>();
+            Assert.Throws<ArgumentException>(() => c.accept_deltaMass_peaks(new List<ProteoformRelation> { r }, new List<ProteoformRelation>()));
+        }
     }
 }

--- a/Test/TestDeltaMassPeak.cs
+++ b/Test/TestDeltaMassPeak.cs
@@ -30,23 +30,23 @@ namespace Test
             Lollipop.peak_width_base_et = 0.015;
 
 
-            ExperimentalProteoform pf1 = new ExperimentalProteoform("acession1");
-            TheoreticalProteoform pf2 = new TheoreticalProteoform("acession2");
+            ExperimentalProteoform pf1 = ConstructorsForTesting.ExperimentalProteoform("acession1");
+            TheoreticalProteoform pf2 = ConstructorsForTesting.make_a_theoretical();
             ProteoformComparison relation_type = ProteoformComparison.et;
             double delta_mass = 1 - 1e-7;
 
-            ExperimentalProteoform pf3 = new ExperimentalProteoform("acession3");
-            TheoreticalProteoform pf4 = new TheoreticalProteoform("acession4");
+            ExperimentalProteoform pf3 = ConstructorsForTesting.ExperimentalProteoform("acession3");
+            TheoreticalProteoform pf4 = ConstructorsForTesting.make_a_theoretical();
             ProteoformComparison relation_type2 = ProteoformComparison.et;
             double delta_mass2 = 1;
 
-            ExperimentalProteoform pf5 = new ExperimentalProteoform("acession5");
-            TheoreticalProteoform pf6 = new TheoreticalProteoform("acession6");
+            ExperimentalProteoform pf5 = ConstructorsForTesting.ExperimentalProteoform("acession5");
+            TheoreticalProteoform pf6 = ConstructorsForTesting.make_a_theoretical();
             ProteoformComparison relation_type3 = ProteoformComparison.et;
             double delta_mass3 = 1 + 1e-7;
 
-            ExperimentalProteoform pf55 = new ExperimentalProteoform("acession5");
-            TheoreticalProteoform pf65 = new TheoreticalProteoform("acession6");
+            ExperimentalProteoform pf55 = ConstructorsForTesting.ExperimentalProteoform("acession5");
+            TheoreticalProteoform pf65 = ConstructorsForTesting.make_a_theoretical();
             ProteoformComparison relation_type35 = ProteoformComparison.et;
             double delta_mass35 = 1 + 2e-7;
 
@@ -70,8 +70,8 @@ namespace Test
 
             decoy_relations["decoyDatabase1"] = new List<ProteoformRelation>();
 
-            ExperimentalProteoform pf7 = new ExperimentalProteoform("experimental1");
-            TheoreticalProteoform pf8 = new TheoreticalProteoform("decoy1");
+            ExperimentalProteoform pf7 = ConstructorsForTesting.ExperimentalProteoform("experimental1");
+            TheoreticalProteoform pf8 = ConstructorsForTesting.make_a_theoretical();
             ProteoformComparison relation_type4 = ProteoformComparison.ed;
             double delta_mass4 = 1;
             ProteoformRelation decoy_relation = new ProteoformRelation(pf7, pf8, relation_type4, delta_mass4);
@@ -105,10 +105,10 @@ namespace Test
             //Testing the acceptance of peaks. The FDR is tested above, so I'm not going to work with that here.
             //Four proteoforms, three relations (linear), middle one isn't accepted; should give 2 families
             Lollipop.min_peak_count_ee = 2;
-            ExperimentalProteoform pf3 = new ExperimentalProteoform("E1");
-            ExperimentalProteoform pf4 = new ExperimentalProteoform("E2");
-            ExperimentalProteoform pf5 = new ExperimentalProteoform("E3");
-            ExperimentalProteoform pf6 = new ExperimentalProteoform("E4");
+            ExperimentalProteoform pf3 = ConstructorsForTesting.ExperimentalProteoform("E1");
+            ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("E2");
+            ExperimentalProteoform pf5 = ConstructorsForTesting.ExperimentalProteoform("E3");
+            ExperimentalProteoform pf6 = ConstructorsForTesting.ExperimentalProteoform("E4");
 
             ProteoformComparison comparison34 = ProteoformComparison.ee;
             ProteoformComparison comparison45 = ProteoformComparison.ee;
@@ -157,8 +157,8 @@ namespace Test
         {
             ProteoformCommunity test_community = new ProteoformCommunity();
             Lollipop.proteoform_community = test_community;
-            ExperimentalProteoform pf3 = new ExperimentalProteoform("E1");
-            ExperimentalProteoform pf4 = new ExperimentalProteoform("E2");
+            ExperimentalProteoform pf3 = ConstructorsForTesting.ExperimentalProteoform("E1");
+            ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("E2");
             ProteoformComparison wrong_comparison = ProteoformComparison.ee;
             ProteoformRelation pr2 = new ProteoformRelation(pf3, pf4, wrong_comparison, 0);
             ProteoformRelation pr3 = new ProteoformRelation(pf3, pf4, wrong_comparison, 0);
@@ -172,8 +172,8 @@ namespace Test
         public void artificial_deltaMPeak()
         {
             Lollipop.opening_results = true;
-            ExperimentalProteoform pf3 = new ExperimentalProteoform("E1");
-            ExperimentalProteoform pf4 = new ExperimentalProteoform("E2");
+            ExperimentalProteoform pf3 = ConstructorsForTesting.ExperimentalProteoform("E1");
+            ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("E2");
             ProteoformComparison comparison = ProteoformComparison.ee;
             ProteoformRelation pr2 = new ProteoformRelation(pf3, pf4, comparison, 0);
             ProteoformRelation pr3 = new ProteoformRelation(pf3, pf4, comparison, 0);
@@ -193,13 +193,13 @@ namespace Test
             List<Component> n2 = TestExperimentalProteoform.generate_neucode_components(100);
             List<Component> n3 = TestExperimentalProteoform.generate_neucode_components(200);
             List<Component> n4 = TestExperimentalProteoform.generate_neucode_components(200);
-            ExperimentalProteoform pf1 = new ExperimentalProteoform("E1");
+            ExperimentalProteoform pf1 = ConstructorsForTesting.ExperimentalProteoform("E1");
             pf1.aggregated_components = n1;
-            ExperimentalProteoform pf2 = new ExperimentalProteoform("E2");
+            ExperimentalProteoform pf2 = ConstructorsForTesting.ExperimentalProteoform("E2");
             pf2.aggregated_components = n2;
-            ExperimentalProteoform pf3 = new ExperimentalProteoform("E3");
+            ExperimentalProteoform pf3 = ConstructorsForTesting.ExperimentalProteoform("E3");
             pf3.aggregated_components = n3;
-            ExperimentalProteoform pf4 = new ExperimentalProteoform("E4");
+            ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("E4");
             pf4.aggregated_components = n4;
 
             Lollipop.proteoform_community.experimental_proteoforms = new List<ExperimentalProteoform> { pf1, pf2, pf3, pf4 }.ToArray();
@@ -209,10 +209,10 @@ namespace Test
             ProteoformComparison comparison25 = ProteoformComparison.et;
             ProteoformComparison comparison36 = ProteoformComparison.et;
             ProteoformComparison comparison47 = ProteoformComparison.et;
-            TheoreticalProteoform pf5 = new TheoreticalProteoform("acession1");
-            TheoreticalProteoform pf6 = new TheoreticalProteoform("acession2");
-            TheoreticalProteoform pf7 = new TheoreticalProteoform("acession2");
-            TheoreticalProteoform pf8 = new TheoreticalProteoform("acession2");
+            TheoreticalProteoform pf5 = ConstructorsForTesting.make_a_theoretical();
+            TheoreticalProteoform pf6 = ConstructorsForTesting.make_a_theoretical();
+            TheoreticalProteoform pf7 = ConstructorsForTesting.make_a_theoretical();
+            TheoreticalProteoform pf8 = ConstructorsForTesting.make_a_theoretical();
             ProteoformRelation pr1 = new ProteoformRelation(pf1, pf5, comparison14, 0);
             ProteoformRelation pr2 = new ProteoformRelation(pf2, pf6, comparison25, 0);
             ProteoformRelation pr3 = new ProteoformRelation(pf3, pf7, comparison36, 1);
@@ -258,13 +258,13 @@ namespace Test
             List<Component> n2 = TestExperimentalProteoform.generate_neucode_components(200);
             List<Component> n3 = TestExperimentalProteoform.generate_neucode_components(200);
             List<Component> n4 = TestExperimentalProteoform.generate_neucode_components(200);
-            ExperimentalProteoform pf1 = new ExperimentalProteoform("E1");
+            ExperimentalProteoform pf1 = ConstructorsForTesting.ExperimentalProteoform("E1");
             pf1.aggregated_components = n1;
-            ExperimentalProteoform pf2 = new ExperimentalProteoform("E2");
+            ExperimentalProteoform pf2 = ConstructorsForTesting.ExperimentalProteoform("E2");
             pf2.aggregated_components = n2;
-            ExperimentalProteoform pf3 = new ExperimentalProteoform("E3");
+            ExperimentalProteoform pf3 = ConstructorsForTesting.ExperimentalProteoform("E3");
             pf3.aggregated_components = n3;
-            ExperimentalProteoform pf4 = new ExperimentalProteoform("E4");
+            ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("E4");
             pf4.aggregated_components = n4;
 
             Lollipop.proteoform_community.experimental_proteoforms = new List<ExperimentalProteoform> { pf1, pf2, pf3, pf4 }.ToArray();
@@ -274,10 +274,10 @@ namespace Test
             ProteoformComparison comparison25 = ProteoformComparison.et;
             ProteoformComparison comparison36 = ProteoformComparison.et;
             ProteoformComparison comparison47 = ProteoformComparison.et;
-            TheoreticalProteoform pf5 = new TheoreticalProteoform("acession1");
-            TheoreticalProteoform pf6 = new TheoreticalProteoform("acession2");
-            TheoreticalProteoform pf7 = new TheoreticalProteoform("acession2");
-            TheoreticalProteoform pf8 = new TheoreticalProteoform("acession2");
+            TheoreticalProteoform pf5 = ConstructorsForTesting.make_a_theoretical();
+            TheoreticalProteoform pf6 = ConstructorsForTesting.make_a_theoretical();
+            TheoreticalProteoform pf7 = ConstructorsForTesting.make_a_theoretical();
+            TheoreticalProteoform pf8 = ConstructorsForTesting.make_a_theoretical();
             ProteoformRelation pr1 = new ProteoformRelation(pf1, pf5, comparison14, 0);
             ProteoformRelation pr2 = new ProteoformRelation(pf2, pf6, comparison25, 0);
             ProteoformRelation pr3 = new ProteoformRelation(pf3, pf7, comparison36, 1);

--- a/Test/TestExperimentalProteoform.cs
+++ b/Test/TestExperimentalProteoform.cs
@@ -98,7 +98,7 @@ namespace Test
         {
             Lollipop.neucode_labeled = true;
             List<Component> components = generate_neucode_components(starter_mass);        
-            ExperimentalProteoform e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(2, e.aggregated_components.Count);
             Assert.AreEqual(3, e.lysine_count);
             double expected_agg_intensity = components.Count * starter_intensity;
@@ -114,7 +114,7 @@ namespace Test
         {
             Lollipop.neucode_labeled = false;
             List<Component> components = generate_unlabeled_components(starter_mass);
-            ExperimentalProteoform e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(2, e.aggregated_components.Count);
             double expected_agg_intensity = components.Count * starter_intensity;
             Assert.AreEqual(expected_agg_intensity, e.agg_intensity);
@@ -129,7 +129,7 @@ namespace Test
             //Make a monoisotopic error, and test that it removes it before aggregation
             List<Component> components = generate_neucode_components(starter_mass);
             components[4].weighted_monoisotopic_mass = starter_mass + missed_monoisotopics * Lollipop.MONOISOTOPIC_UNIT_MASS;
-            ExperimentalProteoform e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             double expected_agg_intensity = components.Count * starter_intensity;
             double intensity_normalization_factor = components.Count * starter_intensity / expected_agg_intensity;
             double expected_agg_mass = starter_mass * intensity_normalization_factor;
@@ -141,12 +141,12 @@ namespace Test
         {
             Lollipop.neucode_labeled = true;
             List<Component> components = generate_neucode_components(starter_mass);
-            ExperimentalProteoform e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             components[1].rt_apex = starter_rt - Convert.ToDouble(Lollipop.retention_time_tolerance) - 1;
-            e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(1, e.aggregated_components.Count);
             components[1].rt_apex = starter_rt + Convert.ToDouble(Lollipop.retention_time_tolerance) + 1;
-            e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(1, e.aggregated_components.Count);
         }
 
@@ -155,12 +155,12 @@ namespace Test
         {
             Lollipop.neucode_labeled = true;
             List<Component> components = generate_neucode_components(starter_mass);
-            ExperimentalProteoform e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             ((NeuCodePair)components[1]).lysine_count = starter_lysine_count + Convert.ToInt32(Lollipop.missed_lysines) + 1;
-            e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(1, e.aggregated_components.Count);
             ((NeuCodePair)components[1]).lysine_count = starter_lysine_count - Convert.ToInt32(Lollipop.missed_lysines) - 1;
-            e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(1, e.aggregated_components.Count);
         }
 
@@ -179,11 +179,11 @@ namespace Test
             // in bounds lowest monoisotopic error
             components[1].charge_states.Clear(); // must clear charge states because you can't set the weighted monoisotopic mass if there are charge states.
             components[1].weighted_monoisotopic_mass = min_monoisotopic_mass - min_monoisotopic_mass / 1000000 * Convert.ToDouble(Lollipop.mass_tolerance);
-            ExperimentalProteoform e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(2, e.aggregated_components.Count);
             // in bounds highest monoisotopic error
             components[1].weighted_monoisotopic_mass = max_monoisotopic_mass + max_monoisotopic_mass / 1000000 * Convert.ToDouble(Lollipop.mass_tolerance);
-            e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(2, e.aggregated_components.Count);
         }
 
@@ -198,11 +198,11 @@ namespace Test
             // below lowest monoisotopic tolerance
             components[1].charge_states.Clear(); // must clear charge states because you can't set the weighted monoisotopic mass if there are charge states.
             components[1].weighted_monoisotopic_mass = min_monoisotopic_mass - 100;
-            ExperimentalProteoform e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(1, e.aggregated_components.Count);
             // above highest monoisotopic tolerance
             components[1].weighted_monoisotopic_mass = (max_monoisotopic_mass + 100);
-            e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(1, e.aggregated_components.Count);
         }
 
@@ -218,11 +218,11 @@ namespace Test
             // in bounds lowest monoisotopic error
             components[1].charge_states.Clear(); // must clear charge states because you can't set the weighted monoisotopic mass if there are charge states.
             components[1].weighted_monoisotopic_mass = (min_monoisotopic_mass - min_monoisotopic_mass / 1000000 * Convert.ToDouble(Lollipop.mass_tolerance));
-            ExperimentalProteoform e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(2, e.aggregated_components.Count);
             // in bounds highest monoisotopic error
             components[1].weighted_monoisotopic_mass = (max_monoisotopic_mass + max_monoisotopic_mass / 1000000 * Convert.ToDouble(Lollipop.mass_tolerance));
-            e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(2, e.aggregated_components.Count);
         }
 
@@ -238,11 +238,11 @@ namespace Test
             // below lowest monoisotopic tolerance
             components[1].charge_states.Clear(); // must clear charge states because you can't set the weighted monoisotopic mass if there are charge states.
             components[1].weighted_monoisotopic_mass = (min_monoisotopic_mass - min_monoisotopic_mass / 1000000 * Convert.ToDouble(Lollipop.mass_tolerance) - Double.MinValue);
-            ExperimentalProteoform e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(1, e.aggregated_components.Count);
             // above highest monoisotopic tolerance
             components[1].weighted_monoisotopic_mass = (max_monoisotopic_mass + max_monoisotopic_mass / 1000000 * Convert.ToDouble(Lollipop.mass_tolerance) + Double.MinValue);
-            e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(1, e.aggregated_components.Count);
         }
 
@@ -251,7 +251,7 @@ namespace Test
         {
             List<Component> components = generate_neucode_components(starter_mass);
             components.Remove(components[1]);
-            ExperimentalProteoform e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(1, e.aggregated_components.Count);
             Assert.AreEqual(components[0], e.aggregated_components.First());
         }
@@ -267,11 +267,11 @@ namespace Test
             // in bounds lowest monoisotopic error
             components[1].charge_states.Clear(); // must clear charge states because you can't set the weighted monoisotopic mass if there are charge states.
             components[1].weighted_monoisotopic_mass = min_monoisotopic_mass - min_monoisotopic_mass / 1000000 * Convert.ToDouble(Lollipop.mass_tolerance);
-            ExperimentalProteoform e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             Assert.AreEqual(2, e.aggregated_components.Count);
             // in bounds highest monoisotopic error
             components[1].weighted_monoisotopic_mass = max_monoisotopic_mass + max_monoisotopic_mass / 1000000 * Convert.ToDouble(Lollipop.mass_tolerance);
-            e = new ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
+            e = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, empty_quant_components_list, true);
             ExperimentalProteoform f = new ExperimentalProteoform(e);
             Assert.AreEqual(e.root, f.root);
             Assert.AreEqual(e.agg_intensity, f.agg_intensity);

--- a/Test/TestFindRawComponentsAndNeuCodePairs.cs
+++ b/Test/TestFindRawComponentsAndNeuCodePairs.cs
@@ -29,7 +29,7 @@ namespace Test
             string inFileId = noisy.UniqueId.ToString();
 
             Lollipop.neucode_labeled = true;
-            Lollipop.process_raw_components();
+            Lollipop.process_raw_components(Lollipop.input_files, Purpose.Identification);
             Assert.AreEqual(223, Lollipop.raw_experimental_components.Count);
 
             //Check the validity of one component read from the Excel file

--- a/Test/TestGeneName.cs
+++ b/Test/TestGeneName.cs
@@ -1,0 +1,28 @@
+﻿using NUnit.Framework;
+using System;
+using Proteomics;
+using ProteoformSuiteInternal;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+
+namespace Test
+{
+    [TestFixture]
+    class TestGeneName
+    {
+        [Test]
+        public void test_construct_genename()
+        {
+            Tuple<string, string> gene_name = new Tuple<string, string>("primary", "ABC");
+            Tuple<string, string> ordered_name = new Tuple<string, string>("ordered locus", "ABCD");
+            Tuple<string, string> ordered_name2 = new Tuple<string, string>("ordered locus", "ABCD2");
+            Tuple<string, string> gene_name2 = new Tuple<string, string>("primary", "ABCDE");
+            List<Tuple<string, string>> gene_names = new List<Tuple<string, string>> { gene_name, ordered_name, ordered_name2, gene_name2 };
+
+            GeneName g = new GeneName(gene_names);
+            Assert.AreEqual(gene_name.Item2, g.primary);
+            Assert.AreEqual(ordered_name.Item2, g.ordered_locus);
+        }
+    }
+}

--- a/Test/TestGeneName.cs
+++ b/Test/TestGeneName.cs
@@ -23,6 +23,29 @@ namespace Test
             GeneName g = new GeneName(gene_names);
             Assert.AreEqual(gene_name.Item2, g.primary);
             Assert.AreEqual(ordered_name.Item2, g.ordered_locus);
+
+            //Getting preferred name
+            Assert.AreEqual(gene_name.Item2, g.get_prefered_name(Lollipop.gene_name_labels[0]));
+            Assert.AreEqual(ordered_name.Item2, g.get_prefered_name(Lollipop.gene_name_labels[1]));
+            Assert.AreEqual(gene_name.Item2, g.get_prefered_name(""));
+        }
+
+        [Test]
+        public void test_construct_genename_from_others()
+        {
+            Tuple<string, string> gene_name = new Tuple<string, string>("primary", "ABC");
+            GeneName g = new GeneName(new List<Tuple<string, string>> { gene_name });
+            Tuple<string, string> ordered_name = new Tuple<string, string>("ordered locus", "ABCD");
+            GeneName h = new GeneName(new List<Tuple<string, string>> { ordered_name });
+            Tuple<string, string> ordered_name2 = new Tuple<string, string>("ordered locus", "ABCD2");
+            GeneName i = new GeneName(new List<Tuple<string, string>> { ordered_name2 });
+            Tuple<string, string> gene_name2 = new Tuple<string, string>("primary", "ABCDE");
+            GeneName j = new GeneName(new List<Tuple<string, string>> { gene_name2 });
+            List<GeneName> gene_names = new List<GeneName> { g,h,i,j };
+
+            GeneName k = new GeneName(gene_names);
+            Assert.AreEqual(gene_name.Item2, k.primary);
+            Assert.AreEqual(ordered_name.Item2, k.ordered_locus);
         }
     }
 }

--- a/Test/TestGoTermNumber.cs
+++ b/Test/TestGoTermNumber.cs
@@ -83,17 +83,17 @@ namespace Test
                 { new InputFile("fake.txt", Purpose.ProteinDatabase), new Protein[] { p2 } },
                 { new InputFile("fake.txt", Purpose.ProteinDatabase), new Protein[] { p3 } },
             };
-            ExperimentalProteoform e1 = new ExperimentalProteoform("E");
-            ExperimentalProteoform e2 = new ExperimentalProteoform("E");
+            ExperimentalProteoform e1 = ConstructorsForTesting.ExperimentalProteoform("E");
+            ExperimentalProteoform e2 = ConstructorsForTesting.ExperimentalProteoform("E");
             e1.quant.intensitySum = 1;
             e1.quant.FDR = 0;
             e1.quant.logFoldChange = 1;
             e2.quant.intensitySum = 1;
             e2.quant.FDR = 0;
             e2.quant.logFoldChange = 1;
-            TheoreticalProteoform t = new TheoreticalProteoform("T1_T1_asdf", "", p1, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform u = new TheoreticalProteoform("T2_T1_asdf_asdf", "", p2, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform v = new TheoreticalProteoform("T3_T1_asdf_Asdf_Asdf", "", p3, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
+            TheoreticalProteoform t = ConstructorsForTesting.make_a_theoretical("T1_T1_asdf", p1, dict);
+            TheoreticalProteoform u = ConstructorsForTesting.make_a_theoretical("T2_T1_asdf_asdf", p2, dict);
+            TheoreticalProteoform v = ConstructorsForTesting.make_a_theoretical("T3_T1_asdf_Asdf_Asdf", p3, dict);
             t.proteinList = new List<ProteinWithGoTerms> { p1 };
             u.proteinList = new List<ProteinWithGoTerms> { p2 };
             v.proteinList = new List<ProteinWithGoTerms> { p3 };
@@ -140,17 +140,17 @@ namespace Test
                 { new InputFile("fake.txt", Purpose.ProteinDatabase), new Protein[] { p2 } },
                 { new InputFile("fake.txt", Purpose.ProteinDatabase), new Protein[] { p3 } },
             };
-            ExperimentalProteoform e1 = new ExperimentalProteoform("E");
-            ExperimentalProteoform e2 = new ExperimentalProteoform("E");
+            ExperimentalProteoform e1 = ConstructorsForTesting.ExperimentalProteoform("E");
+            ExperimentalProteoform e2 = ConstructorsForTesting.ExperimentalProteoform("E");
             e1.quant.intensitySum = 1;
             e1.quant.FDR = 0;
             e1.quant.logFoldChange = 1;
             e2.quant.intensitySum = 1;
             e2.quant.FDR = 0;
             e2.quant.logFoldChange = 1;
-            TheoreticalProteoform t = new TheoreticalProteoform("T1_T1_asdf", "", p1, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform u = new TheoreticalProteoform("T2_T1_asdf_asdf", "", p2, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform v = new TheoreticalProteoform("T3_T1_asdf_Asdf_Asdf", "", p3, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
+            TheoreticalProteoform t = ConstructorsForTesting.make_a_theoretical("T1_T1_asdf", p1, dict);
+            TheoreticalProteoform u = ConstructorsForTesting.make_a_theoretical("T2_T1_asdf_asdf", p2, dict);
+            TheoreticalProteoform v = ConstructorsForTesting.make_a_theoretical("T3_T1_asdf_Asdf_Asdf", p3, dict);
             t.proteinList = new List<ProteinWithGoTerms> { p1 };
             u.proteinList = new List<ProteinWithGoTerms> { p2 };
             v.proteinList = new List<ProteinWithGoTerms> { p3 };
@@ -208,17 +208,17 @@ namespace Test
                 { new InputFile("fake.txt", Purpose.ProteinDatabase), new Protein[] { p2 } },
                 { new InputFile("fake.txt", Purpose.ProteinDatabase), new Protein[] { p3 } },
             };
-            ExperimentalProteoform e1 = new ExperimentalProteoform("E");
-            ExperimentalProteoform e2 = new ExperimentalProteoform("E");
+            ExperimentalProteoform e1 = ConstructorsForTesting.ExperimentalProteoform("E");
+            ExperimentalProteoform e2 = ConstructorsForTesting.ExperimentalProteoform("E");
             e1.quant.intensitySum = 1;
             e1.quant.FDR = 0;
             e1.quant.logFoldChange = 1;
             e2.quant.intensitySum = 1;
             e2.quant.FDR = 0;
             e2.quant.logFoldChange = 1;
-            TheoreticalProteoform t = new TheoreticalProteoform("T1_T1_asdf", "", p1, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform u = new TheoreticalProteoform("T2_T1_asdf_asdf", "", p2, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform v = new TheoreticalProteoform("T3_T1_asdf_Asdf_Asdf", "", p3, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
+            TheoreticalProteoform t = ConstructorsForTesting.make_a_theoretical("T1_T1_asdf", p1, dict);
+            TheoreticalProteoform u = ConstructorsForTesting.make_a_theoretical("T2_T1_asdf_asdf", p2, dict);
+            TheoreticalProteoform v = ConstructorsForTesting.make_a_theoretical("T3_T1_asdf_Asdf_Asdf", p3, dict);
             t.proteinList = new List<ProteinWithGoTerms> { p1 };
             u.proteinList = new List<ProteinWithGoTerms> { p2 };
             v.proteinList = new List<ProteinWithGoTerms> { p3 };

--- a/Test/TestProteoformCommunityRelate.cs
+++ b/Test/TestProteoformCommunityRelate.cs
@@ -2,6 +2,8 @@
 using ProteoformSuiteInternal;
 using System.Collections.Generic;
 using System;
+using System.Linq;
+using Proteomics;
 
 namespace Test
 {
@@ -9,6 +11,7 @@ namespace Test
     public class TestProteoformCommunityRelate
     {
         ProteoformCommunity community = new ProteoformCommunity();
+        ProteinWithGoTerms p1 = new ProteinWithGoTerms("MSSSSSSSSSSS", "T1", new List<Tuple<string, string>> { new Tuple<string, string>("", "") }, new Dictionary<int, List<Modification>>(), new int?[] { 0 }, new int?[] { 0 }, new string[] { "" }, "T2", "T3", true, false, new List<DatabaseReference> { new DatabaseReference("GO", ":", new List<Tuple<string, string>> { new Tuple<string, string>("term", "P:") }) }, new List<GoTerm> { new GoTerm(new DatabaseReference("GO", ":", new List<Tuple<string, string>> { new Tuple<string, string>("term", "P:") })) });
 
         [Test]
         public void TestNeuCodeLabeledProteoformCommunityRelate_EE()
@@ -218,7 +221,11 @@ namespace Test
 
             // One experimental one theoretical proteoforms; lysine count equal; mass difference < 500 -- return 1
             ExperimentalProteoform pf1 = new ExperimentalProteoform("A1", 1000.0, 1, true);
-            TheoreticalProteoform pf2 = new TheoreticalProteoform("T1", 1010.0, 1, true);
+            TheoreticalProteoform pf2 = new TheoreticalProteoform("T1");
+            pf2.modified_mass = 1010.0;
+            pf2.lysine_count = 1;
+            pf2.is_target = true;
+            pf2.proteinList = new List<ProteinWithGoTerms> { p1 };
             ExperimentalProteoform[] paE = new ExperimentalProteoform[1];
             TheoreticalProteoform[] paT = new TheoreticalProteoform[1];
             paE[0] = pf1;
@@ -250,7 +257,11 @@ namespace Test
             //Two experimental one theoretical proteoforms; lysine count equal; mass difference < 500 Da -- return 2
             ExperimentalProteoform pf3 = new ExperimentalProteoform("A1", 1000.0, 1, true);
             ExperimentalProteoform pf4 = new ExperimentalProteoform("A2", 1010.0, 1, true);
-            TheoreticalProteoform pf5 = new TheoreticalProteoform("T1", 1020.0, 1, true);
+            TheoreticalProteoform pf5 = new TheoreticalProteoform("T1");
+            pf5.modified_mass = 1020.0;
+            pf5.lysine_count = 1;
+            pf5.is_target = true;
+            pf5.proteinList = new List<ProteinWithGoTerms> { p1 };
             ExperimentalProteoform[] paE2 = new ExperimentalProteoform[2];
             paE2[0] = pf3;
             paE2[1] = pf4;
@@ -306,7 +317,11 @@ namespace Test
 
             // One experimental one theoretical protoeform; mass difference < 500 -- return 1
             ExperimentalProteoform pf1 = new ExperimentalProteoform("A1", 1000.0, -1, true);
-            TheoreticalProteoform pf2 = new TheoreticalProteoform("T1", 1010.0, 1, true);
+            TheoreticalProteoform pf2 = new TheoreticalProteoform("T1");
+            pf2.modified_mass = 1010.0;
+            pf2.lysine_count = 1;
+            pf2.is_target = true;
+            pf2.proteinList = new List<ProteinWithGoTerms> { p1 };
             ExperimentalProteoform[] paE = new ExperimentalProteoform[1];
             TheoreticalProteoform[] paT = new TheoreticalProteoform[1];
             paE[0] = pf1;
@@ -326,7 +341,11 @@ namespace Test
             //Two experimental one theoretical proteoforms; mass difference < 500 Da -- return 2
             ExperimentalProteoform pf3 = new ExperimentalProteoform("A1", 1000.0, -1, true);
             ExperimentalProteoform pf4 = new ExperimentalProteoform("A2", 1010.0, -1, true);
-            TheoreticalProteoform pf5 = new TheoreticalProteoform("T1", 1020.0, 1, true);
+            TheoreticalProteoform pf5 = new TheoreticalProteoform("T1");
+            pf5.modified_mass = 1020.0;
+            pf5.lysine_count = 1;
+            pf5.is_target = true;
+            pf5.proteinList = new List<ProteinWithGoTerms> { p1 };
             ExperimentalProteoform[] paE2 = new ExperimentalProteoform[2];
             paE2[0] = pf3;
             paE2[1] = pf4;
@@ -381,6 +400,7 @@ namespace Test
             // So testProteoformCommunity.experimental_proteoforms must be non-empty
             // And decoy_proteoforms["fake_decoy_proteoform1"] must be non-empty
             testProteoformCommunity.decoy_proteoforms["fake_decoy_proteoform1"] = new TheoreticalProteoform[] { new TheoreticalProteoform("decoyProteoform1") };
+            testProteoformCommunity.decoy_proteoforms["fake_decoy_proteoform1"].First().proteinList = new List<ProteinWithGoTerms> { p1 };
 
             Assert.IsEmpty(testProteoformCommunity.experimental_proteoforms);
             testProteoformCommunity.experimental_proteoforms = new ExperimentalProteoform[] { new ExperimentalProteoform("experimentalProteoform1") };

--- a/Test/TestProteoformCommunityRelate.cs
+++ b/Test/TestProteoformCommunityRelate.cs
@@ -19,8 +19,8 @@ namespace Test
             Lollipop.neucode_labeled = true;
 
             // Two proteoforms; lysine count equal; mass difference < 250 -- return 1
-            ExperimentalProteoform pf1 = new ExperimentalProteoform("A1", 1000.0, 1, true);
-            ExperimentalProteoform pf2 = new ExperimentalProteoform("A2", 1010.0, 1, true);
+            ExperimentalProteoform pf1 = ConstructorsForTesting.ExperimentalProteoform("A1", 1000.0, 1, true);
+            ExperimentalProteoform pf2 = ConstructorsForTesting.ExperimentalProteoform("A2", 1010.0, 1, true);
             ExperimentalProteoform[] pa1 = new ExperimentalProteoform[2];
             pa1[0] = pf1;
             pa1[1] = pf2;
@@ -49,9 +49,9 @@ namespace Test
             Assert.AreEqual(0, prList.Count);
 
             //Three proteoforms; lysine count equal; mass difference < 250 Da -- return 3
-            ExperimentalProteoform pf3 = new ExperimentalProteoform("A1", 1000.0, 1, true);
-            ExperimentalProteoform pf4 = new ExperimentalProteoform("A2", 1010.0, 1, true);
-            ExperimentalProteoform pf5 = new ExperimentalProteoform("A3", 1020.0, 1, true);
+            ExperimentalProteoform pf3 = ConstructorsForTesting.ExperimentalProteoform("A1", 1000.0, 1, true);
+            ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("A2", 1010.0, 1, true);
+            ExperimentalProteoform pf5 = ConstructorsForTesting.ExperimentalProteoform("A3", 1020.0, 1, true);
             ExperimentalProteoform[] pa2 = new ExperimentalProteoform[3];
             pa2[0] = pf3;
             pa2[1] = pf4;
@@ -106,8 +106,8 @@ namespace Test
             Lollipop.neucode_labeled = false;
 
             // Two proteoforms; mass difference < 250 -- return 1
-            ExperimentalProteoform pf1 = new ExperimentalProteoform("A1", 1000.0, -1, true);
-            ExperimentalProteoform pf2 = new ExperimentalProteoform("A2", 1010.0, -1, true);
+            ExperimentalProteoform pf1 = ConstructorsForTesting.ExperimentalProteoform("A1", 1000.0, -1, true);
+            ExperimentalProteoform pf2 = ConstructorsForTesting.ExperimentalProteoform("A2", 1010.0, -1, true);
             ExperimentalProteoform[] pa1 = new ExperimentalProteoform[2];
             pa1[0] = pf1;
             pa1[1] = pf2;
@@ -124,9 +124,9 @@ namespace Test
             Assert.AreEqual(0, prList.Count);
 
             //Three proteoforms; mass difference < 250 Da -- return 3
-            ExperimentalProteoform pf3 = new ExperimentalProteoform("A1", 1000.0, -1, true);
-            ExperimentalProteoform pf4 = new ExperimentalProteoform("A2", 1010.0, -1, true);
-            ExperimentalProteoform pf5 = new ExperimentalProteoform("A3", 1020.0, -1, true);
+            ExperimentalProteoform pf3 = ConstructorsForTesting.ExperimentalProteoform("A1", 1000.0, -1, true);
+            ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("A2", 1010.0, -1, true);
+            ExperimentalProteoform pf5 = ConstructorsForTesting.ExperimentalProteoform("A3", 1020.0, -1, true);
             ExperimentalProteoform[] pa2 = new ExperimentalProteoform[3];
             pa2[0] = pf3;
             pa2[1] = pf4;
@@ -166,10 +166,10 @@ namespace Test
             test_community = new ProteoformCommunity();
             Lollipop.neucode_labeled = true;
             test_community.experimental_proteoforms = new ExperimentalProteoform[] {
-                new ExperimentalProteoform("A1", 1000.0, 1, true),
-                new ExperimentalProteoform("A2", 1000.0, 2, true),
-                new ExperimentalProteoform("A3", 1000.0, 1, true),
-                new ExperimentalProteoform("A4", 1000.0, 2, true)
+                ConstructorsForTesting. ExperimentalProteoform("A1", 1000.0, 1, true),
+                ConstructorsForTesting. ExperimentalProteoform("A2", 1000.0, 2, true),
+                ConstructorsForTesting. ExperimentalProteoform("A3", 1000.0, 1, true),
+                ConstructorsForTesting. ExperimentalProteoform("A4", 1000.0, 2, true)
             };
             unequal_relations = test_community.relate_unequal_ee_lysine_counts();
             Assert.AreNotEqual(test_community.experimental_proteoforms[0], test_community.experimental_proteoforms[2]);
@@ -183,10 +183,10 @@ namespace Test
             //Two equal, two unequal lysine count. But one each has mass_difference > 250, so no relations
             test_community = new ProteoformCommunity();
             test_community.experimental_proteoforms = new ExperimentalProteoform[] {
-                new ExperimentalProteoform("A1", 1000.0, 1, true),
-                new ExperimentalProteoform("A2", 1000.0, 2, true),
-                new ExperimentalProteoform("A3", 2000.0, 1, true),
-                new ExperimentalProteoform("A4", 2000.0, 2, true)
+                ConstructorsForTesting. ExperimentalProteoform("A1", 1000.0, 1, true),
+                ConstructorsForTesting. ExperimentalProteoform("A2", 1000.0, 2, true),
+                ConstructorsForTesting. ExperimentalProteoform("A3", 2000.0, 1, true),
+                ConstructorsForTesting. ExperimentalProteoform("A4", 2000.0, 2, true)
             };
             unequal_relations = test_community.relate_unequal_ee_lysine_counts();
             Assert.AreEqual(0, unequal_relations.Count);
@@ -194,10 +194,10 @@ namespace Test
             //None equal lysine count (apart from itself), four unequal lysine count. Each should create no unequal relations, so no relations total
             test_community = new ProteoformCommunity();
             test_community.experimental_proteoforms = new ExperimentalProteoform[] {
-                new ExperimentalProteoform("A1", 1000.0, 1, true),
-                new ExperimentalProteoform("A2", 1000.0, 2, true),
-                new ExperimentalProteoform("A3", 1000.0, 3, true),
-                new ExperimentalProteoform("A4", 1000.0, 4, true)
+                ConstructorsForTesting. ExperimentalProteoform("A1", 1000.0, 1, true),
+                ConstructorsForTesting. ExperimentalProteoform("A2", 1000.0, 2, true),
+                ConstructorsForTesting. ExperimentalProteoform("A3", 1000.0, 3, true),
+                ConstructorsForTesting. ExperimentalProteoform("A4", 1000.0, 4, true)
             };
             unequal_relations = test_community.relate_unequal_ee_lysine_counts();
             Assert.AreEqual(0, unequal_relations.Count);
@@ -205,10 +205,10 @@ namespace Test
             //All equal, no unequal lysine count because there's an empty list of unequal lysine-count proteoforms. Each should create no unequal relations, so no relations total
             test_community = new ProteoformCommunity();
             test_community.experimental_proteoforms = new ExperimentalProteoform[] {
-                new ExperimentalProteoform("A1", 1000.0, 1, true),
-                new ExperimentalProteoform("A2", 1000.0, 1, true),
-                new ExperimentalProteoform("A3", 1000.0, 1, true),
-                new ExperimentalProteoform("A4", 1000.0, 1, true)  
+                ConstructorsForTesting. ExperimentalProteoform("A1", 1000.0, 1, true),
+                ConstructorsForTesting. ExperimentalProteoform("A2", 1000.0, 1, true),
+                ConstructorsForTesting. ExperimentalProteoform("A3", 1000.0, 1, true),
+                ConstructorsForTesting. ExperimentalProteoform("A4", 1000.0, 1, true)  
             };
             unequal_relations = test_community.relate_unequal_ee_lysine_counts();
             Assert.AreEqual(0, unequal_relations.Count);
@@ -220,8 +220,8 @@ namespace Test
             Lollipop.neucode_labeled = true;
 
             // One experimental one theoretical proteoforms; lysine count equal; mass difference < 500 -- return 1
-            ExperimentalProteoform pf1 = new ExperimentalProteoform("A1", 1000.0, 1, true);
-            TheoreticalProteoform pf2 = new TheoreticalProteoform("T1");
+            ExperimentalProteoform pf1 = ConstructorsForTesting.ExperimentalProteoform("A1", 1000.0, 1, true);
+            TheoreticalProteoform pf2 = ConstructorsForTesting.make_a_theoretical();
             pf2.modified_mass = 1010.0;
             pf2.lysine_count = 1;
             pf2.is_target = true;
@@ -255,9 +255,9 @@ namespace Test
             Assert.AreEqual(0, prList.Count);
 
             //Two experimental one theoretical proteoforms; lysine count equal; mass difference < 500 Da -- return 2
-            ExperimentalProteoform pf3 = new ExperimentalProteoform("A1", 1000.0, 1, true);
-            ExperimentalProteoform pf4 = new ExperimentalProteoform("A2", 1010.0, 1, true);
-            TheoreticalProteoform pf5 = new TheoreticalProteoform("T1");
+            ExperimentalProteoform pf3 = ConstructorsForTesting.ExperimentalProteoform("A1", 1000.0, 1, true);
+            ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("A2", 1010.0, 1, true);
+            TheoreticalProteoform pf5 = ConstructorsForTesting.make_a_theoretical();
             pf5.modified_mass = 1020.0;
             pf5.lysine_count = 1;
             pf5.is_target = true;
@@ -316,8 +316,8 @@ namespace Test
             Lollipop.neucode_labeled = false;
 
             // One experimental one theoretical protoeform; mass difference < 500 -- return 1
-            ExperimentalProteoform pf1 = new ExperimentalProteoform("A1", 1000.0, -1, true);
-            TheoreticalProteoform pf2 = new TheoreticalProteoform("T1");
+            ExperimentalProteoform pf1 = ConstructorsForTesting.ExperimentalProteoform("A1", 1000.0, -1, true);
+            TheoreticalProteoform pf2 = ConstructorsForTesting.make_a_theoretical();
             pf2.modified_mass = 1010.0;
             pf2.lysine_count = 1;
             pf2.is_target = true;
@@ -339,9 +339,9 @@ namespace Test
             Assert.AreEqual(0, prList.Count);
 
             //Two experimental one theoretical proteoforms; mass difference < 500 Da -- return 2
-            ExperimentalProteoform pf3 = new ExperimentalProteoform("A1", 1000.0, -1, true);
-            ExperimentalProteoform pf4 = new ExperimentalProteoform("A2", 1010.0, -1, true);
-            TheoreticalProteoform pf5 = new TheoreticalProteoform("T1");
+            ExperimentalProteoform pf3 = ConstructorsForTesting.ExperimentalProteoform("A1", 1000.0, -1, true);
+            ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("A2", 1010.0, -1, true);
+            TheoreticalProteoform pf5 = ConstructorsForTesting.make_a_theoretical();
             pf5.modified_mass = 1020.0;
             pf5.lysine_count = 1;
             pf5.is_target = true;
@@ -399,11 +399,11 @@ namespace Test
             // it must take as arguments non-empty pfs1 and pfs2
             // So testProteoformCommunity.experimental_proteoforms must be non-empty
             // And decoy_proteoforms["fake_decoy_proteoform1"] must be non-empty
-            testProteoformCommunity.decoy_proteoforms["fake_decoy_proteoform1"] = new TheoreticalProteoform[] { new TheoreticalProteoform("decoyProteoform1") };
+            testProteoformCommunity.decoy_proteoforms["fake_decoy_proteoform1"] = new TheoreticalProteoform[] { ConstructorsForTesting.make_a_theoretical("decoyProteoform1", 0, -1) };
             testProteoformCommunity.decoy_proteoforms["fake_decoy_proteoform1"].First().proteinList = new List<ProteinWithGoTerms> { p1 };
 
             Assert.IsEmpty(testProteoformCommunity.experimental_proteoforms);
-            testProteoformCommunity.experimental_proteoforms = new ExperimentalProteoform[] { new ExperimentalProteoform("experimentalProteoform1") };
+            testProteoformCommunity.experimental_proteoforms = new ExperimentalProteoform[] { ConstructorsForTesting.ExperimentalProteoform("experimentalProteoform1") };
 
             edDictionary = testProteoformCommunity.relate_ed();
             // Make sure there is one relation total, because only a single decoy was provided
@@ -412,9 +412,7 @@ namespace Test
             // Make sure there is one relation for the provided fake_decoy_proteoform1
             Assert.AreEqual(1, edDictionary["fake_decoy_proteoform1"].Count);
 
-
             ProteoformRelation rel = edDictionary["fake_decoy_proteoform1"][0];
-
 
             Assert.IsFalse(rel.accepted);
             Assert.AreEqual("decoyProteoform1", rel.connected_proteoforms[1].accession);
@@ -423,12 +421,12 @@ namespace Test
             Assert.AreEqual(0, rel.agg_RT_1);
             Assert.AreEqual(0, rel.agg_RT_2);
             Assert.AreEqual(0, rel.delta_mass);
-            Assert.IsNull(rel.fragment);
+            Assert.IsEmpty(rel.fragment);
             Assert.AreEqual(1, rel.nearby_relations_count);  //shows that calculate_unadjusted_group_count works
             //Assert.AreEqual(1, rel.mass_difference_group.Count);  //I don't think we need this test anymore w/ way peaks are made -LVS
             Assert.AreEqual(-1, rel.lysine_count);
-            Assert.IsNull(rel.name);
-            Assert.AreEqual(1, rel.num_observations_1);
+            Assert.AreEqual("T2", rel.name);
+            Assert.AreEqual(0, rel.num_observations_1); //nothing aggregated with the basic constructor
             Assert.AreEqual(0, rel.num_observations_2);
             Assert.IsTrue(rel.outside_no_mans_land);
             Assert.IsNull(rel.peak);
@@ -445,10 +443,10 @@ namespace Test
             community.theoretical_proteoforms = new TheoreticalProteoform[] { };
             Assert.False(community.has_e_proteoforms);
             Assert.False(community.has_e_and_t_proteoforms);
-            community.experimental_proteoforms = new ExperimentalProteoform[] { new ExperimentalProteoform("E1") };
+            community.experimental_proteoforms = new ExperimentalProteoform[] { ConstructorsForTesting.ExperimentalProteoform("E1") };
             Assert.True(community.has_e_proteoforms);
             Assert.False(community.has_e_and_t_proteoforms);
-            community.theoretical_proteoforms = new TheoreticalProteoform[] { new TheoreticalProteoform("T1") };
+            community.theoretical_proteoforms = new TheoreticalProteoform[] { ConstructorsForTesting.make_a_theoretical() };
             Assert.True(community.has_e_proteoforms);
             Assert.True(community.has_e_and_t_proteoforms);
         }

--- a/Test/TestProteoformFamilies.cs
+++ b/Test/TestProteoformFamilies.cs
@@ -275,6 +275,7 @@ namespace Test
             Assert.AreEqual(3, community.families.FirstOrDefault(f => f.proteoforms.Select(p => p.accession).Contains("E6")).proteoforms.Count);
             Assert.AreEqual(3, community.families.FirstOrDefault(f => f.proteoforms.Select(p => p.accession).Contains("E1")).experimental_count);
             Assert.AreEqual(2, community.families.FirstOrDefault(f => f.proteoforms.Select(p => p.accession).Contains("E1")).theoretical_count);
+            Assert.AreEqual("", community.families.FirstOrDefault(f => f.proteoforms.Select(p => p.accession).Contains("E1")).gene_list); //both would give null preferred gene names, since that field isn't set up
             Assert.True(String.Join("", community.families.Select(f => f.experimentals_list)).Contains("E1"));
             Assert.True(String.Join("", community.families.Select(f => f.name_list)).Contains(p1_name));
             Assert.True(String.Join("", community.families.Select(f => f.accession_list)).Contains(pf1_accession));

--- a/Test/TestProteoformFamilies.cs
+++ b/Test/TestProteoformFamilies.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using ProteoformSuiteInternal;
 using Proteomics;

--- a/Test/TestProteoformFamilies.cs
+++ b/Test/TestProteoformFamilies.cs
@@ -20,8 +20,8 @@ namespace Test
 
             //One accepted ET relation; should give one ProteoformFamily
             Lollipop.min_peak_count_et = 1;
-            ExperimentalProteoform pf1 = new ExperimentalProteoform("E1");
-            TheoreticalProteoform pf2 = new TheoreticalProteoform("T1");
+            ExperimentalProteoform pf1 = ConstructorsForTesting.ExperimentalProteoform("E1");
+            TheoreticalProteoform pf2 = ConstructorsForTesting.make_a_theoretical();
             pf2.name = "T1";
             ProteoformComparison comparison = ProteoformComparison.et;
             ProteoformRelation pr1 = new ProteoformRelation(pf1, pf2, comparison, 0);
@@ -51,18 +51,18 @@ namespace Test
             Lollipop.uniprotModificationTable = new Dictionary<string, IList<Modification>> { { "unmodified", new List<Modification> { new Modification("unmodified") } } };
 
             Lollipop.min_peak_count_ee = 2;
-            ExperimentalProteoform pf3 = new ExperimentalProteoform("E1");
-            ExperimentalProteoform pf4 = new ExperimentalProteoform("E2");
-            ExperimentalProteoform pf5 = new ExperimentalProteoform("E3");
-            ExperimentalProteoform pf6 = new ExperimentalProteoform("E4");
+            ExperimentalProteoform pf3 = ConstructorsForTesting.ExperimentalProteoform("E1");
+            ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("E2");
+            ExperimentalProteoform pf5 = ConstructorsForTesting.ExperimentalProteoform("E3");
+            ExperimentalProteoform pf6 = ConstructorsForTesting.ExperimentalProteoform("E4");
             test_community.experimental_proteoforms = new ExperimentalProteoform[] { pf3, pf4, pf5, pf6 };
 
             ProteoformComparison comparison34 = ProteoformComparison.ee;
             ProteoformComparison comparison45 = ProteoformComparison.ee;
             ProteoformComparison comparison56 = ProteoformComparison.ee;
-            make_relation(pf3, pf4, comparison34, 0);
-            make_relation(pf4, pf5, comparison45, 0);
-            make_relation(pf5, pf6, comparison56, 0);
+            ConstructorsForTesting.make_relation(pf3, pf4, comparison34, 0);
+            ConstructorsForTesting.make_relation(pf4, pf5, comparison45, 0);
+            ConstructorsForTesting.make_relation(pf5, pf6, comparison56, 0);
 
             List<ProteoformRelation> prs2 = new HashSet<ProteoformRelation>(test_community.experimental_proteoforms.SelectMany(p => p.relationships).Concat(test_community.theoretical_proteoforms.SelectMany(p => p.relationships))).OrderBy(r => r.delta_mass).ToList();
             foreach (ProteoformRelation pr in prs2) pr.set_nearby_group(prs2, prs2.Select(r => r.instanceId).ToList());
@@ -96,11 +96,11 @@ namespace Test
             Lollipop.peak_width_base_ee = 0.015;
             Lollipop.min_peak_count_ee = 3; //needs to be high so that 0 peak accepted, other peak isn't.... 
 
-            ExperimentalProteoform pf3 = new ExperimentalProteoform("E1");
-            ExperimentalProteoform pf4 = new ExperimentalProteoform("E2");
-            ExperimentalProteoform pf5 = new ExperimentalProteoform("E3");
-            ExperimentalProteoform pf6 = new ExperimentalProteoform("E4");
-            ExperimentalProteoform pf7 = new ExperimentalProteoform("E5");
+            ExperimentalProteoform pf3 = ConstructorsForTesting.ExperimentalProteoform("E1");
+            ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("E2");
+            ExperimentalProteoform pf5 = ConstructorsForTesting.ExperimentalProteoform("E3");
+            ExperimentalProteoform pf6 = ConstructorsForTesting.ExperimentalProteoform("E4");
+            ExperimentalProteoform pf7 = ConstructorsForTesting.ExperimentalProteoform("E5");
 
             ProteoformComparison comparison34 = ProteoformComparison.ee;
             ProteoformComparison comparison45 = ProteoformComparison.ee;
@@ -147,12 +147,13 @@ namespace Test
             Dictionary<InputFile, Protein[]> dict = new Dictionary<InputFile, Protein[]> {
                 { f, new Protein[] { p1 } }
             };
-            TheoreticalProteoform t = new TheoreticalProteoform("T1_asdf", "", p1, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
+            TheoreticalProteoform t = ConstructorsForTesting.make_a_theoretical("T1_T1_asdf", p1, dict);
+            
 
             //One accepted ET relation; should give one ProteoformFamily
             Lollipop.min_peak_count_et = 1;
-            ExperimentalProteoform pf1 = new ExperimentalProteoform("E1");
-            TheoreticalProteoformGroup pf2 = new TheoreticalProteoformGroup(new List<TheoreticalProteoform> { t }, false, new Dictionary<InputFile, Protein[]> { { f, new Protein[] { p1 } } });
+            ExperimentalProteoform pf1 = ConstructorsForTesting.ExperimentalProteoform("E1");
+            TheoreticalProteoformGroup pf2 = new TheoreticalProteoformGroup(new List<TheoreticalProteoform> { t });
             ProteoformComparison comparison = ProteoformComparison.et;
             ProteoformRelation pr1 = new ProteoformRelation(pf1, pf2, comparison, 0);
             List<ProteoformRelation> prs = new List<ProteoformRelation> { pr1 };
@@ -170,13 +171,7 @@ namespace Test
             Assert.AreEqual(p1.Name, test_community.families.First().name_list);
             Assert.AreEqual(pf2.accession, test_community.families.First().accession_list);
         }
-
-        public static void make_relation(Proteoform p1, Proteoform p2, ProteoformComparison c, double delta_mass)
-        {
-            ProteoformRelation pp = new ProteoformRelation(p1, p2, c, delta_mass);
-            p1.relationships.Add(pp);
-            p2.relationships.Add(pp);
-        }
+        
 
         public static string p1_accession = "T1";
         public static string p1_name = "name";
@@ -200,25 +195,25 @@ namespace Test
             InputFile f = new InputFile("fake.txt", Purpose.ProteinDatabase);
             ProteinWithGoTerms p1 = new ProteinWithGoTerms("", p1_accession, new List<Tuple<string, string>> { new Tuple<string, string>("", "") }, new Dictionary<int, List<Modification>>(), new int?[] { 0 }, new int?[] { 0 }, new string[] { "" }, p1_name, p1_fullName, true, false, new List<DatabaseReference> { p1_dbRef }, new List<GoTerm> { p1_goterm });
             Dictionary<InputFile, Protein[]> dict = new Dictionary<InputFile, Protein[]> { { f, new Protein[] { p1 } } };
-            TheoreticalProteoform t = new TheoreticalProteoform("T1_asdf", "T1_asdf", p1, true, 0, 0, new PtmSet(new List<Ptm>()), 1234.56, true, true, dict);
-            TheoreticalProteoformGroup pf1 = new TheoreticalProteoformGroup(new List<TheoreticalProteoform> { t }, false, new Dictionary<InputFile, Protein[]> { { f, new Protein[] { p1 } } });
+            TheoreticalProteoform t = ConstructorsForTesting.make_a_theoretical("T1_asdf", "T1_asdf", 1234.56, p1, dict);
+            TheoreticalProteoformGroup pf1 = new TheoreticalProteoformGroup(new List<TheoreticalProteoform> { t });
 
             //TheoreticalProteoform with an oxidation, but the same accession as the former
             ModificationMotif motif;
             ModificationMotif.TryGetMotif("K", out motif);
             string mod_title = "oxidation"; //fake; I'm giving it 0 mass difference, but it still differentiates the two
             ModificationWithMass m = new ModificationWithMass(mod_title, new Tuple<string, string>("", mod_title), motif, ModificationSites.K, 1, new Dictionary<string, IList<string>>(), -1, new List<double>(), new List<double>(), "");
-            TheoreticalProteoform pf2 = new TheoreticalProteoform("T1_asdf", "T1_asdf_1", p1, true, 0, 0, new PtmSet(new List<Ptm> { new Ptm(0, m) }), 1234.56, true, true, dict);
+            TheoreticalProteoform pf2 = ConstructorsForTesting.make_a_theoretical("T1_asdf", "T1_asdf_1", 1234.56, p1, dict);
 
             community.theoretical_proteoforms = new TheoreticalProteoform[] { pf1, pf2 };
 
             //ExperimentalProteoforms
-            ExperimentalProteoform pf3 = new ExperimentalProteoform("E1", 0, 0, true);
-            ExperimentalProteoform pf4 = new ExperimentalProteoform("E2", 0, 0, true);
-            ExperimentalProteoform pf5 = new ExperimentalProteoform("E3", 0, 0, true);
-            ExperimentalProteoform pf6 = new ExperimentalProteoform("E4", 0, 0, true);
-            ExperimentalProteoform pf7 = new ExperimentalProteoform("E5", 0, 0, true);
-            ExperimentalProteoform pf8 = new ExperimentalProteoform("E6", 0, 0, true);
+            ExperimentalProteoform pf3 = ConstructorsForTesting.ExperimentalProteoform("E1", 0, 0, true);
+            ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("E2", 0, 0, true);
+            ExperimentalProteoform pf5 = ConstructorsForTesting.ExperimentalProteoform("E3", 0, 0, true);
+            ExperimentalProteoform pf6 = ConstructorsForTesting.ExperimentalProteoform("E4", 0, 0, true);
+            ExperimentalProteoform pf7 = ConstructorsForTesting.ExperimentalProteoform("E5", 0, 0, true);
+            ExperimentalProteoform pf8 = ConstructorsForTesting.ExperimentalProteoform("E6", 0, 0, true);
             community.experimental_proteoforms = new ExperimentalProteoform[] { pf3, pf4, pf5, pf6, pf7, pf8 };
             pf3.agg_mass = 1234.56;
             pf4.agg_mass = 1234.56;
@@ -234,13 +229,13 @@ namespace Test
             ProteoformComparison comparison56 = ProteoformComparison.ee;
             ProteoformComparison comparison67 = ProteoformComparison.ee;
             ProteoformComparison comparison78 = ProteoformComparison.ee;
-            make_relation(pf3, pf1, comparison13, 0);
-            make_relation(pf3, pf2, comparison23, 0);
-            make_relation(pf3, pf4, comparison34, 0);
-            make_relation(pf4, pf5, comparison45, 0);
-            make_relation(pf5, pf6, comparison56, 19); //not accepted
-            make_relation(pf6, pf7, comparison67, 0);
-            make_relation(pf7, pf8, comparison78, 0);
+            ConstructorsForTesting.make_relation(pf3, pf1, comparison13, 0);
+            ConstructorsForTesting.make_relation(pf3, pf2, comparison23, 0);
+            ConstructorsForTesting.make_relation(pf3, pf4, comparison34, 0);
+            ConstructorsForTesting.make_relation(pf4, pf5, comparison45, 0);
+            ConstructorsForTesting.make_relation(pf5, pf6, comparison56, 19); //not accepted
+            ConstructorsForTesting.make_relation(pf6, pf7, comparison67, 0);
+            ConstructorsForTesting.make_relation(pf7, pf8, comparison78, 0);
 
             List<ProteoformRelation> prs = new HashSet<ProteoformRelation>(community.experimental_proteoforms.SelectMany(p => p.relationships).Concat(community.theoretical_proteoforms.SelectMany(p => p.relationships))).ToList();
             List<ProteoformRelation> prs_et = prs.Where(r => r.relation_type == ProteoformComparison.et).OrderBy(r => r.delta_mass).ToList();

--- a/Test/TestQuantification.cs
+++ b/Test/TestQuantification.cs
@@ -97,7 +97,7 @@ namespace Test
             List<Component> quant_components_list = generate_neucode_quantitative_components(proteoformMass, 99d, 51d, 1, lysineCount);//these are for quantification
             quant_components_list.AddRange(generate_neucode_quantitative_components(proteoformMass, 101d, 54d, 2, lysineCount));//these are for quantification
             List<Component> components = generate_neucode_components(proteoformMass, intensity, intensity/2d, lysineCount); // these are for indentification
-            ExperimentalProteoform e1 = new ExperimentalProteoform("E1", components[0], components, quant_components_list, true);
+            ExperimentalProteoform e1 = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, quant_components_list, true);
             Assert.AreEqual(2, e1.light_observation_count);
             Assert.AreEqual(2, e1.heavy_observation_count);
 
@@ -138,7 +138,7 @@ namespace Test
             List<Component> components = generate_neucode_components(proteoformMass, intensity, intensity / 2d, lysineCount); // these are for indentification
             quant_components_list.AddRange(generate_neucode_quantitative_components(proteoformMass, 50d, 100d, 3, lysineCount));//these are for quantification
             quant_components_list.AddRange(generate_neucode_quantitative_components(proteoformMass, 48d, 102d, 4, lysineCount));//these are for quantification
-            ExperimentalProteoform e2 = new ExperimentalProteoform("E2", components[0], components, quant_components_list, true);
+            ExperimentalProteoform e2 = ConstructorsForTesting.ExperimentalProteoform("E2", components[0], components, quant_components_list, true);
             Assert.AreEqual(4, e2.light_observation_count);
             Assert.AreEqual(4, e2.heavy_observation_count);
 
@@ -173,7 +173,7 @@ namespace Test
         [Test]
         public void proteinLevelStDev_divide_by_zero_crash()
         {
-            ExperimentalProteoform e = new ExperimentalProteoform("E");
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E");
             List<BiorepIntensity> singleton_list = new List<BiorepIntensity> { new BiorepIntensity(false, false, 1, "", 0) };
             Assert.True(e.quant.getProteinLevelStdDev(singleton_list, singleton_list) > 0);
         }
@@ -181,7 +181,7 @@ namespace Test
         [Test]
         public void quant_variance_without_imputation_aka_unequal_list_lengths()
         {
-            ExperimentalProteoform e = new ExperimentalProteoform("E");
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E");
             List<BiorepIntensity> singleton_list = new List<BiorepIntensity> { new BiorepIntensity(false, false, 1, "", 0) };
             List<BiorepIntensity> shorter_list = new List<BiorepIntensity>();
             try
@@ -197,7 +197,7 @@ namespace Test
         [Test]
         public void quant_permuations_without_imputation_aka_unequal_list_lengths()
         {
-            ExperimentalProteoform e = new ExperimentalProteoform("E");
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E");
             List<BiorepIntensity> singleton_list = new List<BiorepIntensity> { new BiorepIntensity(false, false, 1, "", 0) };
             List<BiorepIntensity> shorter_list = new List<BiorepIntensity>();
             try
@@ -213,7 +213,7 @@ namespace Test
         [Test]
         public void quant_pvalue_without_imputation_aka_unequal_list_lengths()
         {
-            ExperimentalProteoform e = new ExperimentalProteoform("E");
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E");
             List<BiorepIntensity> singleton_list = new List<BiorepIntensity> { new BiorepIntensity(false, false, 1, "", 0) };
             List<BiorepIntensity> shorter_list = new List<BiorepIntensity>();
             try
@@ -239,8 +239,8 @@ namespace Test
             List<Component> components = generate_neucode_components(proteoformMass, intensity, intensity / 2d, lysineCount); // these are for indentification
             Lollipop.input_files = quant_components_list.Select(c => c.input_file).Distinct().ToList();
             Lollipop.getObservationParameters(true, Lollipop.input_files);
-            ExperimentalProteoform e1 = new ExperimentalProteoform("E1", components[0], components, quant_components_list, true);
-            ExperimentalProteoform e2 = new ExperimentalProteoform("E2", components[0], components, quant_components_list.Concat(generate_neucode_quantitative_components(proteoformMass, 50d, 100d, 3, lysineCount)).ToList(), true);
+            ExperimentalProteoform e1 = ConstructorsForTesting.ExperimentalProteoform("E1", components[0], components, quant_components_list, true);
+            ExperimentalProteoform e2 = ConstructorsForTesting.ExperimentalProteoform("E2", components[0], components, quant_components_list.Concat(generate_neucode_quantitative_components(proteoformMass, 50d, 100d, 3, lysineCount)).ToList(), true);
             Lollipop.computeBiorepIntensities(new List<ExperimentalProteoform> { e1, e2 }, Lollipop.ltConditionsBioReps.Keys, Lollipop.hvConditionsBioReps.Keys);
             Assert.True(e1.biorepIntensityList.Count > 0);
             Assert.True(e2.biorepIntensityList.Count > 0);
@@ -354,7 +354,7 @@ namespace Test
                 db.Add(new DummyBiorepable(new InputFile("path", Labeling.NeuCode, Purpose.Quantification, "light", "heavy", 1),1d));
             }
 
-            List<BiorepIntensity> bril = new ExperimentalProteoform("E").make_biorepIntensityList(db,db,lightConditions,heavyConditions);
+            List<BiorepIntensity> bril = ConstructorsForTesting.ExperimentalProteoform("E").make_biorepIntensityList(db,db,lightConditions,heavyConditions);
 
             Assert.AreEqual(2, bril.Count());
 
@@ -363,13 +363,13 @@ namespace Test
                 db.Add(new DummyBiorepable(new InputFile("path", Labeling.NeuCode, Purpose.Quantification, "light", "heavy", 2), 2d));
             }
 
-            bril = new ExperimentalProteoform("E").make_biorepIntensityList(db, db, lightConditions, heavyConditions);
+            bril = ConstructorsForTesting.ExperimentalProteoform("E").make_biorepIntensityList(db, db, lightConditions, heavyConditions);
 
             Assert.AreEqual(4, bril.Count());
 
             Lollipop.neucode_labeled = false;
 
-            bril = new ExperimentalProteoform("E").make_biorepIntensityList(db, db, lightConditions, heavyConditions);
+            bril = ConstructorsForTesting.ExperimentalProteoform("E").make_biorepIntensityList(db, db, lightConditions, heavyConditions);
 
             Assert.AreEqual(2, bril.Count());
 
@@ -382,7 +382,7 @@ namespace Test
 
             for (int i = 0; i < 10; i++)
             {
-                ExperimentalProteoform e = new ExperimentalProteoform("E");
+                ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E");
                 List<decimal> onepst = new List<decimal>();
                 for (int j = 0; j < 10; j++)
                 {
@@ -410,7 +410,7 @@ namespace Test
 
             for (int i = 0; i < 10; i++)
             {
-                ExperimentalProteoform e = new ExperimentalProteoform("E");
+                ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E");
                 List<decimal> onepst = new List<decimal>();
                 for (int j = 0; j < 10; j++)
                 {
@@ -506,7 +506,7 @@ namespace Test
         public void test_gaussian_area_calculation()
         {
             SortedDictionary<decimal, int> histogram = new SortedDictionary<decimal, int>();
-            ExperimentalProteoform e = new ExperimentalProteoform("E");
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E");
             
             //Each biorepIntensity has a unique combination of light/heavy + condition + biorep, since that's how they're made in the program
             e.biorepIntensityList.AddRange(from i in Enumerable.Range(1, 3) select new BiorepIntensity(true, false, i, "first", 0));
@@ -540,7 +540,7 @@ namespace Test
         public void all_intensity_distribution_avgIntensity_and_stdv_calculations()
         {
             SortedDictionary<decimal, int> histogram = new SortedDictionary<decimal, int>();
-            ExperimentalProteoform e = new ExperimentalProteoform("E");
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E");
 
             //Each biorepIntensity has a unique combination of light/heavy + condition + biorep, since that's how they're made in the program
             e.biorepIntensityList.AddRange(from i in Enumerable.Range(1, 3) select new BiorepIntensity(true, false, i, "first", 0));
@@ -604,7 +604,7 @@ namespace Test
 
             List<string> conditions = new List<string> { "s", "ns" };
             BiorepIntensity b1 = new BiorepIntensity(false, false, 1, conditions[0], 0);
-            List<ExperimentalProteoform> exps = new List<ExperimentalProteoform> { new ExperimentalProteoform("E") };
+            List<ExperimentalProteoform> exps = new List<ExperimentalProteoform> { ConstructorsForTesting.ExperimentalProteoform("E") };
             exps[0].biorepIntensityList.Add(b1);
             List<ExperimentalProteoform> exps_out = new List<ExperimentalProteoform>();
 
@@ -787,16 +787,6 @@ namespace Test
             satisfactoryProteoformsCount++;
         }
 
-        public void make_relation(Proteoform p1, Proteoform p2)
-        {
-            ProteoformRelation pp = new ProteoformRelation(p1, p2, ProteoformComparison.ee, 0);
-            DeltaMassPeak ppp = new DeltaMassPeak(pp, new List<ProteoformRelation> { pp });
-            pp.peak = ppp;
-            ppp.peak_accepted = true;
-            p1.relationships.Add(pp);
-            p2.relationships.Add(pp);
-        }
-
         [Test]
         public void test_get_observed_proteins()
         {
@@ -808,10 +798,10 @@ namespace Test
                 { new InputFile("fake.txt", Purpose.ProteinDatabase), new Protein[] { p2 } },
                 { new InputFile("fake.txt", Purpose.ProteinDatabase), new Protein[] { p3 } },
             };
-            TheoreticalProteoform t = new TheoreticalProteoform("T1_T1_asdf", "", p1, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform u = new TheoreticalProteoform("T2_T1_asdf_asdf", "", p2, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform v = new TheoreticalProteoform("T3_T1_asdf_Asdf_Asdf", "", p3, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            ExperimentalProteoform e = new ExperimentalProteoform("E1");
+            TheoreticalProteoform t = ConstructorsForTesting.make_a_theoretical("T1_T1_asdf", p1, dict);
+            TheoreticalProteoform u = ConstructorsForTesting.make_a_theoretical("T2_T1_asdf_asdf", p2, dict);
+            TheoreticalProteoform v = ConstructorsForTesting.make_a_theoretical("T3_T1_asdf_Asdf_Asdf", p3, dict);
+            ExperimentalProteoform e = ConstructorsForTesting.ExperimentalProteoform("E1");
             ProteoformRelation et = new ProteoformRelation(e, t, ProteoformComparison.et, 0);
             DeltaMassPeak etp = new DeltaMassPeak(et, new List<ProteoformRelation> { et });
             et.peak = etp;
@@ -847,19 +837,19 @@ namespace Test
                 { new InputFile("fake.txt", Purpose.ProteinDatabase), new Protein[] { p2 } },
                 { new InputFile("fake.txt", Purpose.ProteinDatabase), new Protein[] { p3 } },
             };
-            TheoreticalProteoform t = new TheoreticalProteoform("T1_T1_asdf", "", p1, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform u = new TheoreticalProteoform("T2_T1_asdf_asdf", "", p2, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform v = new TheoreticalProteoform("T3_T1_asdf_Asdf_Asdf", "", p3, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            ExperimentalProteoform ex = new ExperimentalProteoform("E1");
-            ExperimentalProteoform fx = new ExperimentalProteoform("E1");
-            ExperimentalProteoform gx = new ExperimentalProteoform("E1");
-            ExperimentalProteoform hx = new ExperimentalProteoform("E1");
-            make_relation(ex, t);
-            make_relation(ex, u);
-            //make_relation(ex, v);
-            make_relation(ex, fx);
-            make_relation(ex, gx);
-            make_relation(ex, hx);
+            TheoreticalProteoform t = ConstructorsForTesting.make_a_theoretical("T1_T1_asdf", p1, dict);
+            TheoreticalProteoform u = ConstructorsForTesting.make_a_theoretical("T2_T1_asdf_asdf", p2, dict);
+            TheoreticalProteoform v = ConstructorsForTesting.make_a_theoretical("T3_T1_asdf_Asdf_Asdf", p3, dict);
+            ExperimentalProteoform ex = ConstructorsForTesting.ExperimentalProteoform("E1");
+            ExperimentalProteoform fx = ConstructorsForTesting.ExperimentalProteoform("E1");
+            ExperimentalProteoform gx = ConstructorsForTesting.ExperimentalProteoform("E1");
+            ExperimentalProteoform hx = ConstructorsForTesting.ExperimentalProteoform("E1");
+            ConstructorsForTesting.make_relation(ex, t);
+            ConstructorsForTesting.make_relation(ex, u);
+            //ConstructorsForTesting.make_relation(ex, v);
+            ConstructorsForTesting.make_relation(ex, fx);
+            ConstructorsForTesting.make_relation(ex, gx);
+            ConstructorsForTesting.make_relation(ex, hx);
             ProteoformFamily f = new ProteoformFamily(ex);
             f.construct_family();
             ex.family = f;
@@ -915,10 +905,10 @@ namespace Test
         [Test]
         public void get_interesting_pfs()
         {
-            ExperimentalProteoform ex = new ExperimentalProteoform("E1");
-            ExperimentalProteoform fx = new ExperimentalProteoform("E2");
-            ExperimentalProteoform gx = new ExperimentalProteoform("E3");
-            ExperimentalProteoform hx = new ExperimentalProteoform("E4");
+            ExperimentalProteoform ex = ConstructorsForTesting.ExperimentalProteoform("E1");
+            ExperimentalProteoform fx = ConstructorsForTesting.ExperimentalProteoform("E2");
+            ExperimentalProteoform gx = ConstructorsForTesting.ExperimentalProteoform("E3");
+            ExperimentalProteoform hx = ConstructorsForTesting.ExperimentalProteoform("E4");
             ex.quant.logFoldChange = 12;
             ex.quant.FDR = 0.4m;
             ex.quant.intensitySum = 2;
@@ -941,13 +931,13 @@ namespace Test
                 { new InputFile("fake.txt", Purpose.ProteinDatabase), new Protein[] { p2 } },
                 { new InputFile("fake.txt", Purpose.ProteinDatabase), new Protein[] { p3 } },
             };
-            TheoreticalProteoform t = new TheoreticalProteoform("T1_T1_asdf", "", p1, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform u = new TheoreticalProteoform("T2_T1_asdf_asdf", "", p2, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform v = new TheoreticalProteoform("T3_T1_asdf_Asdf_Asdf", "", p3, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            ExperimentalProteoform ex = new ExperimentalProteoform("E1");
-            ExperimentalProteoform fx = new ExperimentalProteoform("E2");
-            ExperimentalProteoform gx = new ExperimentalProteoform("E3");
-            ExperimentalProteoform hx = new ExperimentalProteoform("E4");
+            TheoreticalProteoform t = ConstructorsForTesting.make_a_theoretical("T1_T1_asdf", p1, dict);
+            TheoreticalProteoform u = ConstructorsForTesting.make_a_theoretical("T2_T1_asdf_asdf", p2, dict);
+            TheoreticalProteoform v = ConstructorsForTesting.make_a_theoretical("T3_T1_asdf_Asdf_Asdf", p3, dict);
+            ExperimentalProteoform ex = ConstructorsForTesting.ExperimentalProteoform("E1");
+            ExperimentalProteoform fx = ConstructorsForTesting.ExperimentalProteoform("E2");
+            ExperimentalProteoform gx = ConstructorsForTesting.ExperimentalProteoform("E3");
+            ExperimentalProteoform hx = ConstructorsForTesting.ExperimentalProteoform("E4");
             ex.quant.logFoldChange = 12;
             ex.quant.FDR = 0.4m;
             ex.quant.intensitySum = 2;
@@ -955,10 +945,10 @@ namespace Test
             fx.quant.FDR = 0.4m;
             fx.quant.intensitySum = 2;
             List<ExperimentalProteoform> exps = new List<ExperimentalProteoform> { ex, fx, gx, hx };
-            make_relation(gx, v);
-            make_relation(fx, v);
-            make_relation(hx, t);
-            make_relation(hx, u);        
+            ConstructorsForTesting.make_relation(gx, v);
+            ConstructorsForTesting.make_relation(fx, v);
+            ConstructorsForTesting.make_relation(hx, t);
+            ConstructorsForTesting.make_relation(hx, u);        
             ProteoformFamily e = new ProteoformFamily(ex);
             ProteoformFamily f = new ProteoformFamily(v);
             ProteoformFamily h = new ProteoformFamily(hx);

--- a/Test/TestQuantification.cs
+++ b/Test/TestQuantification.cs
@@ -351,7 +351,7 @@ namespace Test
             List<DummyBiorepable> db = new List<DummyBiorepable>();
             for (int i = 0; i < 6; i++)
             {
-                db.Add(new DummyBiorepable(new InputFile("path", Labeling.NeuCode, Purpose.Quantification, "light", "heavy", 1),1d));
+                db.Add(new DummyBiorepable(ConstructorsForTesting.InputFile("path.txt", Labeling.NeuCode, Purpose.Quantification, "light", "heavy", 1, -1, -1), 1d));
             }
 
             List<BiorepIntensity> bril = ConstructorsForTesting.ExperimentalProteoform("E").make_biorepIntensityList(db,db,lightConditions,heavyConditions);
@@ -360,7 +360,7 @@ namespace Test
 
             for (int i = 0; i < 6; i++)
             {
-                db.Add(new DummyBiorepable(new InputFile("path", Labeling.NeuCode, Purpose.Quantification, "light", "heavy", 2), 2d));
+                db.Add(new DummyBiorepable(ConstructorsForTesting.InputFile("path.txt", Labeling.NeuCode, Purpose.Quantification, "light", "heavy", 2, -1, -1), 2d));
             }
 
             bril = ConstructorsForTesting.ExperimentalProteoform("E").make_biorepIntensityList(db, db, lightConditions, heavyConditions);

--- a/Test/TestTheoreticalCreation.cs
+++ b/Test/TestTheoreticalCreation.cs
@@ -29,7 +29,7 @@ namespace Test
             ProteinWithGoTerms p1 = new ProteinWithGoTerms("MSSSSSSSSSSS", "T1", new List<Tuple<string, string>> { new Tuple<string, string>("", "") }, new Dictionary<int, List<Modification>>(), new int?[] { 0 }, new int?[] { 0 }, new string[] { "" }, "T2", "T3", true, false, new List<DatabaseReference> { d1 }, new List<GoTerm> { g1 });
             ProteinWithGoTerms p2 = new ProteinWithGoTerms("MSSSSSSSSSSS", "T2", new List<Tuple<string, string>> { new Tuple<string, string>("", "") }, new Dictionary<int, List<Modification>>(), new int?[] { 0 }, new int?[] { 0 }, new string[] { "" }, "T2", "T3", true, false, new List<DatabaseReference> { d2 }, new List<GoTerm> { g2 });
             ProteinWithGoTerms p3 = new ProteinWithGoTerms("MCSSSSSSSSSS", "T3", new List<Tuple<string, string>> { new Tuple<string, string>("", "") }, new Dictionary<int, List<Modification>>(), new int?[] { 0 }, new int?[] { 0 }, new string[] { "" }, "T2", "T3", true, false, new List<DatabaseReference> { d3 }, new List<GoTerm> { g3 });
-            ProteinSequenceGroup psg = new ProteinSequenceGroup(new List<ProteinWithGoTerms> { p1, p2, p3 });
+            ProteinSequenceGroup psg = new ProteinSequenceGroup(new List<ProteinWithGoTerms> { p1, p2, p3 }.OrderByDescending(p => p.IsContaminant ? 1 : 0));
             Assert.AreEqual(3, psg.GoTerms.Count());
             Assert.AreEqual(3, psg.GeneNames.Count());
             Assert.AreEqual("T1_3G", psg.Accession);
@@ -49,12 +49,12 @@ namespace Test
             ProteinWithGoTerms p1 = new ProteinWithGoTerms("MSSSSSSSSSSS", "T1", new List<Tuple<string, string>> { new Tuple<string, string>("", "") }, new Dictionary<int, List<Modification>>(), new int?[] { 0 }, new int?[] { 0 }, new string[] { "" }, "T2", "T3", true, false, new List<DatabaseReference> { d1 }, new List<GoTerm> { g1 });
             ProteinWithGoTerms p2 = new ProteinWithGoTerms("MSSSSSSSSSSS", "T2", new List<Tuple<string, string>> { new Tuple<string, string>("", "") }, new Dictionary<int, List<Modification>>(), new int?[] { 0 }, new int?[] { 0 }, new string[] { "" }, "T2", "T3", true, false, new List<DatabaseReference> { d2 }, new List<GoTerm> { g2 });
             ProteinWithGoTerms p3 = new ProteinWithGoTerms("MCSSSSSSSSSS", "T3", new List<Tuple<string, string>> { new Tuple<string, string>("", "") }, new Dictionary<int, List<Modification>>(), new int?[] { 0 }, new int?[] { 0 }, new string[] { "" }, "T2", "T3", true, true, new List<DatabaseReference> { d3 }, new List<GoTerm> { g3 });
-            ProteinSequenceGroup psg = new ProteinSequenceGroup(new List<ProteinWithGoTerms> { p1, p2, p3 });
+            ProteinSequenceGroup psg = new ProteinSequenceGroup(new List<ProteinWithGoTerms> { p1, p2, p3 }.OrderByDescending(p => p.IsContaminant ? 1 : 0));
             Assert.AreEqual(3, psg.GoTerms.Count());
             Assert.AreEqual(3, psg.GeneNames.Count());
             Assert.AreEqual("T3_3G", psg.Accession);
             Assert.True(psg.IsContaminant);
-            Assert.AreEqual("MSSSSSSSSSSS", psg.BaseSequence);
+            Assert.AreEqual("MCSSSSSSSSSS", psg.BaseSequence);
         }
     }
 }

--- a/Test/TestTheoreticalCreation.cs
+++ b/Test/TestTheoreticalCreation.cs
@@ -32,7 +32,7 @@ namespace Test
             ProteinSequenceGroup psg = new ProteinSequenceGroup(new List<ProteinWithGoTerms> { p1, p2, p3 });
             Assert.AreEqual(3, psg.GoTerms.Count());
             Assert.AreEqual(3, psg.GeneNames.Count());
-            Assert.AreEqual("T1_G3", psg.Accession);
+            Assert.AreEqual("T1_3G", psg.Accession);
             Assert.False(psg.IsContaminant);
             Assert.AreEqual("MSSSSSSSSSSS", psg.BaseSequence);
         }
@@ -52,7 +52,7 @@ namespace Test
             ProteinSequenceGroup psg = new ProteinSequenceGroup(new List<ProteinWithGoTerms> { p1, p2, p3 });
             Assert.AreEqual(3, psg.GoTerms.Count());
             Assert.AreEqual(3, psg.GeneNames.Count());
-            Assert.AreEqual("T3_G3", psg.Accession);
+            Assert.AreEqual("T3_3G", psg.Accession);
             Assert.True(psg.IsContaminant);
             Assert.AreEqual("MSSSSSSSSSSS", psg.BaseSequence);
         }

--- a/Test/TestTheoreticalDatabaseCreate.cs
+++ b/Test/TestTheoreticalDatabaseCreate.cs
@@ -11,13 +11,6 @@ namespace Test
     [TestFixture]
     public class TestTheoreticalDatabaseCreate
     {
-
-        [OneTimeSetUp]
-        public void setup()
-        {
-            Environment.CurrentDirectory = TestContext.CurrentContext.TestDirectory;
-        }
-
         [Test]
         public void test_contaminant_check()
         {
@@ -33,15 +26,15 @@ namespace Test
                 { g, new Protein[] { p2 } },
                 { h, new Protein[] { p3 } },
             };
-            TheoreticalProteoform t = new TheoreticalProteoform("T1_asdf", "", p1, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform u = new TheoreticalProteoform("T2_asdf_asdf", "", p2, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform v = new TheoreticalProteoform("T3_asdf_Asdf_Asdf", "", p3, true, 0, 0, new PtmSet(new List<Ptm>()), 0, true, true, dict);
-            TheoreticalProteoform w = new TheoreticalProteoformGroup(new List<TheoreticalProteoform> { v, u, t }, true, dict);
+            TheoreticalProteoform t = ConstructorsForTesting.make_a_theoretical("T1_T1_asdf", p1, dict);
+            TheoreticalProteoform u = ConstructorsForTesting.make_a_theoretical("T2_T1_asdf_asdf", p2, dict);
+            TheoreticalProteoform v = ConstructorsForTesting.make_a_theoretical("T3_T1_asdf_Asdf_Asdf", p3, dict);
+            TheoreticalProteoform w = new TheoreticalProteoformGroup(new List<TheoreticalProteoform> { v, u, t }.OrderByDescending(theo => theo.contaminant ? 1 : 0));
             Assert.True(w.contaminant);
             Assert.True(w.accession.Contains(p1.Accession));
 
             //Not contaminant
-            TheoreticalProteoform x = new TheoreticalProteoformGroup(new List<TheoreticalProteoform> { v, u }, true, dict);
+            TheoreticalProteoform x = new TheoreticalProteoformGroup(new List<TheoreticalProteoform> { v, u });
             Assert.False(x.contaminant);
 
             //PTM mass test


### PR DESCRIPTION
* Also, fixed non-unique theoretical accessions
* The changes to the accessions change the results of ET relations slightly, but I checked and it appears to be accurate and okay. These results are very sensitive to the use of accessions in ProteoformCommunity around line 35.
* Addresses https://github.com/smith-chem-wisc/proteoform-suite/issues/317
* Addresses https://github.com/smith-chem-wisc/proteoform-suite/issues/231