### PR TITLE
decoy proteoform communities

### DIFF
--- a/ProteoformSuiteGUI/AggregatedProteoforms.cs
+++ b/ProteoformSuiteGUI/AggregatedProteoforms.cs
@@ -40,7 +40,7 @@ namespace ProteoformSuiteGUI
 
         private void updateFiguresOfMerit()
         {
-            tb_totalAggregatedProteoforms.Text = SaveState.lollipop.proteoform_community.experimental_proteoforms.Count(p => p.accepted).ToString();
+            tb_totalAggregatedProteoforms.Text = SaveState.lollipop.target_proteoform_community.experimental_proteoforms.Count(p => p.accepted).ToString();
         }
 
         private void nUP_mass_tolerance_ValueChanged(object sender, EventArgs e)
@@ -68,7 +68,7 @@ namespace ProteoformSuiteGUI
             {
                 RunTheGamut();
             }
-            else if (SaveState.lollipop.proteoform_community.experimental_proteoforms.Length <= 0)
+            else if (SaveState.lollipop.target_proteoform_community.experimental_proteoforms.Length <= 0)
             {
                 MessageBox.Show("Go back and load in deconvolution results.");
             }
@@ -92,8 +92,8 @@ namespace ProteoformSuiteGUI
         private void tb_tableFilter_TextChanged(object sender, EventArgs e)
         {
             IEnumerable<object> selected_aggregates = tb_tableFilter.Text == "" ?
-                SaveState.lollipop.proteoform_community.experimental_proteoforms :
-                ExtensionMethods.filter(SaveState.lollipop.proteoform_community.experimental_proteoforms, tb_tableFilter.Text);
+                SaveState.lollipop.target_proteoform_community.experimental_proteoforms :
+                ExtensionMethods.filter(SaveState.lollipop.target_proteoform_community.experimental_proteoforms, tb_tableFilter.Text);
 
             DisplayUtility.FillDataGridView(dgv_AggregatedProteoforms, selected_aggregates.OfType<ExperimentalProteoform>().Select(ep => new DisplayExperimentalProteoform(ep)));
             DisplayExperimentalProteoform.FormatAggregatesTable(dgv_AggregatedProteoforms);
@@ -110,7 +110,7 @@ namespace ProteoformSuiteGUI
 
         public bool ReadyToRunTheGamut()
         {
-            return SaveState.lollipop.proteoform_community.experimental_proteoforms.Length <= 0
+            return SaveState.lollipop.target_proteoform_community.experimental_proteoforms.Length <= 0
                 && (SaveState.lollipop.neucode_labeled && SaveState.lollipop.raw_neucode_pairs.Count > 0 || SaveState.lollipop.raw_experimental_components.Count > 0);
         }
 
@@ -120,7 +120,7 @@ namespace ProteoformSuiteGUI
             ClearListsTablesFigures();
             SaveState.lollipop.aggregate_proteoforms(SaveState.lollipop.validate_proteoforms, SaveState.lollipop.raw_neucode_pairs, SaveState.lollipop.raw_experimental_components, SaveState.lollipop.raw_quantification_components, SaveState.lollipop.min_num_CS);
             FillTablesAndCharts();
-            if (SaveState.lollipop.neucode_labeled && SaveState.lollipop.proteoform_community.theoretical_proteoforms.Length > 0)
+            if (SaveState.lollipop.neucode_labeled && SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Length > 0)
             {
                 ((ProteoformSweet)MdiParent).experimentalTheoreticalComparison.RunTheGamut();
                 ((ProteoformSweet)MdiParent).experimentExperimentComparison.RunTheGamut();
@@ -138,7 +138,7 @@ namespace ProteoformSuiteGUI
 
         public void FillTablesAndCharts()
         {
-            DisplayUtility.FillDataGridView(dgv_AggregatedProteoforms, SaveState.lollipop.proteoform_community.experimental_proteoforms.Select(e => new DisplayExperimentalProteoform(e)));
+            DisplayUtility.FillDataGridView(dgv_AggregatedProteoforms, SaveState.lollipop.target_proteoform_community.experimental_proteoforms.Select(e => new DisplayExperimentalProteoform(e)));
             DisplayExperimentalProteoform.FormatAggregatesTable(dgv_AggregatedProteoforms);
         }
 

--- a/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentExperimentComparison.cs
@@ -46,13 +46,7 @@ namespace ProteoformSuiteGUI
         {
             Cursor = Cursors.WaitCursor;
             SaveState.lollipop.ee_relations = SaveState.lollipop.target_proteoform_community.relate(SaveState.lollipop.target_proteoform_community.experimental_proteoforms, SaveState.lollipop.target_proteoform_community.experimental_proteoforms, ProteoformComparison.ExperimentalExperimental, true);
-            for(int i = 0; i < SaveState.lollipop.decoy_databases; i++)
-            {
-                string key = "Decoy_Proteoform_Community_" + i;
-                SaveState.lollipop.ef_relations.Add(key, SaveState.lollipop.decoy_proteoform_communities[key].relate_ef(SaveState.lollipop.decoy_proteoform_communities[key].experimental_proteoforms, SaveState.lollipop.decoy_proteoform_communities[key].experimental_proteoforms));
-                if (i == 0) ProteoformCommunity.count_nearby_relations(SaveState.lollipop.ef_relations[key]); //count from first decoy database (for histogram)
-            }
-
+            SaveState.lollipop.relate_ef();
             SaveState.lollipop.ee_peaks = SaveState.lollipop.target_proteoform_community.accept_deltaMass_peaks(SaveState.lollipop.ee_relations, SaveState.lollipop.ef_relations);
             ((ProteoformSweet)MdiParent).proteoformFamilies.ClearListsTablesFigures();
             ((ProteoformSweet)MdiParent).quantification.ClearListsTablesFigures();
@@ -65,7 +59,7 @@ namespace ProteoformSuiteGUI
 
             if (SaveState.lollipop.neucode_labeled)
             {
-                ((ProteoformSweet)MdiParent).proteoformFamilies.fill_proteoform_families("");
+                ((ProteoformSweet)MdiParent).proteoformFamilies.fill_proteoform_families("", -1);
                 ((ProteoformSweet)MdiParent).proteoformFamilies.update_figures_of_merit();
             }
 

--- a/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
+++ b/ProteoformSuiteGUI/ExperimentTheoreticalComparison.cs
@@ -46,12 +46,7 @@ namespace ProteoformSuiteGUI
         {
             Cursor = Cursors.WaitCursor;
             SaveState.lollipop.et_relations = SaveState.lollipop.target_proteoform_community.relate(SaveState.lollipop.target_proteoform_community.experimental_proteoforms, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms, ProteoformComparison.ExperimentalTheoretical, true);
-            for (int i = 0; i < SaveState.lollipop.decoy_databases; i++)
-            {
-                string key = "Decoy_Proteoform_Community_" + i;
-                SaveState.lollipop.ed_relations.Add(key, SaveState.lollipop.decoy_proteoform_communities[key].relate(SaveState.lollipop.decoy_proteoform_communities[key].experimental_proteoforms, SaveState.lollipop.decoy_proteoform_communities[key].theoretical_proteoforms, ProteoformComparison.ExperimentalDecoy, true));
-                if (i == 0) ProteoformCommunity.count_nearby_relations(SaveState.lollipop.ed_relations[key]); //count from first decoy database (for histogram)
-            }
+            SaveState.lollipop.relate_ed();
             SaveState.lollipop.et_peaks = SaveState.lollipop.target_proteoform_community.accept_deltaMass_peaks(SaveState.lollipop.et_relations, SaveState.lollipop.ed_relations);
             ((ProteoformSweet)MdiParent).proteoformFamilies.ClearListsTablesFigures();
             FillTablesAndCharts();

--- a/ProteoformSuiteGUI/ProteoformFamilies.Designer.cs
+++ b/ProteoformSuiteGUI/ProteoformFamilies.Designer.cs
@@ -82,6 +82,10 @@
             this.label8 = new System.Windows.Forms.Label();
             this.label7 = new System.Windows.Forms.Label();
             this.Families_update = new System.Windows.Forms.Button();
+            this.tb_identified_experimentals = new System.Windows.Forms.TextBox();
+            this.tb_identified_decoys = new System.Windows.Forms.TextBox();
+            this.label5 = new System.Windows.Forms.Label();
+            this.label13 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -332,6 +336,10 @@
             // 
             // splitContainer3.Panel2
             // 
+            this.splitContainer3.Panel2.Controls.Add(this.label13);
+            this.splitContainer3.Panel2.Controls.Add(this.label5);
+            this.splitContainer3.Panel2.Controls.Add(this.tb_identified_decoys);
+            this.splitContainer3.Panel2.Controls.Add(this.tb_identified_experimentals);
             this.splitContainer3.Panel2.Controls.Add(this.groupBox2);
             this.splitContainer3.Panel2.Controls.Add(this.cb_geneCentric);
             this.splitContainer3.Panel2.Controls.Add(this.btn_inclusion_list_all_families);
@@ -709,6 +717,48 @@
             this.Families_update.UseVisualStyleBackColor = true;
             this.Families_update.Click += new System.EventHandler(this.Families_update_Click);
             // 
+            // tb_identified_experimentals
+            // 
+            this.tb_identified_experimentals.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.tb_identified_experimentals.Location = new System.Drawing.Point(286, 345);
+            this.tb_identified_experimentals.Margin = new System.Windows.Forms.Padding(2);
+            this.tb_identified_experimentals.Name = "tb_identified_experimentals";
+            this.tb_identified_experimentals.ReadOnly = true;
+            this.tb_identified_experimentals.Size = new System.Drawing.Size(86, 20);
+            this.tb_identified_experimentals.TabIndex = 63;
+            // 
+            // tb_identified_decoys
+            // 
+            this.tb_identified_decoys.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.tb_identified_decoys.Location = new System.Drawing.Point(286, 369);
+            this.tb_identified_decoys.Margin = new System.Windows.Forms.Padding(2);
+            this.tb_identified_decoys.Name = "tb_identified_decoys";
+            this.tb_identified_decoys.ReadOnly = true;
+            this.tb_identified_decoys.Size = new System.Drawing.Size(86, 20);
+            this.tb_identified_decoys.TabIndex = 64;
+            // 
+            // label5
+            // 
+            this.label5.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(376, 348);
+            this.label5.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(118, 13);
+            this.label5.TabIndex = 65;
+            this.label5.Text = "Identified Experimentals";
+            // 
+            // label13
+            // 
+            this.label13.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.label13.AutoSize = true;
+            this.label13.Location = new System.Drawing.Point(374, 372);
+            this.label13.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.label13.Name = "label13";
+            this.label13.Size = new System.Drawing.Size(89, 13);
+            this.label13.TabIndex = 66;
+            this.label13.Text = "Identified Decoys";
+            // 
             // ProteoformFamilies
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -801,5 +851,9 @@
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.TextBox tb_likelyCleavages;
         private System.Windows.Forms.Label label12;
+        private System.Windows.Forms.Label label13;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.TextBox tb_identified_decoys;
+        private System.Windows.Forms.TextBox tb_identified_experimentals;
     }
 }

--- a/ProteoformSuiteGUI/ProteoformFamilies.cs
+++ b/ProteoformSuiteGUI/ProteoformFamilies.cs
@@ -75,14 +75,14 @@ namespace ProteoformSuiteGUI
 
         public bool ReadyToRunTheGamut()
         {
-            return SaveState.lollipop.proteoform_community.families.Count <= 0 && SaveState.lollipop.proteoform_community.has_e_proteoforms;
+            return SaveState.lollipop.target_proteoform_community.families.Count <= 0 && SaveState.lollipop.target_proteoform_community.has_e_proteoforms;
         }
 
         public void RunTheGamut()
         {
             Cursor = Cursors.WaitCursor;
-            SaveState.lollipop.proteoform_community.clear_families();
-            SaveState.lollipop.proteoform_community.construct_families();
+            SaveState.lollipop.clear_families();
+            SaveState.lollipop.construct_families();
             fill_proteoform_families("");
             update_figures_of_merit();
             Cursor = Cursors.Default;
@@ -96,7 +96,7 @@ namespace ProteoformSuiteGUI
 
         public void ClearListsTablesFigures()
         {
-            SaveState.lollipop.proteoform_community.clear_families();
+            SaveState.lollipop.clear_families();
             dgv_main.DataSource = null;
             dgv_main.Rows.Clear();
             dgv_proteoform_family_members.DataSource = null;
@@ -105,9 +105,11 @@ namespace ProteoformSuiteGUI
 
         public void update_figures_of_merit()
         {
-            tb_TotalFamilies.Text = SaveState.lollipop.proteoform_community.families.Count(f => f.proteoforms.Count > 1).ToString();
-            tb_IdentifiedFamilies.Text = SaveState.lollipop.proteoform_community.families.Count(f => f.theoretical_proteoforms.Count > 0).ToString();
-            tb_singleton_count.Text = SaveState.lollipop.proteoform_community.families.Count(f => f.proteoforms.Count == 1).ToString();
+            tb_TotalFamilies.Text = SaveState.lollipop.target_proteoform_community.families.Count(f => f.proteoforms.Count > 1).ToString();
+            tb_IdentifiedFamilies.Text = SaveState.lollipop.target_proteoform_community.families.Count(f => f.theoretical_proteoforms.Count > 0).ToString();
+            tb_singleton_count.Text = SaveState.lollipop.target_proteoform_community.families.Count(f => f.proteoforms.Count == 1).ToString();
+            tb_identified_experimentals.Text = SaveState.lollipop.target_proteoform_community.families.Where(f => f.gene_names.Select(g => g.ordered_locus).Distinct().Count() == 1).Sum(f => f.experimental_proteoforms.Count).ToString();
+            tb_identified_decoys.Text = SaveState.lollipop.decoy_proteoform_communities.Values.Average(d => d.families.Where(f => f.gene_names.Select(g => g.ordered_locus).Distinct().Count() == 1).Sum(f => f.experimental_proteoforms.Count)).ToString();
         }
 
         #endregion Public Methods
@@ -152,8 +154,8 @@ namespace ProteoformSuiteGUI
         public void fill_proteoform_families(string filter)
         {
             IEnumerable<object> families = filter == "" ?
-                SaveState.lollipop.proteoform_community.families.OrderByDescending(f => f.relations.Count) :
-                ExtensionMethods.filter(SaveState.lollipop.proteoform_community.families.OrderByDescending(f => f.relations.Count), filter);
+                SaveState.lollipop.target_proteoform_community.families.OrderByDescending(f => f.relations.Count) :
+                ExtensionMethods.filter(SaveState.lollipop.target_proteoform_community.families.OrderByDescending(f => f.relations.Count), filter);
             DisplayUtility.FillDataGridView(dgv_main, families.OfType<ProteoformFamily>().Select(f => new DisplayProteoformFamily(f)));
             DisplayProteoformFamily.format_families_dgv(dgv_main);
         }
@@ -161,8 +163,8 @@ namespace ProteoformSuiteGUI
         private void fill_theoreticals(string filter)
         {
             IEnumerable<object> theoreticals = filter == "" ?
-                SaveState.lollipop.proteoform_community.families.SelectMany(f => f.theoretical_proteoforms) :
-                ExtensionMethods.filter(SaveState.lollipop.proteoform_community.families.SelectMany(f => f.theoretical_proteoforms), filter);
+                SaveState.lollipop.target_proteoform_community.families.SelectMany(f => f.theoretical_proteoforms) :
+                ExtensionMethods.filter(SaveState.lollipop.target_proteoform_community.families.SelectMany(f => f.theoretical_proteoforms), filter);
             DisplayUtility.FillDataGridView(dgv_main, theoreticals.OfType<TheoreticalProteoform>().Select(t => new DisplayTheoreticalProteoform(t)));
             DisplayTheoreticalProteoform.FormatTheoreticalProteoformTable(dgv_main);
         }
@@ -170,8 +172,8 @@ namespace ProteoformSuiteGUI
         private void fill_go(Aspect aspect, string filter)
         {
             DisplayUtility.FillDataGridView(dgv_main, filter == "" ?
-                SaveState.lollipop.proteoform_community.families.SelectMany(f => f.theoretical_proteoforms).SelectMany(t => t.ExpandedProteinList).SelectMany(g => g.GoTerms).Where(g => g.Aspect == aspect) :
-                ExtensionMethods.filter(SaveState.lollipop.proteoform_community.families.SelectMany(f => f.theoretical_proteoforms).SelectMany(t => t.ExpandedProteinList).SelectMany(g => g.GoTerms).Where(g => g.Aspect == aspect), filter));
+                SaveState.lollipop.target_proteoform_community.families.SelectMany(f => f.theoretical_proteoforms).SelectMany(t => t.ExpandedProteinList).SelectMany(g => g.GoTerms).Where(g => g.Aspect == aspect) :
+                ExtensionMethods.filter(SaveState.lollipop.target_proteoform_community.families.SelectMany(f => f.theoretical_proteoforms).SelectMany(t => t.ExpandedProteinList).SelectMany(g => g.GoTerms).Where(g => g.Aspect == aspect), filter));
         }
 
         private void dgv_proteoform_families_CellContentClick(object sender, DataGridViewCellEventArgs e)
@@ -266,7 +268,7 @@ namespace ProteoformSuiteGUI
         {
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
-            string message = CytoscapeScript.write_cytoscape_script(SaveState.lollipop.proteoform_community.families, SaveState.lollipop.proteoform_community.families,
+            string message = CytoscapeScript.write_cytoscape_script(SaveState.lollipop.target_proteoform_community.families, SaveState.lollipop.target_proteoform_community.families,
                 SaveState.lollipop.family_build_folder_path, "", time_stamp,
                 cb_buildAsQuantitative.Checked, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked,
                 cmbx_colorScheme.SelectedItem.ToString(), cmbx_edgeLabel.SelectedItem.ToString(), cmbx_nodeLabel.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), SaveState.lollipop.deltaM_edge_display_rounding,
@@ -279,7 +281,7 @@ namespace ProteoformSuiteGUI
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
             object[] selected = DisplayUtility.get_selected_objects(dgv_main);
-            string message = CytoscapeScript.write_cytoscape_script(selected, SaveState.lollipop.proteoform_community.families,
+            string message = CytoscapeScript.write_cytoscape_script(selected, SaveState.lollipop.target_proteoform_community.families,
                 SaveState.lollipop.family_build_folder_path, "", time_stamp,
                 cb_buildAsQuantitative.Checked, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked,
                 cmbx_colorScheme.SelectedItem.ToString(), cmbx_edgeLabel.SelectedItem.ToString(), cmbx_nodeLabel.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), SaveState.lollipop.deltaM_edge_display_rounding,
@@ -317,9 +319,9 @@ namespace ProteoformSuiteGUI
         private void btn_inclusion_list_all_families_Click(object sender, EventArgs e)
         {
             List<ExperimentalProteoform> proteoforms = new List<ExperimentalProteoform>();
-            if (cb_identified_families.Checked) proteoforms.AddRange(SaveState.lollipop.proteoform_community.families.Where(f => f.relations.Count > 0 && f.theoretical_proteoforms.Count > 0).SelectMany(f => f.experimental_proteoforms).ToList());
-            if (cb_unidentified_families.Checked) proteoforms.AddRange(SaveState.lollipop.proteoform_community.families.Where(f => f.relations.Count > 0 && f.theoretical_proteoforms.Count == 0).SelectMany(f => f.experimental_proteoforms).ToList());
-            if (cb_orphans.Checked) proteoforms.AddRange(SaveState.lollipop.proteoform_community.families.Where(f => f.relations.Count == 0).SelectMany(f => f.experimental_proteoforms).ToList());
+            if (cb_identified_families.Checked) proteoforms.AddRange(SaveState.lollipop.target_proteoform_community.families.Where(f => f.relations.Count > 0 && f.theoretical_proteoforms.Count > 0).SelectMany(f => f.experimental_proteoforms).ToList());
+            if (cb_unidentified_families.Checked) proteoforms.AddRange(SaveState.lollipop.target_proteoform_community.families.Where(f => f.relations.Count > 0 && f.theoretical_proteoforms.Count == 0).SelectMany(f => f.experimental_proteoforms).ToList());
+            if (cb_orphans.Checked) proteoforms.AddRange(SaveState.lollipop.target_proteoform_community.families.Where(f => f.relations.Count == 0).SelectMany(f => f.experimental_proteoforms).ToList());
             write_inclusion_list(proteoforms);
         }
 

--- a/ProteoformSuiteGUI/ProteoformFamilies.cs
+++ b/ProteoformSuiteGUI/ProteoformFamilies.cs
@@ -82,7 +82,7 @@ namespace ProteoformSuiteGUI
         {
             Cursor = Cursors.WaitCursor;
             SaveState.lollipop.clear_families();
-            SaveState.lollipop.construct_families();
+            SaveState.lollipop.construct_target_and_decoy_families();
             cmbx_tableSelector.SelectedIndex = 0;
             tb_tableFilter.Text = "";
             fill_proteoform_families("", -1);
@@ -173,10 +173,10 @@ namespace ProteoformSuiteGUI
             IEnumerable<object> families = filter == "" ?
                  ( decoyCommunityMinusOneIsTarget < 0 ? 
                 SaveState.lollipop.target_proteoform_community.families.OrderByDescending(f => f.relations.Count) :
-                SaveState.lollipop.decoy_proteoform_communities["Decoy_Proteoform_Community_" + decoyCommunityMinusOneIsTarget].families.OrderByDescending(f => f.relations.Count)) :
+                SaveState.lollipop.decoy_proteoform_communities[SaveState.lollipop.decoy_community_name_prefix + decoyCommunityMinusOneIsTarget].families.OrderByDescending(f => f.relations.Count)) :
                 ( decoyCommunityMinusOneIsTarget < 0 ?
                 ExtensionMethods.filter(SaveState.lollipop.target_proteoform_community.families.OrderByDescending(f => f.relations.Count), filter)
-                : ExtensionMethods.filter(SaveState.lollipop.decoy_proteoform_communities["Decoy_Proteoform_Community_" + decoyCommunityMinusOneIsTarget].families.OrderByDescending(f => f.relations.Count), filter));
+                : ExtensionMethods.filter(SaveState.lollipop.decoy_proteoform_communities[SaveState.lollipop.decoy_community_name_prefix + decoyCommunityMinusOneIsTarget].families.OrderByDescending(f => f.relations.Count), filter));
             DisplayUtility.FillDataGridView(dgv_main, families.OfType<ProteoformFamily>().Select(f => new DisplayProteoformFamily(f)));
             DisplayProteoformFamily.format_families_dgv(dgv_main);
         }

--- a/ProteoformSuiteGUI/ProteoformSweet.cs
+++ b/ProteoformSuiteGUI/ProteoformSweet.cs
@@ -126,7 +126,7 @@ namespace ProteoformSuiteGUI
         {
             showForm(aggregatedProteoforms);
             if (run_when_form_loads && aggregatedProteoforms.ReadyToRunTheGamut()) aggregatedProteoforms.RunTheGamut();
-            else if (!aggregatedProteoforms.ReadyToRunTheGamut() && SaveState.lollipop.proteoform_community.experimental_proteoforms.Length <= 0) MessageBox.Show("Go back and load in deconvolution results.");
+            else if (!aggregatedProteoforms.ReadyToRunTheGamut() && SaveState.lollipop.target_proteoform_community.experimental_proteoforms.Length <= 0) MessageBox.Show("Go back and load in deconvolution results.");
         }
 
         private void theoreticalProteoformDatabaseToolStripMenuItem_Click(object sender, EventArgs e)
@@ -139,7 +139,7 @@ namespace ProteoformSuiteGUI
         {
             showForm(experimentalTheoreticalComparison);
             if (run_when_form_loads && experimentalTheoreticalComparison.ReadyToRunTheGamut()) experimentalTheoreticalComparison.RunTheGamut();
-            else if (!experimentalTheoreticalComparison.ReadyToRunTheGamut() && SaveState.lollipop.et_relations.Count == 0 && SaveState.lollipop.proteoform_community.has_e_proteoforms) MessageBox.Show("Go back and create a theoretical database.");
+            else if (!experimentalTheoreticalComparison.ReadyToRunTheGamut() && SaveState.lollipop.et_relations.Count == 0 && SaveState.lollipop.target_proteoform_community.has_e_proteoforms) MessageBox.Show("Go back and create a theoretical database.");
             else if (!experimentalTheoreticalComparison.ReadyToRunTheGamut() && SaveState.lollipop.et_relations.Count == 0) MessageBox.Show("Go back and aggregate experimental proteoforms.");
         }
 
@@ -317,18 +317,14 @@ namespace ProteoformSuiteGUI
         {
             SaveState.lollipop.raw_experimental_components.Clear();
             SaveState.lollipop.raw_neucode_pairs.Clear();
-            SaveState.lollipop.proteoform_community.experimental_proteoforms = new ExperimentalProteoform[0];
-            SaveState.lollipop.proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
+            SaveState.lollipop.target_proteoform_community = new ProteoformCommunity();
+            SaveState.lollipop.decoy_proteoform_communities.Clear();
             SaveState.lollipop.et_relations.Clear();
             SaveState.lollipop.et_peaks.Clear();
             SaveState.lollipop.ee_relations.Clear();
             SaveState.lollipop.ee_peaks.Clear();
-            SaveState.lollipop.proteoform_community.families.Clear();
             SaveState.lollipop.ed_relations.Clear();
-            SaveState.lollipop.proteoform_community.relations_in_peaks.Clear();
-            SaveState.lollipop.proteoform_community.delta_mass_peaks.Clear();
             SaveState.lollipop.ef_relations.Clear();
-            SaveState.lollipop.proteoform_community.decoy_proteoforms.Clear();
         }
 
         #endregion Public Method

--- a/ProteoformSuiteGUI/Quantification.cs
+++ b/ProteoformSuiteGUI/Quantification.cs
@@ -62,7 +62,7 @@ namespace ProteoformSuiteGUI
 
         public bool ReadyToRunTheGamut()
         {
-            return SaveState.lollipop.get_files(SaveState.lollipop.input_files, Purpose.Quantification).Count() > 0 && SaveState.lollipop.proteoform_community.experimental_proteoforms.Length > 0 && SaveState.lollipop.qVals.Count <= 0;
+            return SaveState.lollipop.get_files(SaveState.lollipop.input_files, Purpose.Quantification).Count() > 0 && SaveState.lollipop.target_proteoform_community.experimental_proteoforms.Length > 0 && SaveState.lollipop.qVals.Count <= 0;
         }
 
         public void FillTablesAndCharts()
@@ -305,14 +305,14 @@ namespace ProteoformSuiteGUI
         private void nud_bkgdShift_ValueChanged(object sender, EventArgs e)
         {
             SaveState.lollipop.backgroundShift = nud_bkgdShift.Value;
-            if (SaveState.lollipop.qVals.Count > 0) SaveState.lollipop.defineAllObservedIntensityDistribution(SaveState.lollipop.proteoform_community.experimental_proteoforms, SaveState.lollipop.logIntensityHistogram);
+            if (SaveState.lollipop.qVals.Count > 0) SaveState.lollipop.defineAllObservedIntensityDistribution(SaveState.lollipop.target_proteoform_community.experimental_proteoforms, SaveState.lollipop.logIntensityHistogram);
             if (SaveState.lollipop.qVals.Count > 0) SaveState.lollipop.defineBackgroundIntensityDistribution(SaveState.lollipop.neucode_labeled, SaveState.lollipop.quantBioFracCombos, SaveState.lollipop.satisfactoryProteoforms, SaveState.lollipop.backgroundShift, SaveState.lollipop.backgroundWidth);
         }
 
         private void nud_bkgdWidth_ValueChanged(object sender, EventArgs e)
         {
             SaveState.lollipop.backgroundWidth = nud_bkgdWidth.Value;
-            if (SaveState.lollipop.qVals.Count > 0) SaveState.lollipop.defineAllObservedIntensityDistribution(SaveState.lollipop.proteoform_community.experimental_proteoforms, SaveState.lollipop.logIntensityHistogram);
+            if (SaveState.lollipop.qVals.Count > 0) SaveState.lollipop.defineAllObservedIntensityDistribution(SaveState.lollipop.target_proteoform_community.experimental_proteoforms, SaveState.lollipop.logIntensityHistogram);
             if (SaveState.lollipop.qVals.Count > 0) SaveState.lollipop.defineBackgroundIntensityDistribution(SaveState.lollipop.neucode_labeled, SaveState.lollipop.quantBioFracCombos, SaveState.lollipop.satisfactoryProteoforms, SaveState.lollipop.backgroundShift, SaveState.lollipop.backgroundWidth);
         }
 
@@ -489,7 +489,7 @@ namespace ProteoformSuiteGUI
         {
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
-            string message = CytoscapeScript.write_cytoscape_script(SaveState.lollipop.proteoform_community.families, SaveState.lollipop.proteoform_community.families,
+            string message = CytoscapeScript.write_cytoscape_script(SaveState.lollipop.target_proteoform_community.families, SaveState.lollipop.target_proteoform_community.families,
                 SaveState.lollipop.family_build_folder_path, "", time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked,
                 cmbx_colorScheme.SelectedItem.ToString(), cmbx_nodeLabel.SelectedItem.ToString(), cmbx_edgeLabel.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), SaveState.lollipop.deltaM_edge_display_rounding,
                 cb_geneCentric.Checked, cmbx_geneLabel.SelectedItem.ToString());
@@ -501,7 +501,7 @@ namespace ProteoformSuiteGUI
             List<ProteoformFamily> families = SaveState.lollipop.getInterestingFamilies(SaveState.lollipop.satisfactoryProteoforms, SaveState.lollipop.minProteoformFoldChange, SaveState.lollipop.minProteoformFDR, SaveState.lollipop.minProteoformIntensity).Distinct().ToList();
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
-            string message = CytoscapeScript.write_cytoscape_script(families, SaveState.lollipop.proteoform_community.families,
+            string message = CytoscapeScript.write_cytoscape_script(families, SaveState.lollipop.target_proteoform_community.families,
                 SaveState.lollipop.family_build_folder_path, "", time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked,
                 cmbx_colorScheme.SelectedItem.ToString(), cmbx_edgeLabel.SelectedItem.ToString(), cmbx_nodeLabel.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), SaveState.lollipop.deltaM_edge_display_rounding,
                 cb_geneCentric.Checked, cmbx_geneLabel.SelectedItem.ToString());
@@ -513,7 +513,7 @@ namespace ProteoformSuiteGUI
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
             object[] selected = DisplayUtility.get_selected_objects(dgv_quantification_results);
-            string message = CytoscapeScript.write_cytoscape_script(selected, SaveState.lollipop.proteoform_community.families,
+            string message = CytoscapeScript.write_cytoscape_script(selected, SaveState.lollipop.target_proteoform_community.families,
                 SaveState.lollipop.family_build_folder_path, "", time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked,
                 cmbx_colorScheme.SelectedItem.ToString(), cmbx_edgeLabel.SelectedItem.ToString(), cmbx_nodeLabel.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), SaveState.lollipop.deltaM_edge_display_rounding,
                 cb_geneCentric.Checked, cmbx_geneLabel.SelectedItem.ToString());
@@ -523,10 +523,10 @@ namespace ProteoformSuiteGUI
         private void btn_buildFamiliesAllGO_Click(object sender, EventArgs e)
         {
             Aspect a = (Aspect)cmbx_goAspect.SelectedItem;
-            List<ProteoformFamily> go_families = SaveState.lollipop.getInterestingFamilies(SaveState.lollipop.goTermNumbers.Where(n => n.Aspect == a).Distinct().ToList(), SaveState.lollipop.proteoform_community.families);
+            List<ProteoformFamily> go_families = SaveState.lollipop.getInterestingFamilies(SaveState.lollipop.goTermNumbers.Where(n => n.Aspect == a).Distinct().ToList(), SaveState.lollipop.target_proteoform_community.families);
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
-            string message = CytoscapeScript.write_cytoscape_script(go_families, SaveState.lollipop.proteoform_community.families,
+            string message = CytoscapeScript.write_cytoscape_script(go_families, SaveState.lollipop.target_proteoform_community.families,
                 SaveState.lollipop.family_build_folder_path, "", time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked,
                 cmbx_colorScheme.SelectedItem.ToString(), cmbx_edgeLabel.SelectedItem.ToString(), cmbx_nodeLabel.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), SaveState.lollipop.deltaM_edge_display_rounding,
                 cb_geneCentric.Checked, cmbx_geneLabel.SelectedItem.ToString());
@@ -536,10 +536,10 @@ namespace ProteoformSuiteGUI
         private void btn_buildFromSelectedGoTerms_Click(object sender, EventArgs e)
         {
             List<GoTermNumber> selected_gos = (DisplayUtility.get_selected_objects(dgv_goAnalysis).Select(o => (GoTermNumber)o)).ToList();
-            List<ProteoformFamily> selected_families = SaveState.lollipop.getInterestingFamilies(selected_gos, SaveState.lollipop.proteoform_community.families).Distinct().ToList();
+            List<ProteoformFamily> selected_families = SaveState.lollipop.getInterestingFamilies(selected_gos, SaveState.lollipop.target_proteoform_community.families).Distinct().ToList();
             string time_stamp = SaveState.time_stamp();
             tb_recentTimeStamp.Text = time_stamp;
-            string message = CytoscapeScript.write_cytoscape_script(selected_families, SaveState.lollipop.proteoform_community.families,
+            string message = CytoscapeScript.write_cytoscape_script(selected_families, SaveState.lollipop.target_proteoform_community.families,
                 SaveState.lollipop.family_build_folder_path, "", time_stamp, true, cb_redBorder.Checked, cb_boldLabel.Checked, cb_moreOpacity.Checked,
                 cmbx_colorScheme.SelectedItem.ToString(), cmbx_edgeLabel.SelectedItem.ToString(), cmbx_nodeLabel.SelectedItem.ToString(), cmbx_nodeLabelPositioning.SelectedItem.ToString(), SaveState.lollipop.deltaM_edge_display_rounding,
                 cb_geneCentric.Checked, cmbx_geneLabel.SelectedItem.ToString());

--- a/ProteoformSuiteGUI/RawExperimentalComponents.cs
+++ b/ProteoformSuiteGUI/RawExperimentalComponents.cs
@@ -33,7 +33,7 @@ namespace ProteoformSuiteGUI
                 () => SaveState.lollipop.process_raw_components(SaveState.lollipop.input_files, SaveState.lollipop.raw_quantification_components, Purpose.Quantification),
                 () => 
                 {
-                    if (SaveState.lollipop.proteoform_community.theoretical_proteoforms.Length <= 0)
+                    if (SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Length <= 0)
                         SaveState.lollipop.theoretical_database.get_theoretical_proteoforms(Path.Combine(Path.Combine(Environment.CurrentDirectory)));
                 }
             );

--- a/ProteoformSuiteGUI/RelationUtility.cs
+++ b/ProteoformSuiteGUI/RelationUtility.cs
@@ -50,9 +50,9 @@ namespace ProteoformSuiteGUI
                 int rowIndex = dgv.CurrentCell.RowIndex;
 
                 if (columnIndex < 0) return;
-                string columnName = dgv.Columns[columnIndex].Name;
+                string columnName = dgv.Columns[columnIndex].HeaderText;
 
-                if (columnName == "peak_accepted")
+                if (columnName == "Peak Accepted")
                 {
                     bool acceptibilityStatus = Convert.ToBoolean(dgv.Rows[rowIndex].Cells[columnIndex].Value);
                     DeltaMassPeak selected_peak = (DeltaMassPeak)dgv.Rows[rowIndex].DataBoundItem;

--- a/ProteoformSuiteGUI/ResultsSummary.cs
+++ b/ProteoformSuiteGUI/ResultsSummary.cs
@@ -106,7 +106,7 @@ namespace ProteoformSuiteGUI
             if (cb_saveCytoScripts.Checked)
             {
                 string message = "";
-                message += CytoscapeScript.write_cytoscape_script(SaveState.lollipop.proteoform_community.families, SaveState.lollipop.proteoform_community.families,
+                message += CytoscapeScript.write_cytoscape_script(SaveState.lollipop.target_proteoform_community.families, SaveState.lollipop.target_proteoform_community.families,
                     tb_summarySaveFolder.Text, "AllFamilies_", timestamp,
                     SaveState.lollipop.qVals.Count > 0, true, true, false,
                     CytoscapeScript.color_scheme_names[0], Lollipop.edge_labels[1], Lollipop.node_labels[1], CytoscapeScript.node_label_positions[0], 2,
@@ -115,7 +115,7 @@ namespace ProteoformSuiteGUI
 
                 foreach (GoTermNumber gtn in SaveState.lollipop.goTermNumbers.Where(g => g.by < (double)SaveState.lollipop.minProteoformFDR).ToList())
                 {
-                    message += CytoscapeScript.write_cytoscape_script(new GoTermNumber[] { gtn }, SaveState.lollipop.proteoform_community.families,
+                    message += CytoscapeScript.write_cytoscape_script(new GoTermNumber[] { gtn }, SaveState.lollipop.target_proteoform_community.families,
                         tb_summarySaveFolder.Text, gtn.Aspect.ToString() + gtn.Description.Replace(" ", "_") + "_", timestamp,
                         true, true, true, false,
                         CytoscapeScript.color_scheme_names[0], Lollipop.edge_labels[1], Lollipop.node_labels[1], CytoscapeScript.node_label_positions[0], 2,

--- a/ProteoformSuiteGUI/TheoreticalDatabase.cs
+++ b/ProteoformSuiteGUI/TheoreticalDatabase.cs
@@ -51,9 +51,9 @@ namespace ProteoformSuiteGUI
             {
                 string table = cmbx_DisplayWhichDB.SelectedItem.ToString();
                 if (table == "Target")
-                    DisplayUtility.FillDataGridView(dgv_Database, SaveState.lollipop.proteoform_community.theoretical_proteoforms.Select(t => new DisplayTheoreticalProteoform(t)));
+                    DisplayUtility.FillDataGridView(dgv_Database, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Select(t => new DisplayTheoreticalProteoform(t)));
                 else
-                    DisplayUtility.FillDataGridView(dgv_Database, SaveState.lollipop.proteoform_community.decoy_proteoforms[table].Select(t => new DisplayTheoreticalProteoform(t)));
+                    DisplayUtility.FillDataGridView(dgv_Database, SaveState.lollipop.decoy_proteoform_communities[table].theoretical_proteoforms.Select(t => new DisplayTheoreticalProteoform(t)));
             }
             DisplayTheoreticalProteoform.FormatTheoreticalProteoformTable(dgv_Database);
         }
@@ -64,7 +64,7 @@ namespace ProteoformSuiteGUI
 
         public void load_dgv()
         {
-            DisplayUtility.FillDataGridView(dgv_Database, SaveState.lollipop.proteoform_community.theoretical_proteoforms.Select(t => new DisplayTheoreticalProteoform(t)));
+            DisplayUtility.FillDataGridView(dgv_Database, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Select(t => new DisplayTheoreticalProteoform(t)));
             this.initialize_table_bindinglist();
             DisplayTheoreticalProteoform.FormatTheoreticalProteoformTable(dgv_Database);
         }
@@ -77,9 +77,9 @@ namespace ProteoformSuiteGUI
         public void FillDataBaseTable(string table)
         {
             if (table == "Target")
-                DisplayUtility.FillDataGridView(dgv_Database, SaveState.lollipop.proteoform_community.theoretical_proteoforms.Select(t => new DisplayTheoreticalProteoform(t)));
-            else if (SaveState.lollipop.proteoform_community.decoy_proteoforms.ContainsKey(table))
-                DisplayUtility.FillDataGridView(dgv_Database, SaveState.lollipop.proteoform_community.decoy_proteoforms[table].Select(t => new DisplayTheoreticalProteoform(t)));
+                DisplayUtility.FillDataGridView(dgv_Database, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Select(t => new DisplayTheoreticalProteoform(t)));
+            else if (SaveState.lollipop.decoy_proteoform_communities.ContainsKey(table))
+                DisplayUtility.FillDataGridView(dgv_Database, SaveState.lollipop.decoy_proteoform_communities[table].theoretical_proteoforms.Select(t => new DisplayTheoreticalProteoform(t)));
             DisplayTheoreticalProteoform.FormatTheoreticalProteoformTable(dgv_Database);
         }
 
@@ -88,14 +88,14 @@ namespace ProteoformSuiteGUI
             SaveState.lollipop.theoretical_database.get_theoretical_proteoforms(Environment.CurrentDirectory);
             ((ProteoformSweet)MdiParent).experimentalTheoreticalComparison.ClearListsTablesFigures();
             ((ProteoformSweet)MdiParent).proteoformFamilies.ClearListsTablesFigures();
-            tb_totalTheoreticalProteoforms.Text = SaveState.lollipop.proteoform_community.theoretical_proteoforms.Length.ToString();
+            tb_totalTheoreticalProteoforms.Text = SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Length.ToString();
         }
 
         public void initialize_table_bindinglist()
         {
             List<string> databases = new List<string> { "Target" };
-            if (SaveState.lollipop.proteoform_community.decoy_proteoforms.Keys.Count > 0)
-                foreach (string name in SaveState.lollipop.proteoform_community.decoy_proteoforms.Keys)
+            if (SaveState.lollipop.decoy_proteoform_communities.Keys.Count > 0)
+            foreach (string name in SaveState.lollipop.decoy_proteoform_communities.Keys)
                     databases.Add(name);
             cmbx_DisplayWhichDB.DataSource = new BindingList<string>(databases.ToList());
         }
@@ -155,7 +155,7 @@ namespace ProteoformSuiteGUI
         
         public void FillTablesAndCharts()
         {
-            DisplayUtility.FillDataGridView(dgv_Database, SaveState.lollipop.proteoform_community.theoretical_proteoforms.Select(t => new DisplayTheoreticalProteoform(t)));
+            DisplayUtility.FillDataGridView(dgv_Database, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Select(t => new DisplayTheoreticalProteoform(t)));
             initialize_table_bindinglist();
             DisplayTheoreticalProteoform.FormatTheoreticalProteoformTable(dgv_Database);
         }
@@ -267,8 +267,8 @@ namespace ProteoformSuiteGUI
         private void tb_tableFilter_TextChanged(object sender, EventArgs e)
         {
             IEnumerable<object> selected_theoreticals = tb_tableFilter.Text == "" ?
-                SaveState.lollipop.proteoform_community.theoretical_proteoforms :
-                ExtensionMethods.filter(SaveState.lollipop.proteoform_community.theoretical_proteoforms, tb_tableFilter.Text);
+                SaveState.lollipop.target_proteoform_community.theoretical_proteoforms :
+                ExtensionMethods.filter(SaveState.lollipop.target_proteoform_community.theoretical_proteoforms, tb_tableFilter.Text);
             DisplayUtility.FillDataGridView(dgv_Database, selected_theoreticals.OfType<TheoreticalProteoform>().Select(t => new DisplayTheoreticalProteoform(t)));
             DisplayTheoreticalProteoform.FormatTheoreticalProteoformTable(dgv_Database);
         }

--- a/ProteoformSuiteGUI/TheoreticalDatabase.cs
+++ b/ProteoformSuiteGUI/TheoreticalDatabase.cs
@@ -87,6 +87,7 @@ namespace ProteoformSuiteGUI
         {
             SaveState.lollipop.theoretical_database.get_theoretical_proteoforms(Environment.CurrentDirectory);
             ((ProteoformSweet)MdiParent).experimentalTheoreticalComparison.ClearListsTablesFigures();
+            ((ProteoformSweet)MdiParent).experimentExperimentComparison.ClearListsTablesFigures();
             ((ProteoformSweet)MdiParent).proteoformFamilies.ClearListsTablesFigures();
             tb_totalTheoreticalProteoforms.Text = SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Length.ToString();
         }

--- a/ProteoformSuiteInternal/DeltaMassPeak.cs
+++ b/ProteoformSuiteInternal/DeltaMassPeak.cs
@@ -83,9 +83,9 @@ namespace ProteoformSuiteInternal
                 DeltaMass = grouped_relations.Select(r => r.DeltaMass).Average();
             }
 
-            //foreach (ProteoformRelation mass_difference in grouped_relations)
-            //    foreach (Proteoform p in mass_difference.connected_proteoforms)
-            //        lock (p) p.relationships.Add(mass_difference);
+            foreach (ProteoformRelation mass_difference in grouped_relations)
+                foreach (Proteoform p in mass_difference.connected_proteoforms)
+                    lock (p) p.relationships.Add(mass_difference);
 
             return grouped_relations;
         }
@@ -98,7 +98,7 @@ namespace ProteoformSuiteInternal
             Parallel.ForEach(decoys_in_peaks, r =>
             {
                 r.Accepted = this.Accepted;
-                if (r.Accepted) r.peak = this; else r.peak = null;
+                if (r.Accepted) r.peak = this; //assign relation this peak so possible peak assignments used when identifying experimentals
             });
             return decoys_in_peaks.Count;
         }

--- a/ProteoformSuiteInternal/DeltaMassPeak.cs
+++ b/ProteoformSuiteInternal/DeltaMassPeak.cs
@@ -17,7 +17,7 @@ namespace ProteoformSuiteInternal
 
         #region Public Properties
 
-        public List<ProteoformRelation> grouped_relations { get; set; }
+        public List<ProteoformRelation> grouped_relations { get; set; } //target relations only. Decoy relations in the peak range have relation.peak set to this
         public double DeltaMass { get; set; }
         public int peak_relation_group_count { get { return grouped_relations.Count; } }
         public double decoy_relation_count { get; set; }
@@ -99,11 +99,13 @@ namespace ProteoformSuiteInternal
             {
                 lock (r)
                 {
-                    r.Accepted = this.Accepted;
-                    r.peak = this; //assign relation this peak so possible peak assignments used when identifying experimentals
+                    if (r.peak == null || this.peak_relation_group_count > r.peak.peak_relation_group_count)
+                    {
+                        r.Accepted = this.Accepted;
+                        r.peak = this; //assign relation this peak so possible peak assignments used when identifying experimentals
+                    }
                 }
             }
-
             return decoys_in_peaks.Count;
         }
 

--- a/ProteoformSuiteInternal/Lollipop.cs
+++ b/ProteoformSuiteInternal/Lollipop.cs
@@ -514,6 +514,40 @@ namespace ProteoformSuiteInternal
         public List<DeltaMassPeak> et_peaks = new List<DeltaMassPeak>();
         public List<DeltaMassPeak> ee_peaks = new List<DeltaMassPeak>();
 
+        public void relate_ed()
+        {
+            SaveState.lollipop.ed_relations.Clear();
+            for (int i = 0; i < SaveState.lollipop.decoy_proteoform_communities.Count; i++)
+            {
+                string key = "Decoy_Proteoform_Community_" + i;
+                SaveState.lollipop.ed_relations.Add(key, SaveState.lollipop.decoy_proteoform_communities[key].relate(SaveState.lollipop.decoy_proteoform_communities[key].experimental_proteoforms, SaveState.lollipop.decoy_proteoform_communities[key].theoretical_proteoforms, ProteoformComparison.ExperimentalDecoy, true));
+                if (i == 0) ProteoformCommunity.count_nearby_relations(SaveState.lollipop.ed_relations[key]); //count from first decoy database (for histogram)
+            }
+
+            foreach (ProteoformRelation mass_difference in ed_relations.Values.SelectMany(v => v))
+            {
+                foreach (Proteoform p in mass_difference.connected_proteoforms)
+                p.relationships.Add(mass_difference);
+            }
+        }
+
+        public void relate_ef()
+        {
+            SaveState.lollipop.ef_relations.Clear();
+            for (int i = 0; i < SaveState.lollipop.decoy_proteoform_communities.Count; i++)
+            {
+                string key = "Decoy_Proteoform_Community_" + i;
+                SaveState.lollipop.ef_relations.Add(key, SaveState.lollipop.decoy_proteoform_communities[key].relate_ef(SaveState.lollipop.decoy_proteoform_communities[key].experimental_proteoforms, SaveState.lollipop.decoy_proteoform_communities[key].experimental_proteoforms));
+                if (i == 0) ProteoformCommunity.count_nearby_relations(SaveState.lollipop.ef_relations[key]); //count from first decoy database (for histogram)
+            }
+
+            foreach (ProteoformRelation mass_difference in ef_relations.Values.SelectMany(v => v))
+            {
+                foreach (Proteoform p in mass_difference.connected_proteoforms)
+                    p.relationships.Add(mass_difference);
+            }
+        }
+
         #endregion ET,ED,EE,EF COMPARISONS Public Fields
 
         #region PROTEOFORM FAMILIES Public Fields
@@ -976,15 +1010,7 @@ namespace ProteoformSuiteInternal
         {
             foreach (ProteoformCommunity community in decoy_proteoform_communities.Values.Concat(new List<ProteoformCommunity> { target_proteoform_community }))
             {
-                community.families.Clear();
-                foreach (Proteoform p in community.experimental_proteoforms)
-                {
-                    p.family = null;
-                    p.ptm_set = new PtmSet(new List<Ptm>());
-                    p.linked_proteoform_references = null;
-                    p.gene_name = null;
-                }
-                foreach (Proteoform p in community.theoretical_proteoforms) p.family = null;
+                community.clear_families();
             }
         }
     }

--- a/ProteoformSuiteInternal/Lollipop.cs
+++ b/ProteoformSuiteInternal/Lollipop.cs
@@ -262,6 +262,7 @@ namespace ProteoformSuiteInternal
 
         public ProteoformCommunity target_proteoform_community = new ProteoformCommunity();
         public Dictionary<string, ProteoformCommunity> decoy_proteoform_communities = new Dictionary<string, ProteoformCommunity> ();
+        public string decoy_community_name_prefix = "Decoy_Proteoform_Community_";
         public List<Component> remaining_components = new List<Component>();
         public List<Component> remaining_verification_components = new List<Component>();
         public List<Component> remaining_quantification_components = new List<Component>();
@@ -519,7 +520,7 @@ namespace ProteoformSuiteInternal
             SaveState.lollipop.ed_relations.Clear();
             for (int i = 0; i < SaveState.lollipop.decoy_proteoform_communities.Count; i++)
             {
-                string key = "Decoy_Proteoform_Community_" + i;
+                string key = decoy_community_name_prefix + i;
                 SaveState.lollipop.ed_relations.Add(key, SaveState.lollipop.decoy_proteoform_communities[key].relate(SaveState.lollipop.decoy_proteoform_communities[key].experimental_proteoforms, SaveState.lollipop.decoy_proteoform_communities[key].theoretical_proteoforms, ProteoformComparison.ExperimentalDecoy, true));
                 if (i == 0) ProteoformCommunity.count_nearby_relations(SaveState.lollipop.ed_relations[key]); //count from first decoy database (for histogram)
             }
@@ -536,7 +537,7 @@ namespace ProteoformSuiteInternal
             SaveState.lollipop.ef_relations.Clear();
             for (int i = 0; i < SaveState.lollipop.decoy_proteoform_communities.Count; i++)
             {
-                string key = "Decoy_Proteoform_Community_" + i;
+                string key = decoy_community_name_prefix + i;
                 SaveState.lollipop.ef_relations.Add(key, SaveState.lollipop.decoy_proteoform_communities[key].relate_ef(SaveState.lollipop.decoy_proteoform_communities[key].experimental_proteoforms, SaveState.lollipop.decoy_proteoform_communities[key].experimental_proteoforms));
                 if (i == 0) ProteoformCommunity.count_nearby_relations(SaveState.lollipop.ef_relations[key]); //count from first decoy database (for histogram)
             }
@@ -560,7 +561,7 @@ namespace ProteoformSuiteInternal
         public static List<string> gene_name_labels = new List<string> { "Primary, e.g. HOG1", "Ordered Locus, e.g. YLR113W" };
         public string[] likely_cleavages = new string[] { "I", "L", "A" };
 
-        public void construct_families()
+        public void construct_target_and_decoy_families()
         {
             target_proteoform_community.construct_families();
             foreach (var decoys in decoy_proteoform_communities.Values) decoys.construct_families();

--- a/ProteoformSuiteInternal/Proteoform.cs
+++ b/ProteoformSuiteInternal/Proteoform.cs
@@ -79,7 +79,7 @@ namespace ProteoformSuiteInternal
         public List<ExperimentalProteoform> identify_connected_experimentals(List<PtmSet> all_possible_ptmsets, List<ModificationWithMass> all_mods_with_mass)
         {
             List<ExperimentalProteoform> identified = new List<ExperimentalProteoform>();
-            foreach (ProteoformRelation r in relationships.Where(r => r.peak.Accepted).Distinct().ToList())
+            foreach (ProteoformRelation r in relationships.Where(r => r.Accepted).Distinct().ToList())
             {
                 ExperimentalProteoform e = r.connected_proteoforms.OfType<ExperimentalProteoform>().FirstOrDefault(p => p != this);
                 if (e == null) continue; // Looking at an ET pair, expecting an EE pair

--- a/ProteoformSuiteInternal/ProteoformCommunity.cs
+++ b/ProteoformSuiteInternal/ProteoformCommunity.cs
@@ -74,10 +74,6 @@ namespace ProteoformSuiteInternal
                  from pf2 in pf1.candidate_relatives
                  select new ProteoformRelation(pf1, pf2, relation_type, pf1.modified_mass - pf2.modified_mass)).ToList();
 
-            foreach (ProteoformRelation mass_difference in relations)
-                foreach (Proteoform p in mass_difference.connected_proteoforms)
-                    lock (p) p.relationships.Add(mass_difference);
-
             return count_nearby_relations(relations);  //putative counts include no-mans land
         }
 
@@ -310,7 +306,23 @@ namespace ProteoformSuiteInternal
 
         #endregion CONSTRUCTING FAMILIES
 
+        #region CLEAR FAMILIES
 
-
+        public void clear_families()
+        {
+            families.Clear();
+            foreach (Proteoform p in experimental_proteoforms)
+            {
+                p.family = null;
+                p.ptm_set = new PtmSet(new List<Ptm>());
+                p.linked_proteoform_references = null;
+                p.gene_name = null;
+            }
+            foreach (Proteoform p in theoretical_proteoforms) p.family = null;
+        }
+        #endregion CLEAR FAMILIES
     }
+
+
+
 }

--- a/ProteoformSuiteInternal/ProteoformCommunity.cs
+++ b/ProteoformSuiteInternal/ProteoformCommunity.cs
@@ -13,9 +13,6 @@ namespace ProteoformSuiteInternal
 
         public ExperimentalProteoform[] experimental_proteoforms = new ExperimentalProteoform[0];
         public TheoreticalProteoform[] theoretical_proteoforms = new TheoreticalProteoform[0];
-        public Dictionary<string, TheoreticalProteoform[]> decoy_proteoforms = new Dictionary<string, TheoreticalProteoform[]>();
-        public List<ProteoformRelation> relations_in_peaks = new List<ProteoformRelation>();
-        public List<DeltaMassPeak> delta_mass_peaks = new List<DeltaMassPeak>();
         public List<ProteoformFamily> families = new List<ProteoformFamily>();
 
         #endregion Public Fields
@@ -77,6 +74,10 @@ namespace ProteoformSuiteInternal
                  from pf2 in pf1.candidate_relatives
                  select new ProteoformRelation(pf1, pf2, relation_type, pf1.modified_mass - pf2.modified_mass)).ToList();
 
+            foreach (ProteoformRelation mass_difference in relations)
+                foreach (Proteoform p in mass_difference.connected_proteoforms)
+                    lock (p) p.relationships.Add(mass_difference);
+
             return count_nearby_relations(relations);  //putative counts include no-mans land
         }
 
@@ -111,7 +112,7 @@ namespace ProteoformSuiteInternal
             }
         }
 
-        private static List<ProteoformRelation> count_nearby_relations(List<ProteoformRelation> all_relations)
+        public static List<ProteoformRelation> count_nearby_relations(List<ProteoformRelation> all_relations)
         {
             List<ProteoformRelation> all_ordered_relations = all_relations.OrderBy(x => x.DeltaMass).ToList();
             List<int> ordered_relation_ids = all_ordered_relations.Select(r => r.InstanceId).ToList();
@@ -119,32 +120,22 @@ namespace ProteoformSuiteInternal
             return all_ordered_relations;
         }
 
-        public Dictionary<string, List<ProteoformRelation>> relate_ed()
-        {
-            Dictionary<string, List<ProteoformRelation>> ed_relations = new Dictionary<string, List<ProteoformRelation>>();
-            foreach (var decoys in decoy_proteoforms)
-            {
-                ed_relations.Add(decoys.Key, relate(experimental_proteoforms, decoys.Value, ProteoformComparison.ExperimentalDecoy, true));
-            }
-            return ed_relations;
-        }
+        //public Dictionary<string, List<ProteoformRelation>> relate_ed()
+        //{
+        //    Dictionary<string, List<ProteoformRelation>> ed_relations = new Dictionary<string, List<ProteoformRelation>>();
+        //    foreach (var decoys in decoy_proteoforms)
+        //    {
+        //        ed_relations.Add(decoys.Key, relate(experimental_proteoforms, decoys.Value, ProteoformComparison.ExperimentalDecoy, true));
+        //    }
+        //    return ed_relations;
+        //}
 
-        public Dictionary<string, List<ProteoformRelation>> relate_ef(ExperimentalProteoform[] pfs1, ExperimentalProteoform[] pfs2)
+        public List<ProteoformRelation> relate_ef(ExperimentalProteoform[] pfs1, ExperimentalProteoform[] pfs2)
         {
             List<ProteoformRelation> all_ef_relations = relate(pfs1, pfs2, ProteoformComparison.ExperimentalFalse, true);
-
-            //take 10 random subsets from all allowed ef relations (will use median for fdr calculations of each peak)
-            Dictionary<string, List<ProteoformRelation>> ef_relations = new Dictionary<string, List<ProteoformRelation>>();
-            Parallel.For(0, 10, i =>
-            {
-                string key = "EF_relations_" + i;
-                ProteoformRelation[] to_shuffle = new List<ProteoformRelation>(all_ef_relations).ToArray();
-                to_shuffle.Shuffle();
-                lock (ef_relations) ef_relations.Add(key, to_shuffle.Take(SaveState.lollipop.ee_relations.Count).ToList());
-            });
-
-            count_nearby_relations(ef_relations.Values.First()); //count from first decoy database
-            return ef_relations;
+            ProteoformRelation[] to_shuffle = new List<ProteoformRelation>(all_ef_relations).ToArray();
+            to_shuffle.Shuffle();
+            return to_shuffle.Take(SaveState.lollipop.ee_relations.Count).ToList();
         }
 
         #endregion BUILDING RELATIONSHIPS
@@ -194,14 +185,13 @@ namespace ProteoformSuiteInternal
                 }
 
                 List<ProteoformRelation> mass_differences_in_peaks = running.SelectMany(r => r.peak.grouped_relations).ToList();
-                relations_in_peaks.AddRange(mass_differences_in_peaks);
                 remaining_relations_outside_no_mans = remaining_relations_outside_no_mans.Except(mass_differences_in_peaks).ToList();
 
                 running.Clear();
                 active.Clear();
                 root = find_next_root(remaining_relations_outside_no_mans, running);
             }
-            delta_mass_peaks.AddRange(peaks);
+            if (peaks.Count > 0 && peaks.First().RelationType == ProteoformComparison.ExperimentalTheoretical) SaveState.lollipop.et_peaks.AddRange(peaks); else SaveState.lollipop.ee_peaks.AddRange(peaks);
 
             //Nearby relations are no longer needed after counting them
             Parallel.ForEach(decoy_relations.SelectMany(kv => kv.Value).Concat(relations).ToList(), r =>
@@ -291,7 +281,7 @@ namespace ProteoformSuiteInternal
                 while (remaining.Count > 0 && active.Count < Environment.ProcessorCount)
                 {
                     ProteoformFamily fam = remaining.Pop();
-                    Thread t = new Thread(new ThreadStart(fam.merge_families));
+                    Thread t = new Thread(() => fam.merge_families(this.families));
                     t.Start();
                     running.Add(fam);
                     active.Add(t);
@@ -320,73 +310,7 @@ namespace ProteoformSuiteInternal
 
         #endregion CONSTRUCTING FAMILIES
 
-        #region CLEAR METHODS
 
-        public void clear_et()
-        {
-            SaveState.lollipop.et_relations.Clear();
-            SaveState.lollipop.et_peaks.Clear();
-            SaveState.lollipop.ed_relations.Clear();
-            SaveState.lollipop.proteoform_community.families.Clear();
-
-            foreach (Proteoform p in experimental_proteoforms)
-            {
-                p.relationships.RemoveAll(r => r.RelationType == ProteoformComparison.ExperimentalTheoretical || r.RelationType == ProteoformComparison.ExperimentalDecoy);
-                p.family = null;
-                p.ptm_set = new PtmSet(new List<Ptm>());
-                p.linked_proteoform_references = null;
-                p.gene_name = null;
-            }
-
-            foreach (Proteoform p in theoretical_proteoforms)
-            {
-                p.relationships.RemoveAll(r => r.RelationType == ProteoformComparison.ExperimentalTheoretical || r.RelationType == ProteoformComparison.ExperimentalDecoy);
-                p.family = null;
-            }
-
-            foreach (Proteoform p in SaveState.lollipop.proteoform_community.decoy_proteoforms.Values.SelectMany(d => d))
-            {
-                p.relationships.RemoveAll(r => r.RelationType == ProteoformComparison.ExperimentalTheoretical || r.RelationType == ProteoformComparison.ExperimentalDecoy);
-            }
-
-            relations_in_peaks.RemoveAll(r => r.RelationType == ProteoformComparison.ExperimentalTheoretical || r.RelationType == ProteoformComparison.ExperimentalDecoy);
-            delta_mass_peaks.RemoveAll(k => k.RelationType == ProteoformComparison.ExperimentalTheoretical || k.RelationType == ProteoformComparison.ExperimentalDecoy);
-        }
-
-        public void clear_ee()
-        {
-            SaveState.lollipop.ee_relations.Clear();
-            SaveState.lollipop.ee_peaks.Clear();
-            SaveState.lollipop.ef_relations.Clear();
-            SaveState.lollipop.proteoform_community.families.Clear();
-
-            foreach (Proteoform p in SaveState.lollipop.proteoform_community.experimental_proteoforms)
-            {
-                p.relationships.RemoveAll(r => r.RelationType == ProteoformComparison.ExperimentalExperimental || r.RelationType == ProteoformComparison.ExperimentalFalse);
-                p.family = null;
-                p.ptm_set = new PtmSet(new List<Ptm>());
-                p.linked_proteoform_references = null;
-                p.gene_name = null;
-            }
-
-            relations_in_peaks.RemoveAll(r => r.RelationType == ProteoformComparison.ExperimentalExperimental || r.RelationType == ProteoformComparison.ExperimentalFalse);
-            delta_mass_peaks.RemoveAll(k => k.RelationType == ProteoformComparison.ExperimentalExperimental || k.RelationType == ProteoformComparison.ExperimentalFalse);
-        }
-
-        public void clear_families()
-        {
-            families.Clear();
-            foreach (Proteoform p in experimental_proteoforms)
-            {
-                p.family = null;
-                p.ptm_set = new PtmSet(new List<Ptm>());
-                p.linked_proteoform_references = null;
-                p.gene_name = null;
-            }
-            foreach (Proteoform p in theoretical_proteoforms) p.family = null;
-            foreach (Proteoform p in decoy_proteoforms.Values.SelectMany(d => d)) p.family = null;
-        }
-        #endregion CLEAR METHODS
 
     }
 }

--- a/ProteoformSuiteInternal/ProteoformFamily.cs
+++ b/ProteoformSuiteInternal/ProteoformFamily.cs
@@ -56,10 +56,10 @@ namespace ProteoformSuiteInternal
             separate_proteoforms();
         }
 
-        public void merge_families()
+        public void merge_families(List<ProteoformFamily> families)
         {
             IEnumerable<ProteoformFamily> gene_family =
-                    from f in SaveState.lollipop.proteoform_community.families
+                    from f in families
                     from n in gene_names.Select(g => g.get_prefered_name(ProteoformCommunity.preferred_gene_label)).Distinct()
                     where f.gene_names.Select(g => g.get_prefered_name(ProteoformCommunity.preferred_gene_label)).Contains(n)
                     select f;
@@ -116,7 +116,7 @@ namespace ProteoformSuiteInternal
             theoretical_proteoforms = proteoforms.OfType<TheoreticalProteoform>().ToList();
             gene_names = theoretical_proteoforms.Select(t => t.gene_name).ToList();
             experimental_proteoforms = proteoforms.OfType<ExperimentalProteoform>().ToList();
-            relations = new HashSet<ProteoformRelation>(proteoforms.SelectMany(p => p.relationships.Where(r => r.peak.Accepted))).ToList();
+            relations = new HashSet<ProteoformRelation>(proteoforms.SelectMany(p => p.relationships.Where(r => r.Accepted))).ToList();
         }
 
         #endregion Private Methods

--- a/ProteoformSuiteInternal/ProteoformRelation.cs
+++ b/ProteoformSuiteInternal/ProteoformRelation.cs
@@ -120,7 +120,7 @@ namespace ProteoformSuiteInternal
 
         public void generate_peak()
         {
-            new DeltaMassPeak(this, SaveState.lollipop.proteoform_community.remaining_relations_outside_no_mans); //setting the peak takes place elsewhere, but this constructs it
+            new DeltaMassPeak(this, SaveState.lollipop.target_proteoform_community.remaining_relations_outside_no_mans); //setting the peak takes place elsewhere, but this constructs it
             if (connected_proteoforms[1] as TheoreticalProteoform != null && SaveState.lollipop.ed_relations.Count > 0)
                 lock (peak) peak.calculate_fdr(SaveState.lollipop.ed_relations);
             else if (connected_proteoforms[1] as ExperimentalProteoform != null && SaveState.lollipop.ef_relations.Count > 0)

--- a/ProteoformSuiteInternal/ResultsSummaryGenerator.cs
+++ b/ProteoformSuiteInternal/ResultsSummaryGenerator.cs
@@ -62,7 +62,11 @@ namespace ProteoformSuiteInternal
             report += identified_families.Sum(f => f.experimental_proteoforms.Count).ToString() + "\tExperimental Proteoforms in Identified Families" + Environment.NewLine;
             report += ambiguous_families.Count.ToString() + "\tAmbiguous Families (Correspond to > 1 gene)" + Environment.NewLine;
             report += ambiguous_families.Sum(f => f.experimental_proteoforms.Count).ToString() + "\tExperimental Proteoforms in Ambiguous Families" + Environment.NewLine;
-            report += SaveState.lollipop.target_proteoform_community.families.Count(f => f.proteoforms.Count == 1).ToString() + "\tOrphaned Experimental Proteoforms (Not joined with another proteoform)" + Environment.NewLine + Environment.NewLine;
+            report += SaveState.lollipop.target_proteoform_community.families.Count(f => f.proteoforms.Count == 1).ToString() + "\tOrphaned Experimental Proteoforms (Not joined with another proteoform)" + Environment.NewLine;
+            report += SaveState.lollipop.target_proteoform_community.experimental_proteoforms.Count(e => e.linked_proteoform_references != null).ToString() + "\tIdentified Experimental Proteoforms" + Environment.NewLine;
+            if (SaveState.lollipop.decoy_proteoform_communities.Values.SelectMany(v => v.families).Count() > 0)
+                report += Math.Round(SaveState.lollipop.decoy_proteoform_communities.Average(v => v.Value.experimental_proteoforms.Count(e => e.linked_proteoform_references != null)) / SaveState.lollipop.target_proteoform_community.experimental_proteoforms.Count(e => e.linked_proteoform_references != null), 2) + "\tProteoform FDR" + Environment.NewLine;
+            report += Environment.NewLine;
 
             report += SaveState.lollipop.satisfactoryProteoforms.Count.ToString() + "\tQuantified Experimental Proteoforms (Threshold for Quantification: " + SaveState.lollipop.minBiorepsWithObservations.ToString() + " = " + SaveState.lollipop.observation_requirement + ")" + Environment.NewLine;
             report += SaveState.lollipop.satisfactoryProteoforms.Count(p => p.quant.significant).ToString() + "\tExperimental Proteoforms with Significant Change (Threshold for Significance: Log2FoldChange > " + SaveState.lollipop.minProteoformFoldChange.ToString() + ", & Total Intensity from Quantification > " + SaveState.lollipop.minProteoformIntensity.ToString() + ", & Q-Value < " + SaveState.lollipop.minProteoformFDR.ToString() + ")" + Environment.NewLine + Environment.NewLine;

--- a/ProteoformSuiteInternal/ResultsSummaryGenerator.cs
+++ b/ProteoformSuiteInternal/ResultsSummaryGenerator.cs
@@ -37,11 +37,11 @@ namespace ProteoformSuiteInternal
             report += SaveState.lollipop.raw_neucode_pairs.Count.ToString() + "\tRaw NeuCode Pairs" + Environment.NewLine;
             report += SaveState.lollipop.raw_neucode_pairs.Count(nc => nc.accepted).ToString() + "\tAccepted NeuCode Pairs" + Environment.NewLine + Environment.NewLine;
 
-            report += SaveState.lollipop.proteoform_community.experimental_proteoforms.Length.ToString() + "\tExperimental Proteoforms" + Environment.NewLine;
-            report += SaveState.lollipop.proteoform_community.experimental_proteoforms.Count(e => e.accepted).ToString() + "\tAccepted Experimental Proteoforms" + Environment.NewLine;
+            report += SaveState.lollipop.target_proteoform_community.experimental_proteoforms.Length.ToString() + "\tExperimental Proteoforms" + Environment.NewLine;
+            report += SaveState.lollipop.target_proteoform_community.experimental_proteoforms.Count(e => e.accepted).ToString() + "\tAccepted Experimental Proteoforms" + Environment.NewLine;
             report += SaveState.lollipop.theoretical_database.theoretical_proteins.Sum(kv => kv.Value.Length).ToString() + "\tTheoretical Proteins" + Environment.NewLine;
             report += SaveState.lollipop.theoretical_database.expanded_proteins.Length + "\tExpanded Theoretical Proteins" + Environment.NewLine;
-            report += SaveState.lollipop.proteoform_community.theoretical_proteoforms.Length.ToString() + "\tTheoretical Proteoforms" + Environment.NewLine + Environment.NewLine;
+            report += SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Length.ToString() + "\tTheoretical Proteoforms" + Environment.NewLine + Environment.NewLine;
 
             report += SaveState.lollipop.et_peaks.Count.ToString() + "\tExperimental-Theoretical Peaks" + Environment.NewLine;
             report += SaveState.lollipop.et_relations.Count.ToString() + "\tExperimental-Theoretical Pairs" + Environment.NewLine;
@@ -55,14 +55,14 @@ namespace ProteoformSuiteInternal
             report += SaveState.lollipop.ee_relations.Count(r => r.Accepted).ToString() + "\tAccepted Experimental-Experimental Pairs" + Environment.NewLine;
             report += SaveState.lollipop.ef_relations.Count <= 0 ? Environment.NewLine : SaveState.lollipop.ef_relations.Average(d => d.Value.Count).ToString() + "\tAverage Experimental-False Pairs" + Environment.NewLine + Environment.NewLine;
 
-            report += SaveState.lollipop.proteoform_community.families.Count.ToString() + "\tProteoform Families" + Environment.NewLine;
-            List<ProteoformFamily> identified_families = SaveState.lollipop.proteoform_community.families.Where(f => f.gene_names.Select(g => g.ordered_locus).Distinct().Count() == 1).ToList();
-            List<ProteoformFamily> ambiguous_families = SaveState.lollipop.proteoform_community.families.Where(f => f.gene_names.Select(g => g.ordered_locus).Distinct().Count() > 1).ToList();
+            report += SaveState.lollipop.target_proteoform_community.families.Count.ToString() + "\tProteoform Families" + Environment.NewLine;
+            List<ProteoformFamily> identified_families = SaveState.lollipop.target_proteoform_community.families.Where(f => f.gene_names.Select(g => g.ordered_locus).Distinct().Count() == 1).ToList();
+            List<ProteoformFamily> ambiguous_families = SaveState.lollipop.target_proteoform_community.families.Where(f => f.gene_names.Select(g => g.ordered_locus).Distinct().Count() > 1).ToList();
             report += identified_families.Count.ToString() + "\tIdentified Families (Correspond to 1 gene)" + Environment.NewLine;
             report += identified_families.Sum(f => f.experimental_proteoforms.Count).ToString() + "\tExperimental Proteoforms in Identified Families" + Environment.NewLine;
             report += ambiguous_families.Count.ToString() + "\tAmbiguous Families (Correspond to > 1 gene)" + Environment.NewLine;
             report += ambiguous_families.Sum(f => f.experimental_proteoforms.Count).ToString() + "\tExperimental Proteoforms in Ambiguous Families" + Environment.NewLine;
-            report += SaveState.lollipop.proteoform_community.families.Count(f => f.proteoforms.Count == 1).ToString() + "\tOrphaned Experimental Proteoforms (Not joined with another proteoform)" + Environment.NewLine + Environment.NewLine;
+            report += SaveState.lollipop.target_proteoform_community.families.Count(f => f.proteoforms.Count == 1).ToString() + "\tOrphaned Experimental Proteoforms (Not joined with another proteoform)" + Environment.NewLine + Environment.NewLine;
 
             report += SaveState.lollipop.satisfactoryProteoforms.Count.ToString() + "\tQuantified Experimental Proteoforms (Threshold for Quantification: " + SaveState.lollipop.minBiorepsWithObservations.ToString() + " = " + SaveState.lollipop.observation_requirement + ")" + Environment.NewLine;
             report += SaveState.lollipop.satisfactoryProteoforms.Count(p => p.quant.significant).ToString() + "\tExperimental Proteoforms with Significant Change (Threshold for Significance: Log2FoldChange > " + SaveState.lollipop.minProteoformFoldChange.ToString() + ", & Total Intensity from Quantification > " + SaveState.lollipop.minProteoformIntensity.ToString() + ", & Q-Value < " + SaveState.lollipop.minProteoformFDR.ToString() + ")" + Environment.NewLine + Environment.NewLine;
@@ -103,7 +103,7 @@ namespace ProteoformSuiteInternal
             results.Columns.Add((SaveState.lollipop.denominator_condition == "" ? "Condition #2" : SaveState.lollipop.denominator_condition) + " Quantified Proteoform Intensity", typeof(double));
             results.Columns.Add("Statistically Significant", typeof(bool));
 
-            foreach (ExperimentalProteoform e in SaveState.lollipop.proteoform_community.families.SelectMany(f => f.experimental_proteoforms)
+            foreach (ExperimentalProteoform e in SaveState.lollipop.target_proteoform_community.families.SelectMany(f => f.experimental_proteoforms)
                 .Where(e => e.linked_proteoform_references != null)
                 .OrderByDescending(e => e.quant.significant ? 1 : 0)
                 .ThenBy(e => (e.linked_proteoform_references.First() as TheoreticalProteoform).accession)

--- a/ProteoformSuiteInternal/TheoreticalProteoformDatabase.cs
+++ b/ProteoformSuiteInternal/TheoreticalProteoformDatabase.cs
@@ -285,6 +285,7 @@ namespace ProteoformSuiteInternal
 
         private void process_decoys(ProteinWithGoTerms[] expanded_proteins, IEnumerable<ModificationWithMass> variableModifications)
         {
+            SaveState.lollipop.decoy_proteoform_communities.Clear();
             Parallel.For(0, SaveState.lollipop.decoy_databases, decoyNumber =>
             {
             List<TheoreticalProteoform> decoy_proteoforms = new List<TheoreticalProteoform>();

--- a/ProteoformSuiteInternal/TheoreticalProteoformDatabase.cs
+++ b/ProteoformSuiteInternal/TheoreticalProteoformDatabase.cs
@@ -47,7 +47,11 @@ namespace ProteoformSuiteInternal
                 return;
 
             //Clear out data from potential previous runs
-            SaveState.lollipop.proteoform_community.decoy_proteoforms.Clear();
+            foreach(ProteoformCommunity community in SaveState.lollipop.decoy_proteoform_communities.Values)
+            {
+                community.theoretical_proteoforms = new TheoreticalProteoform[0];
+
+            }
             theoretical_proteins.Clear();
 
             //Read the UniProt-XML and ptmlist
@@ -96,8 +100,11 @@ namespace ProteoformSuiteInternal
 
             if (SaveState.lollipop.combine_theoretical_proteoforms_byMass)
             {
-                SaveState.lollipop.proteoform_community.theoretical_proteoforms = group_proteoforms_by_mass(SaveState.lollipop.proteoform_community.theoretical_proteoforms);
-                SaveState.lollipop.proteoform_community.decoy_proteoforms = SaveState.lollipop.proteoform_community.decoy_proteoforms.ToDictionary(kv => kv.Key, kv => group_proteoforms_by_mass(kv.Value) as TheoreticalProteoform[]);
+                SaveState.lollipop.target_proteoform_community.theoretical_proteoforms = group_proteoforms_by_mass(SaveState.lollipop.target_proteoform_community.theoretical_proteoforms);
+                foreach (ProteoformCommunity community in SaveState.lollipop.decoy_proteoform_communities.Values)
+                {
+                   community.theoretical_proteoforms = group_proteoforms_by_mass(community.theoretical_proteoforms);
+                }
             }
         }
 
@@ -273,30 +280,34 @@ namespace ProteoformSuiteInternal
         {
             List<TheoreticalProteoform> theoretical_proteoforms = new List<TheoreticalProteoform>();
             Parallel.ForEach(expanded_proteins, p => EnterTheoreticalProteformFamily(p.BaseSequence, p, p.Accession, theoretical_proteoforms, -100, variableModifications));
-            SaveState.lollipop.proteoform_community.theoretical_proteoforms = theoretical_proteoforms.ToArray();
+            SaveState.lollipop.target_proteoform_community.theoretical_proteoforms = theoretical_proteoforms.ToArray();
         }
 
         private void process_decoys(ProteinWithGoTerms[] expanded_proteins, IEnumerable<ModificationWithMass> variableModifications)
         {
             Parallel.For(0, SaveState.lollipop.decoy_databases, decoyNumber =>
             {
-                List<TheoreticalProteoform> decoy_proteoforms = new List<TheoreticalProteoform>();
-                string giantProtein = GetOneGiantProtein(expanded_proteins, SaveState.lollipop.methionine_cleavage); //Concatenate a giant protein out of all protein read from the UniProt-XML, and construct target and decoy proteoform databases
-                string decoy_database_name = SaveState.lollipop.decoy_database_name_prefix + decoyNumber;
-                ProteinWithGoTerms[] shuffled_proteins = new ProteinWithGoTerms[expanded_proteins.Length];
-                Array.Copy(expanded_proteins, shuffled_proteins, expanded_proteins.Length);
-                new Random().Shuffle(shuffled_proteins); //randomize order of protein array
+            List<TheoreticalProteoform> decoy_proteoforms = new List<TheoreticalProteoform>();
+            string giantProtein = GetOneGiantProtein(expanded_proteins, SaveState.lollipop.methionine_cleavage); //Concatenate a giant protein out of all protein read from the UniProt-XML, and construct target and decoy proteoform databases
+            ProteinWithGoTerms[] shuffled_proteins = new ProteinWithGoTerms[expanded_proteins.Length];
+            Array.Copy(expanded_proteins, shuffled_proteins, expanded_proteins.Length);
+            new Random().Shuffle(shuffled_proteins); //randomize order of protein array
 
-                int prevLength = 0;
-                Parallel.ForEach(shuffled_proteins, p =>
-                {
-                    string hunk = giantProtein.Substring(prevLength, p.BaseSequence.Length);
-                    prevLength += p.BaseSequence.Length;
-                    EnterTheoreticalProteformFamily(hunk, p, p.Accession + "_DECOY_" + decoyNumber, decoy_proteoforms, decoyNumber, variableModifications);
-                });
+            int prevLength = 0;
+            Parallel.ForEach(shuffled_proteins, p =>
+            {
+                string hunk = giantProtein.Substring(prevLength, p.BaseSequence.Length);
+                prevLength += p.BaseSequence.Length;
+                EnterTheoreticalProteformFamily(hunk, p, p.Accession + "_DECOY_" + decoyNumber, decoy_proteoforms, decoyNumber, variableModifications);
+            });
 
-                lock (SaveState.lollipop.proteoform_community.decoy_proteoforms)
-                    SaveState.lollipop.proteoform_community.decoy_proteoforms.Add(decoy_database_name, decoy_proteoforms.ToArray());
+            lock (SaveState.lollipop.decoy_proteoform_communities)
+            {
+                SaveState.lollipop.decoy_proteoform_communities.Add("Decoy_Proteoform_Community_" + decoyNumber, new ProteoformCommunity());
+                SaveState.lollipop.decoy_proteoform_communities["Decoy_Proteoform_Community_" + decoyNumber].theoretical_proteoforms = decoy_proteoforms.ToArray();
+                SaveState.lollipop.decoy_proteoform_communities["Decoy_Proteoform_Community_" + decoyNumber].experimental_proteoforms =
+                SaveState.lollipop.target_proteoform_community.experimental_proteoforms.Select(e => new ExperimentalProteoform(e)).ToArray();
+            }
             });
         }
 

--- a/ProteoformSuiteInternal/TheoreticalProteoformDatabase.cs
+++ b/ProteoformSuiteInternal/TheoreticalProteoformDatabase.cs
@@ -304,9 +304,9 @@ namespace ProteoformSuiteInternal
 
             lock (SaveState.lollipop.decoy_proteoform_communities)
             {
-                SaveState.lollipop.decoy_proteoform_communities.Add("Decoy_Proteoform_Community_" + decoyNumber, new ProteoformCommunity());
-                SaveState.lollipop.decoy_proteoform_communities["Decoy_Proteoform_Community_" + decoyNumber].theoretical_proteoforms = decoy_proteoforms.ToArray();
-                SaveState.lollipop.decoy_proteoform_communities["Decoy_Proteoform_Community_" + decoyNumber].experimental_proteoforms =
+                SaveState.lollipop.decoy_proteoform_communities.Add(SaveState.lollipop.decoy_community_name_prefix + decoyNumber, new ProteoformCommunity());
+                SaveState.lollipop.decoy_proteoform_communities[SaveState.lollipop.decoy_community_name_prefix + decoyNumber].theoretical_proteoforms = decoy_proteoforms.ToArray();
+                SaveState.lollipop.decoy_proteoform_communities[SaveState.lollipop.decoy_community_name_prefix + decoyNumber].experimental_proteoforms =
                 SaveState.lollipop.target_proteoform_community.experimental_proteoforms.Select(e => new ExperimentalProteoform(e)).ToArray();
             }
             });

--- a/Test/TestCytoscapeScript.cs
+++ b/Test/TestCytoscapeScript.cs
@@ -179,7 +179,7 @@ namespace Test
         public void cytoscape_edges_and_nodes_match()
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
-            SaveState.lollipop.proteoform_community = community;
+            SaveState.lollipop.target_proteoform_community = community;
             IEnumerable<TheoreticalProteoform> theoreticals = community.families.SelectMany(f => f.theoretical_proteoforms);
             string edges = CytoscapeScript.get_cytoscape_edges_tsv(community.families,
                 Lollipop.edge_labels[0], Lollipop.node_labels[0], 2, 
@@ -215,7 +215,7 @@ namespace Test
         public void cytoscape_script_from_theoreticals()
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
-            SaveState.lollipop.proteoform_community = community;
+            SaveState.lollipop.target_proteoform_community = community;
             CytoscapeScript.write_cytoscape_script(community.families.SelectMany(f => f.theoretical_proteoforms.Where(t => t.ExpandedProteinList.Select(p => p.FullName).Contains(TestProteoformFamilies.p1_fullName))).ToArray(), community.families, 
                 TestContext.CurrentContext.TestDirectory, "", "test", 
                 false, false, false, false, 
@@ -249,7 +249,7 @@ namespace Test
         public void cytoscape_script_from_goterm()
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
-            SaveState.lollipop.proteoform_community = community;
+            SaveState.lollipop.target_proteoform_community = community;
             CytoscapeScript.write_cytoscape_script(new GoTerm[] { TestProteoformFamilies.p1_goterm }, community.families, 
                 TestContext.CurrentContext.TestDirectory, "", "test", 
                 false, false, false, false, 
@@ -283,7 +283,7 @@ namespace Test
         public void cytoscape_script_from_gotermnumber()
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
-            SaveState.lollipop.proteoform_community = community;
+            SaveState.lollipop.target_proteoform_community = community;
             CytoscapeScript.write_cytoscape_script(new GoTermNumber[] { new GoTermNumber(TestProteoformFamilies.p1_goterm, 0,0,0,0) }, community.families,
                 TestContext.CurrentContext.TestDirectory, "", "test",
                 false, false, false, false,
@@ -317,7 +317,7 @@ namespace Test
         public void cytoscape_script_from_quantValues()
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
-            SaveState.lollipop.proteoform_community = community;
+            SaveState.lollipop.target_proteoform_community = community;
             CytoscapeScript.write_cytoscape_script(community.families.SelectMany(f => f.experimental_proteoforms.Select(ex => ex.quant)).ToArray(), community.families, 
                 TestContext.CurrentContext.TestDirectory, "", "test", 
                 false, false, false, false,
@@ -350,7 +350,7 @@ namespace Test
         public void cytoscape_script_from_subset_of_families()
         {
             ProteoformCommunity community = TestProteoformFamilies.construct_two_families_with_potentially_colliding_theoreticals();
-            SaveState.lollipop.proteoform_community = community;
+            SaveState.lollipop.target_proteoform_community = community;
             CytoscapeScript.write_cytoscape_script(new List<ProteoformFamily> { community.families[0] }, community.families, 
                 TestContext.CurrentContext.TestDirectory, "", "test", 
                 false, false, false, false, 

--- a/Test/TestDeltaMassPeak.cs
+++ b/Test/TestDeltaMassPeak.cs
@@ -91,8 +91,9 @@ namespace Test
         [Test]
         public void TestAcceptDeltaMassPeaks()
         {
+            SaveState.lollipop = new Lollipop();
             ProteoformCommunity test_community = new ProteoformCommunity();
-            SaveState.lollipop.proteoform_community = test_community;
+            SaveState.lollipop.target_proteoform_community = test_community;
 
             SaveState.lollipop.theoretical_database.uniprotModifications = new Dictionary<string, List<Modification>>
             {
@@ -130,9 +131,9 @@ namespace Test
             Assert.AreEqual(3, pr4.nearby_relations_count);
 
             SaveState.lollipop.theoretical_database.all_possible_ptmsets = new List<PtmSet> { new PtmSet(new List<Ptm> { new Ptm(-1, ConstructorsForTesting.get_modWithMass("unmodified", 0)) }) };
-            test_community.accept_deltaMass_peaks(prs2, new List<ProteoformRelation>());
-            Assert.AreEqual(1, test_community.delta_mass_peaks.Count);
-            DeltaMassPeak peak = test_community.delta_mass_peaks[0];
+            SaveState.lollipop.et_peaks = test_community.accept_deltaMass_peaks(prs2, new List<ProteoformRelation>());
+            Assert.AreEqual(1, SaveState.lollipop.et_peaks.Count);
+            DeltaMassPeak peak = SaveState.lollipop.et_peaks[0];
             Assert.AreEqual(3, peak.grouped_relations.Count);
             Assert.AreEqual(3, pr2.peak.peak_relation_group_count);
             Assert.AreEqual(0, pr2.peak.DeltaMass);
@@ -148,7 +149,7 @@ namespace Test
         public void wrong_relation_shifting()
         {
             ProteoformCommunity test_community = new ProteoformCommunity();
-            SaveState.lollipop.proteoform_community = test_community;
+            SaveState.lollipop.target_proteoform_community = test_community;
             ExperimentalProteoform pf3 = ConstructorsForTesting.ExperimentalProteoform("E1");
             ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("E2");
             ProteoformComparison wrong_comparison = ProteoformComparison.ExperimentalExperimental;
@@ -157,7 +158,7 @@ namespace Test
             List<ProteoformRelation> prs = new List<ProteoformRelation> { pr2, pr3 };
             foreach (ProteoformRelation pr in prs) pr.set_nearby_group(prs, prs.Select(r => r.InstanceId).ToList());
             test_community.accept_deltaMass_peaks(prs, new List<ProteoformRelation>());
-            Assert.False(test_community.delta_mass_peaks[0].shift_experimental_masses(1, true));
+            Assert.False(SaveState.lollipop.et_peaks[0].shift_experimental_masses(1, true));
         }
 
         [Test]
@@ -176,8 +177,9 @@ namespace Test
         [Test]
         public void shift_et_peak_neucode()
         {
+            SaveState.lollipop = new Lollipop();
             ProteoformCommunity test_community = new ProteoformCommunity();
-            SaveState.lollipop.proteoform_community = test_community;
+            SaveState.lollipop.target_proteoform_community = test_community;
 
             //Make a few experimental proteoforms
             List<Component> n1 = TestExperimentalProteoform.generate_neucode_components(100);
@@ -193,7 +195,7 @@ namespace Test
             ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("E4");
             pf4.aggregated_components = n4;
 
-            SaveState.lollipop.proteoform_community.experimental_proteoforms = new List<ExperimentalProteoform> { pf1, pf2, pf3, pf4 }.ToArray();
+            SaveState.lollipop.target_proteoform_community.experimental_proteoforms = new List<ExperimentalProteoform> { pf1, pf2, pf3, pf4 }.ToArray();
 
             //Connect them to theoreticals to form two peaks
             ProteoformComparison comparison14 = ProteoformComparison.ExperimentalTheoretical;
@@ -211,10 +213,10 @@ namespace Test
             List<ProteoformRelation> prs = new List<ProteoformRelation> { pr1, pr2, pr3, pr4 };
             foreach (ProteoformRelation pr in prs) pr.set_nearby_group(prs, prs.Select(r => r.InstanceId).ToList());
             test_community.accept_deltaMass_peaks(prs, new List<ProteoformRelation>());
-            Assert.AreEqual(2, test_community.delta_mass_peaks.Count);
+            Assert.AreEqual(2, SaveState.lollipop.et_peaks.Count);
 
             //Shift the peaks, which shifts all of the proteoforms
-            DeltaMassPeak d2 = test_community.delta_mass_peaks[1];
+            DeltaMassPeak d2 = SaveState.lollipop.et_peaks[1];
             d2.shift_experimental_masses(-1, true);
 
             Assert.IsTrue(pf3.mass_shifted);
@@ -241,8 +243,9 @@ namespace Test
         [Test]
         public void shift_et_peak_unlabeled()
         {
+            SaveState.lollipop = new Lollipop();
             ProteoformCommunity test_community = new ProteoformCommunity();
-            SaveState.lollipop.proteoform_community = test_community;
+            SaveState.lollipop.target_proteoform_community = test_community;
 
             //Make a few experimental proteoforms
             List<Component> n1 = TestExperimentalProteoform.generate_neucode_components(100);
@@ -258,7 +261,7 @@ namespace Test
             ExperimentalProteoform pf4 = ConstructorsForTesting.ExperimentalProteoform("E4");
             pf4.aggregated_components = n4;
 
-            SaveState.lollipop.proteoform_community.experimental_proteoforms = new List<ExperimentalProteoform> { pf1, pf2, pf3, pf4 }.ToArray();
+            SaveState.lollipop.target_proteoform_community.experimental_proteoforms = new List<ExperimentalProteoform> { pf1, pf2, pf3, pf4 }.ToArray();
 
             //Connect them to theoreticals to form two peaks
             ProteoformComparison comparison14 = ProteoformComparison.ExperimentalTheoretical;
@@ -276,10 +279,10 @@ namespace Test
             List<ProteoformRelation> prs = new List<ProteoformRelation> { pr1, pr2, pr3, pr4 };
             foreach (ProteoformRelation pr in prs) pr.set_nearby_group(prs, prs.Select(r => r.InstanceId).ToList());
             test_community.accept_deltaMass_peaks(prs, new List<ProteoformRelation>());
-            Assert.AreEqual(2, test_community.delta_mass_peaks.Count);
+            Assert.AreEqual(2, SaveState.lollipop.et_peaks.Count);
 
             //Shift the peaks, which shifts all of the proteoforms
-            DeltaMassPeak d2 = test_community.delta_mass_peaks[1];
+            DeltaMassPeak d2 = SaveState.lollipop.et_peaks[1];
             d2.shift_experimental_masses(-1, false);
 
             Assert.IsTrue(pf3.mass_shifted);

--- a/Test/TestProteoformCommunityRelate.cs
+++ b/Test/TestProteoformCommunityRelate.cs
@@ -172,7 +172,7 @@ namespace Test
                 ConstructorsForTesting. ExperimentalProteoform("A4", 1000.0, 2, true)
             };
             SaveState.lollipop.ee_relations = test_community.relate(test_community.experimental_proteoforms, test_community.experimental_proteoforms, ProteoformComparison.ExperimentalExperimental, true);
-            unequal_relations = test_community.relate_ef(test_community.experimental_proteoforms, test_community.experimental_proteoforms).Values.First();
+            unequal_relations = test_community.relate_ef(test_community.experimental_proteoforms, test_community.experimental_proteoforms);
             Assert.AreNotEqual(test_community.experimental_proteoforms[0], test_community.experimental_proteoforms[2]);
             Assert.False(test_community.allowed_relation(test_community.experimental_proteoforms[0], test_community.experimental_proteoforms[0], ProteoformComparison.ExperimentalExperimental));
             Assert.AreNotEqual(test_community.experimental_proteoforms[0].lysine_count, test_community.experimental_proteoforms[1].lysine_count);
@@ -190,7 +190,7 @@ namespace Test
                 ConstructorsForTesting.ExperimentalProteoform("A4", 4000, 2, true)
             };
             SaveState.lollipop.ee_relations = test_community.relate(test_community.experimental_proteoforms, test_community.experimental_proteoforms, ProteoformComparison.ExperimentalExperimental, true);
-            unequal_relations = test_community.relate_ef(test_community.experimental_proteoforms, test_community.experimental_proteoforms).Values.First();
+            unequal_relations = test_community.relate_ef(test_community.experimental_proteoforms, test_community.experimental_proteoforms);
             Assert.AreEqual(0, unequal_relations.Count);
 
             //None equal lysine count (apart from itself), four unequal lysine count. Each should create no unequal relations, so no relations total
@@ -202,7 +202,7 @@ namespace Test
                 ConstructorsForTesting. ExperimentalProteoform("A4", 1000.0, 4, true)
             };
             SaveState.lollipop.ee_relations = test_community.relate(test_community.experimental_proteoforms, test_community.experimental_proteoforms, ProteoformComparison.ExperimentalExperimental, true);
-            unequal_relations = test_community.relate_ef(test_community.experimental_proteoforms, test_community.experimental_proteoforms).Values.First();
+            unequal_relations = test_community.relate_ef(test_community.experimental_proteoforms, test_community.experimental_proteoforms);
             Assert.AreEqual(0, unequal_relations.Count);
 
             //All equal, no unequal lysine count because there's an empty list of unequal lysine-count proteoforms. Each should create no unequal relations, so no relations total
@@ -213,7 +213,7 @@ namespace Test
                 ConstructorsForTesting. ExperimentalProteoform("A3", 1000.0, 1, true),
                 ConstructorsForTesting. ExperimentalProteoform("A4", 1000.0, 1, true)
             };
-            unequal_relations = test_community.relate_ef(test_community.experimental_proteoforms, test_community.experimental_proteoforms).Values.First();
+            unequal_relations = test_community.relate_ef(test_community.experimental_proteoforms, test_community.experimental_proteoforms);
             Assert.AreEqual(0, unequal_relations.Count);
         }
 
@@ -438,44 +438,41 @@ namespace Test
         [Test]
         public void TestProteoformCommunityRelate_ED()
         {
-            ProteoformCommunity testProteoformCommunity = new ProteoformCommunity();
-            var edDictionary = testProteoformCommunity.relate_ed();
+            SaveState.lollipop = new Lollipop();
+            SaveState.lollipop.decoy_databases = 1;
             // In empty comminity, relate ed is empty
-            Assert.AreEqual(0, edDictionary.Count);
+            Assert.AreEqual(0, SaveState.lollipop.ed_relations.Count);
 
-            testProteoformCommunity.decoy_proteoforms = new Dictionary<string, TheoreticalProteoform[]>();
-            edDictionary = testProteoformCommunity.relate_ed();
-            // In comminity with initialized decoy_proteoforms, still no relations
-            Assert.AreEqual(0, edDictionary.Count);
-
-            testProteoformCommunity.decoy_proteoforms["fake_decoy_proteoform1"] = new TheoreticalProteoform[0];
-            edDictionary = testProteoformCommunity.relate_ed();
-            // In community with a single decoy proteoform, have a single relation
-            Assert.AreEqual(1, edDictionary.Count);
+            //create a decoy proteoform community
+            SaveState.lollipop.decoy_proteoform_communities.Add("Decoy_Proteoform_Community_0", new ProteoformCommunity());            
+            TheoreticalProteoform pf2 = ConstructorsForTesting.make_a_theoretical("decoyProteoform1", 0, -1);
+            SaveState.lollipop.decoy_proteoform_communities["Decoy_Proteoform_Community_0"].theoretical_proteoforms = new TheoreticalProteoform[1] { pf2 };
+            SaveState.lollipop.relate_ed();
+            // Have a single decoy community --> have single ed_relations 
+            Assert.AreEqual(1, SaveState.lollipop.ed_relations.Count);
             // But it's empty
-            Assert.IsEmpty(edDictionary["fake_decoy_proteoform1"]);
+            Assert.IsEmpty(SaveState.lollipop.ed_relations["Decoy_Proteoform_Community_0"]);
 
             // In order to make it not empty, we must have relate_et method output a non-empty List
             // it must take as arguments non-empty pfs1 and pfs2
             // So testProteoformCommunity.experimental_proteoforms must be non-empty
             // And decoy_proteoforms["fake_decoy_proteoform1"] must be non-empty
             ExperimentalProteoform pf1 = ConstructorsForTesting.ExperimentalProteoform("experimentalProteoform1");
-            TheoreticalProteoform pf2 = ConstructorsForTesting.make_a_theoretical("decoyProteoform1", 0, -1);
-            testProteoformCommunity.decoy_proteoforms["fake_decoy_proteoform1"] = new TheoreticalProteoform[] { pf2 };
-            testProteoformCommunity.decoy_proteoforms["fake_decoy_proteoform1"].First().ExpandedProteinList = new List<ProteinWithGoTerms> { p1 };
+            SaveState.lollipop.decoy_proteoform_communities["Decoy_Proteoform_Community_0"].theoretical_proteoforms.First().ExpandedProteinList = new List<ProteinWithGoTerms> { p1 };
 
-            Assert.IsEmpty(testProteoformCommunity.experimental_proteoforms);
-            testProteoformCommunity.experimental_proteoforms = new ExperimentalProteoform[] { pf1 };
+            Assert.IsEmpty(SaveState.lollipop.decoy_proteoform_communities["Decoy_Proteoform_Community_0"].experimental_proteoforms);
+            SaveState.lollipop.decoy_proteoform_communities["Decoy_Proteoform_Community_0"].experimental_proteoforms = new ExperimentalProteoform[] { pf1 };
 
+            SaveState.lollipop.clear_et();
             prepare_for_et(new List<double> { pf1.modified_mass - pf2.modified_mass });
-            edDictionary = testProteoformCommunity.relate_ed();
+            SaveState.lollipop.relate_ed();
 
             // Make sure there is one relation total, because only a single decoy was provided
-            Assert.AreEqual(1, edDictionary.Count);
-            Assert.IsNotEmpty(edDictionary["fake_decoy_proteoform1"]);
-            Assert.AreEqual(1, edDictionary["fake_decoy_proteoform1"].Count); // Make sure there is one relation for the provided fake_decoy_proteoform1
+            Assert.AreEqual(1, SaveState.lollipop.ed_relations.Count);
+            Assert.IsNotEmpty(SaveState.lollipop.ed_relations);
+            Assert.AreEqual(1, SaveState.lollipop.ed_relations["Decoy_Proteoform_Community_0"].Count); // Make sure there is one relation for the provided fake_decoy_proteoform1
 
-            ProteoformRelation rel = edDictionary["fake_decoy_proteoform1"][0];
+            ProteoformRelation rel = SaveState.lollipop.ed_relations["Decoy_Proteoform_Community_0"][0];
 
             Assert.IsFalse(rel.Accepted);
             Assert.AreEqual("decoyProteoform1", rel.connected_proteoforms[1].accession);

--- a/Test/TestProteoformCommunityRelate.cs
+++ b/Test/TestProteoformCommunityRelate.cs
@@ -217,7 +217,7 @@ namespace Test
             Assert.AreEqual(0, unequal_relations.Count);
         }
 
-        private void prepare_for_et(List<double> delta_masses)
+        public static void prepare_for_et(List<double> delta_masses)
         {
             SaveState.lollipop.theoretical_database.all_mods_with_mass = new List<ModificationWithMass>();
             SaveState.lollipop.theoretical_database.all_possible_ptmsets = new List<PtmSet>();
@@ -444,24 +444,24 @@ namespace Test
             Assert.AreEqual(0, SaveState.lollipop.ed_relations.Count);
 
             //create a decoy proteoform community
-            SaveState.lollipop.decoy_proteoform_communities.Add("Decoy_Proteoform_Community_0", new ProteoformCommunity());            
+            SaveState.lollipop.decoy_proteoform_communities.Add(SaveState.lollipop.decoy_community_name_prefix + "0", new ProteoformCommunity());            
             TheoreticalProteoform pf2 = ConstructorsForTesting.make_a_theoretical("decoyProteoform1", 0, -1);
-            SaveState.lollipop.decoy_proteoform_communities["Decoy_Proteoform_Community_0"].theoretical_proteoforms = new TheoreticalProteoform[1] { pf2 };
+            SaveState.lollipop.decoy_proteoform_communities[SaveState.lollipop.decoy_community_name_prefix + "0"].theoretical_proteoforms = new TheoreticalProteoform[1] { pf2 };
             SaveState.lollipop.relate_ed();
             // Have a single decoy community --> have single ed_relations 
             Assert.AreEqual(1, SaveState.lollipop.ed_relations.Count);
             // But it's empty
-            Assert.IsEmpty(SaveState.lollipop.ed_relations["Decoy_Proteoform_Community_0"]);
+            Assert.IsEmpty(SaveState.lollipop.ed_relations[SaveState.lollipop.decoy_community_name_prefix + "0"]);
 
             // In order to make it not empty, we must have relate_et method output a non-empty List
             // it must take as arguments non-empty pfs1 and pfs2
             // So testProteoformCommunity.experimental_proteoforms must be non-empty
             // And decoy_proteoforms["fake_decoy_proteoform1"] must be non-empty
             ExperimentalProteoform pf1 = ConstructorsForTesting.ExperimentalProteoform("experimentalProteoform1");
-            SaveState.lollipop.decoy_proteoform_communities["Decoy_Proteoform_Community_0"].theoretical_proteoforms.First().ExpandedProteinList = new List<ProteinWithGoTerms> { p1 };
+            SaveState.lollipop.decoy_proteoform_communities[SaveState.lollipop.decoy_community_name_prefix + "0"].theoretical_proteoforms.First().ExpandedProteinList = new List<ProteinWithGoTerms> { p1 };
 
-            Assert.IsEmpty(SaveState.lollipop.decoy_proteoform_communities["Decoy_Proteoform_Community_0"].experimental_proteoforms);
-            SaveState.lollipop.decoy_proteoform_communities["Decoy_Proteoform_Community_0"].experimental_proteoforms = new ExperimentalProteoform[] { pf1 };
+            Assert.IsEmpty(SaveState.lollipop.decoy_proteoform_communities[SaveState.lollipop.decoy_community_name_prefix + "0"].experimental_proteoforms);
+            SaveState.lollipop.decoy_proteoform_communities[SaveState.lollipop.decoy_community_name_prefix + "0"].experimental_proteoforms = new ExperimentalProteoform[] { pf1 };
 
             SaveState.lollipop.clear_et();
             prepare_for_et(new List<double> { pf1.modified_mass - pf2.modified_mass });
@@ -470,9 +470,9 @@ namespace Test
             // Make sure there is one relation total, because only a single decoy was provided
             Assert.AreEqual(1, SaveState.lollipop.ed_relations.Count);
             Assert.IsNotEmpty(SaveState.lollipop.ed_relations);
-            Assert.AreEqual(1, SaveState.lollipop.ed_relations["Decoy_Proteoform_Community_0"].Count); // Make sure there is one relation for the provided fake_decoy_proteoform1
+            Assert.AreEqual(1, SaveState.lollipop.ed_relations[SaveState.lollipop.decoy_community_name_prefix + "0"].Count); // Make sure there is one relation for the provided fake_decoy_proteoform1
 
-            ProteoformRelation rel = SaveState.lollipop.ed_relations["Decoy_Proteoform_Community_0"][0];
+            ProteoformRelation rel = SaveState.lollipop.ed_relations[SaveState.lollipop.decoy_community_name_prefix + "0"][0];
 
             Assert.IsFalse(rel.Accepted);
             Assert.AreEqual("decoyProteoform1", rel.connected_proteoforms[1].accession);

--- a/Test/TestProteoformFamilies.cs
+++ b/Test/TestProteoformFamilies.cs
@@ -361,7 +361,14 @@ namespace Test
 
 
             //peak is accepted --> relation should be accepted, peak added to relation
+            SaveState.lollipop.clear_et();
             SaveState.lollipop.min_peak_count_et = 1;
+            SaveState.lollipop.et_relations = SaveState.lollipop.target_proteoform_community.relate(SaveState.lollipop.target_proteoform_community.experimental_proteoforms, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms, ProteoformComparison.ExperimentalTheoretical, true);
+            SaveState.lollipop.relate_ed();
+            foreach (ProteoformRelation pr in SaveState.lollipop.et_relations) pr.set_nearby_group(SaveState.lollipop.et_relations, SaveState.lollipop.et_relations.Select(r => r.InstanceId).ToList());
+            foreach (ProteoformRelation pr in SaveState.lollipop.ee_relations) pr.set_nearby_group(SaveState.lollipop.ee_relations, SaveState.lollipop.ee_relations.Select(r => r.InstanceId).ToList());
+            SaveState.lollipop.et_peaks = SaveState.lollipop.target_proteoform_community.accept_deltaMass_peaks(SaveState.lollipop.et_relations, SaveState.lollipop.ed_relations);
+
             SaveState.lollipop.et_peaks = SaveState.lollipop.target_proteoform_community.accept_deltaMass_peaks(SaveState.lollipop.et_relations, SaveState.lollipop.ed_relations);
             Assert.IsTrue(SaveState.lollipop.ed_relations.First().Value.FirstOrDefault().Accepted); //should be true if peak accepted
             Assert.IsNotNull(SaveState.lollipop.ed_relations.Values.SelectMany(v => v).First().peak);
@@ -372,9 +379,13 @@ namespace Test
             Assert.AreEqual(0, SaveState.lollipop.ef_relations.Values.SelectMany(v => v).Count(r => r.Accepted)); //all peaks accepted are false, so relation accepted should be false
 
             //one peak accepted --> one of the EF relations falls into range of peak and should be accepted
+            SaveState.lollipop.clear_ee();
             SaveState.lollipop.min_peak_count_ee = 1;
+            SaveState.lollipop.ee_relations = SaveState.lollipop.target_proteoform_community.relate(SaveState.lollipop.target_proteoform_community.experimental_proteoforms, SaveState.lollipop.target_proteoform_community.experimental_proteoforms, ProteoformComparison.ExperimentalExperimental, true);
+            SaveState.lollipop.relate_ef();
             SaveState.lollipop.ee_peaks = SaveState.lollipop.target_proteoform_community.accept_deltaMass_peaks(SaveState.lollipop.ee_relations, SaveState.lollipop.ef_relations);
             Assert.AreEqual(3, SaveState.lollipop.ee_peaks.Count(p => p.Accepted));
+            Assert.AreEqual(3, SaveState.lollipop.ee_relations.Count);
             Assert.AreEqual(1, SaveState.lollipop.ef_relations.Values.SelectMany(v => v).Count(r => r.Accepted)); //only 1 relation is in delta mass range of accepted peak - only 1 accepted
             SaveState.lollipop.construct_target_and_decoy_families();
 

--- a/Test/TestSaveState.cs
+++ b/Test/TestSaveState.cs
@@ -95,7 +95,7 @@ namespace Test
             e.ptm_set = e.linked_proteoform_references.Last().ptm_set;
             ProteoformFamily f = new ProteoformFamily(e);
             f.construct_family();
-            SaveState.lollipop.proteoform_community.families = new List<ProteoformFamily> { f };
+            SaveState.lollipop.target_proteoform_community.families = new List<ProteoformFamily> { f };
             string[] lines = ResultsSummaryGenerator.results_dataframe().Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
             Assert.True(lines.Count() == 3);
             Assert.True(lines.Any(a => a.Contains("E1")));

--- a/Test/TestTheoreticalDatabaseCreate.cs
+++ b/Test/TestTheoreticalDatabaseCreate.cs
@@ -64,13 +64,13 @@ namespace Test
             SaveState.lollipop.theoretical_database.theoretical_proteins.Clear();
             SaveState.lollipop.theoretical_database.get_theoretical_proteoforms(Path.Combine(TestContext.CurrentContext.TestDirectory));
             Assert.AreEqual(54, SaveState.lollipop.theoretical_database.theoretical_proteins.SelectMany(kv => kv.Value).Sum(p => p.DatabaseReferences.Where(dbRef => dbRef.Type == "GO").Count()));
-            Assert.AreEqual(20, SaveState.lollipop.proteoform_community.theoretical_proteoforms.SelectMany(t => t.goTerms.Select(go => go.Id)).Distinct().Count());
+            Assert.AreEqual(20, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.SelectMany(t => t.goTerms.Select(go => go.Id)).Distinct().Count());
 
-            List<TheoreticalProteoform> peptides = SaveState.lollipop.proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "peptide").ToList();
-            List<TheoreticalProteoform> chains = SaveState.lollipop.proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "chain").ToList();
-            List<TheoreticalProteoform> fulls = SaveState.lollipop.proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "full-met-cleaved").ToList();
-            List<TheoreticalProteoform> propeps = SaveState.lollipop.proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "propeptide").ToList();
-            List<TheoreticalProteoform> signalpeps = SaveState.lollipop.proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "signal-peptide").ToList();
+            List<TheoreticalProteoform> peptides = SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "peptide").ToList();
+            List<TheoreticalProteoform> chains = SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "chain").ToList();
+            List<TheoreticalProteoform> fulls = SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "full-met-cleaved").ToList();
+            List<TheoreticalProteoform> propeps = SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "propeptide").ToList();
+            List<TheoreticalProteoform> signalpeps = SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "signal-peptide").ToList();
 
             Assert.AreEqual(8, chains.Count);
             Assert.AreEqual(12, fulls.Count);
@@ -78,7 +78,7 @@ namespace Test
             Assert.AreEqual(3, propeps.Count);
             Assert.AreEqual(3, signalpeps.Count);
 
-            Assert.AreEqual(28, SaveState.lollipop.proteoform_community.theoretical_proteoforms.Length);
+            Assert.AreEqual(28, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Length);
         }
 
         [Test]
@@ -103,11 +103,11 @@ namespace Test
             SaveState.lollipop.theoretical_database.theoretical_proteins.Clear();
             SaveState.lollipop.theoretical_database.get_theoretical_proteoforms(Path.Combine(TestContext.CurrentContext.TestDirectory));
 
-            List<TheoreticalProteoform> peptides = SaveState.lollipop.proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "peptide").ToList();
-            List<TheoreticalProteoform> chains = SaveState.lollipop.proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "chain").ToList();
-            List<TheoreticalProteoform> fulls = SaveState.lollipop.proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "full-met-cleaved").ToList();
-            List<TheoreticalProteoform> propeps = SaveState.lollipop.proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "propeptide").ToList();
-            List<TheoreticalProteoform> signalpeps = SaveState.lollipop.proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "signal-peptide").ToList();
+            List<TheoreticalProteoform> peptides = SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "peptide").ToList();
+            List<TheoreticalProteoform> chains = SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "chain").ToList();
+            List<TheoreticalProteoform> fulls = SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "full-met-cleaved").ToList();
+            List<TheoreticalProteoform> propeps = SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "propeptide").ToList();
+            List<TheoreticalProteoform> signalpeps = SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Where(p => p.fragment == "signal-peptide").ToList();
 
             Assert.AreEqual(8, chains.Count);
             Assert.AreEqual(9, fulls.Count);
@@ -115,7 +115,7 @@ namespace Test
             Assert.AreEqual(3, propeps.Count);
             Assert.AreEqual(3, signalpeps.Count);
 
-            Assert.AreEqual(25, SaveState.lollipop.proteoform_community.theoretical_proteoforms.Length);
+            Assert.AreEqual(25, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Length);
         }
 
         [Test]
@@ -129,22 +129,22 @@ namespace Test
             SaveState.lollipop.input_files.Clear();
             SaveState.lollipop.enter_input_files(new string[] { Path.Combine(TestContext.CurrentContext.TestDirectory, "stripped.xml"), Path.Combine(TestContext.CurrentContext.TestDirectory, "ptmlist.txt") }, Lollipop.acceptable_extensions[2], Lollipop.file_types[2], SaveState.lollipop.input_files);
             SaveState.lollipop.theoretical_database.theoretical_proteins.Clear();
-            SaveState.lollipop.proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
+            SaveState.lollipop.target_proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
             SaveState.lollipop.theoretical_database.get_theoretical_proteoforms(Path.Combine(TestContext.CurrentContext.TestDirectory));
-            Assert.AreEqual(1, SaveState.lollipop.proteoform_community.theoretical_proteoforms.Length); //no methionine oxidation
+            Assert.AreEqual(1, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Length); //no methionine oxidation
 
             SaveState.lollipop.methionine_oxidation = true;
             SaveState.lollipop.theoretical_database.theoretical_proteins.Clear();
-            SaveState.lollipop.proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
+            SaveState.lollipop.target_proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
             SaveState.lollipop.theoretical_database.get_theoretical_proteoforms(Path.Combine(TestContext.CurrentContext.TestDirectory));
-            Assert.AreEqual(1, SaveState.lollipop.proteoform_community.theoretical_proteoforms.Length); //only one methionine to oxidize, but no PTMs allowed
+            Assert.AreEqual(1, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Length); //only one methionine to oxidize, but no PTMs allowed
             Assert.Less(SaveState.lollipop.modification_ranks[0], SaveState.lollipop.modification_ranks[SaveState.lollipop.theoretical_database.variableModifications[0].monoisotopicMass] - 1); // unmodified gets a lower score than variable oxidation, even with the prioritization (minus one rank)
 
             SaveState.lollipop.max_ptms = 1;
             SaveState.lollipop.theoretical_database.theoretical_proteins.Clear();
-            SaveState.lollipop.proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
+            SaveState.lollipop.target_proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
             SaveState.lollipop.theoretical_database.get_theoretical_proteoforms(Path.Combine(TestContext.CurrentContext.TestDirectory));
-            Assert.AreEqual(2, SaveState.lollipop.proteoform_community.theoretical_proteoforms.Length); //only one methionine to oxidize
+            Assert.AreEqual(2, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Length); //only one methionine to oxidize
         }
 
         [Test]
@@ -157,28 +157,28 @@ namespace Test
             SaveState.lollipop.input_files.Clear();
             SaveState.lollipop.enter_input_files(new string[] { Path.Combine(TestContext.CurrentContext.TestDirectory, "stripped_plus2M.xml") }, Lollipop.acceptable_extensions[2], Lollipop.file_types[2], SaveState.lollipop.input_files);
             SaveState.lollipop.theoretical_database.theoretical_proteins.Clear();
-            SaveState.lollipop.proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
+            SaveState.lollipop.target_proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
             SaveState.lollipop.theoretical_database.get_theoretical_proteoforms(Path.Combine(TestContext.CurrentContext.TestDirectory));
-            Assert.AreEqual(1, SaveState.lollipop.proteoform_community.theoretical_proteoforms.Length); //3 methionines for variable
+            Assert.AreEqual(1, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Length); //3 methionines for variable
 
             SaveState.lollipop.max_ptms = 1;
             SaveState.lollipop.theoretical_database.theoretical_proteins.Clear();
-            SaveState.lollipop.proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
+            SaveState.lollipop.target_proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
             SaveState.lollipop.theoretical_database.get_theoretical_proteoforms(Path.Combine(TestContext.CurrentContext.TestDirectory));
-            Assert.AreEqual(2, SaveState.lollipop.proteoform_community.theoretical_proteoforms.Length); //three methionine sites to oxidize, but all three are equivalent, so just one more added
+            Assert.AreEqual(2, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Length); //three methionine sites to oxidize, but all three are equivalent, so just one more added
 
             SaveState.lollipop.max_ptms = 2;
             SaveState.lollipop.theoretical_database.theoretical_proteins.Clear();
-            SaveState.lollipop.proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
+            SaveState.lollipop.target_proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
             SaveState.lollipop.theoretical_database.get_theoretical_proteoforms(Path.Combine(TestContext.CurrentContext.TestDirectory));
-            Assert.AreEqual(3, SaveState.lollipop.proteoform_community.theoretical_proteoforms.Length); //three methionine sites to oxidize, but all three are equivalent, so just one more added
+            Assert.AreEqual(3, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Length); //three methionine sites to oxidize, but all three are equivalent, so just one more added
 
             SaveState.lollipop.max_ptms = 3;
             SaveState.lollipop.theoretical_database.theoretical_proteins.Clear();
-            SaveState.lollipop.proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
+            SaveState.lollipop.target_proteoform_community.theoretical_proteoforms = new TheoreticalProteoform[0];
             SaveState.lollipop.theoretical_database.get_theoretical_proteoforms(Path.Combine(TestContext.CurrentContext.TestDirectory));
-            Assert.AreEqual(4, SaveState.lollipop.proteoform_community.theoretical_proteoforms.Length); //three methionine sites to oxidize, but all three are equivalent, so just one more added
-            Assert.AreEqual(1, new HashSet<ModificationWithMass>(SaveState.lollipop.proteoform_community.theoretical_proteoforms.SelectMany(t => t.ptm_set.ptm_combination.Select(ptm => ptm.modification))).Count); //Only the variable modification is in there; no sign of the fake oxidation of K I added
+            Assert.AreEqual(4, SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.Length); //three methionine sites to oxidize, but all three are equivalent, so just one more added
+            Assert.AreEqual(1, new HashSet<ModificationWithMass>(SaveState.lollipop.target_proteoform_community.theoretical_proteoforms.SelectMany(t => t.ptm_set.ptm_combination.Select(ptm => ptm.modification))).Count); //Only the variable modification is in there; no sign of the fake oxidation of K I added
         }
 
         [Test]


### PR DESCRIPTION
This was an idea Anthony and I talked about last week - now that we use ptmsets and identify experimentals in families with a set of rules (ex: only allow loss of an AA if it's on a terminus), what if we make families using ED and EF relations. Then, in the same way we do for target, identify experimentals connected to decoys, to get an "identified decoy count" which could help estimate the # falsely identified experimentals. 